### PR TITLE
Fix type assertion due to invalid cast

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -312,16 +312,7 @@ def CallOp
 def IndirectCallOp
   : HighLevel_Op< "indirect_call", [
     DeclareOpInterfaceMethods<CallOpInterface>,
-    TypesMatchWith<
-      "callee input types match argument types",
-      "callee", "argOperands",
-      "getFunctionType($_self).getInputs()"
-    >,
-    TypesMatchWith<
-      "callee result type match result type",
-      "callee", "result",
-      "getFunctionType($_self).getResult(0)"
-    >
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]>
   , Arguments<(ins
       LValueOrType<PointerLikeType>:$callee,
@@ -331,18 +322,11 @@ def IndirectCallOp
   let summary = "VAST call operation";
   let description = [{ VAST call operation }];
 
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder< (ins "mlir::Value":$callee, CArg<"mlir::ValueRange", "{}">:$operands ), [{
-      $_state.addOperands(callee);
-      $_state.addOperands(operands);
-      $_state.addTypes(getFunctionType(callee.getType()).getResult(0));
-    }]>
-  ];
-
   let assemblyFormat = [{
-    $callee `(` $argOperands `)` attr-dict `:` type( $callee )
+    $callee `:` type($callee)  `(` $argOperands `)` attr-dict `:` functional-type( $argOperands, $result )
   }];
+
+  // TODO: add verifiers to check that callee type matches arg operands
 }
 
 def ExprOp

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.hpp
@@ -13,9 +13,11 @@ VAST_RELAX_WARNINGS
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/TypeSupport.h>
 #include <mlir/IR/Types.h>
+#include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/DataLayoutInterfaces.h>
 VAST_UNRELAX_WARNINGS
 
+#include "vast/Util/Common.hpp"
 #include "vast/Util/DataLayout.hpp"
 #include "vast/Util/TypeList.hpp"
 #include "vast/Util/Types.hpp"
@@ -157,8 +159,16 @@ namespace vast::hl
         }
     }
 
-    mlir::FunctionType getFunctionType(PointerType functionPointer);
-    mlir::FunctionType getFunctionType(mlir::Type functionPointer);
+    mlir::FunctionType getFunctionType(Type function_pointer, Module mod);
+
+    mlir::FunctionType getFunctionType(Value callee);
+    mlir::FunctionType getFunctionType(mlir::CallOpInterface call);
+    mlir::FunctionType getFunctionType(mlir::CallInterfaceCallable callee, Module mod);
+
+    Type getTypedefType(TypedefType type, Module mod);
+
+    // unwraps all typedef aliases to get to real underlying type
+    Type getBottomTypedefType(TypedefType def, Module mod);
 
     bool isBoolType(mlir::Type type);
     bool isIntegerType(mlir::Type type);

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -314,6 +314,17 @@ namespace vast::hl
         st.addRegion(std::move(region));
         st.addTypes(rty);
     }
+
+    LogicalResult IndirectCallOp::inferReturnTypes(
+        MContext *context, mlir::Optional<Location> location, mlir::ValueRange operands,
+        mlir::DictionaryAttr attributes, mlir::RegionRange regions,
+        mlir::SmallVectorImpl<Type> &inferredReturnTypes
+    ) {
+        auto callee = operands[0];
+        auto type = getFunctionType(callee);
+        inferredReturnTypes.assign({type.getResult(0)});
+        return mlir::success();
+    }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/vast/Dialect/HighLevel/cast-b.c
+++ b/test/vast/Dialect/HighLevel/cast-b.c
@@ -1,0 +1,16 @@
+// RUN: vast-cc --from-source %s | FileCheck %s
+// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+
+// CHECK: hl.typedef "function_type" : (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.int>) -> !hl.int
+typedef int function_type(int a, int b);
+
+// CHECK: hl.var "p" : !hl.lvalue<!hl.array<2, !hl.ptr<!hl.typedef<"function_type">>>>
+function_type *p[2];
+
+int test_func(void) {
+    // CHECK: [[F:%[0-9]+]] = hl.implicit_cast [[P:%[0-9]+]] LValueToRValue : !hl.lvalue<!hl.ptr<!hl.typedef<"function_type">>> -> !hl.ptr<!hl.typedef<"function_type">>
+    // CHECK: [[A:%[0-9]+]] = hl.const #hl.integer<15> : !hl.int
+    // CHECK: [[B:%[0-9]+]] = hl.const #hl.integer<20> : !hl.int
+    // CHECK: hl.indirect_call [[F]] : !hl.ptr<!hl.typedef<"function_type">>([[A]], [[B]]) : (!hl.int, !hl.int) -> !hl.int
+    return p[1](15, 20);
+}

--- a/test/vast/Dialect/HighLevel/pointers-e.c
+++ b/test/vast/Dialect/HighLevel/pointers-e.c
@@ -11,11 +11,11 @@ int main() {
 
     // CHECK: [[E:%[0-9]+]] = hl.expr : !hl.lvalue<!hl.paren<() -> !hl.int>>
     // CHECK: [[P:%[0-9]+]] = hl.implicit_cast [[E]] FunctionToPointerDecay : !hl.lvalue<!hl.paren<() -> !hl.int>> -> !hl.lvalue<!hl.ptr<!hl.paren<() -> !hl.int>>>
-    // CHECK: hl.indirect_call [[P]]() : !hl.lvalue<!hl.ptr<!hl.paren<() -> !hl.int>>>
+    // CHECK: hl.indirect_call [[P]] : !hl.lvalue<!hl.ptr<!hl.paren<() -> !hl.int>>>() : () -> !hl.int
     (*p)(); // function f invoked through the function designator
 
     // CHECK: [[R:%[0-9]+]] = hl.ref [[FP]] : !hl.lvalue<!hl.ptr<!hl.paren<() -> !hl.int>>>
     // CHECK: [[F:%[0-9]+]] = hl.implicit_cast [[R]] LValueToRValue : !hl.lvalue<!hl.ptr<!hl.paren<() -> !hl.int>>> -> !hl.ptr<!hl.paren<() -> !hl.int>>
-    // CHECK:  hl.indirect_call [[F]]() : !hl.ptr<!hl.paren<() -> !hl.int>>
+    // CHECK:  hl.indirect_call [[F]] : !hl.ptr<!hl.paren<() -> !hl.int>>() : () -> !hl.int
     p();    // function f invoked directly through the pointer
 }


### PR DESCRIPTION
- implements `getFunctionType` for typedef of function pointers. 
- updates `IndirectCallOp` to allow typedef `callee` type.

closes #171 