### PR TITLE
Add missing libraries to linking targets

### DIFF
--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(vast-front
         MLIRPass
         MLIRSupport
 
+        LLVM
         LLVMSupport
 
         FromSourceParser

--- a/tools/vast-opt/CMakeLists.txt
+++ b/tools/vast-opt/CMakeLists.txt
@@ -16,6 +16,8 @@ target_link_libraries(vast-opt
         MLIRHighLevel
 
         vast::settings
+
+        clangAST
 )
 
 mlir_check_all_link_libraries(vast-opt)


### PR DESCRIPTION
Using my local build of llvm I couldn't build the project without these libraries in the CMake files.