### PR TITLE
Update linking library to LLVMTarget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,9 @@ target_include_directories(vast_settings INTERFACE
 )
 
 if (NOT LLVM_ENABLE_RTTI)
-  set_target_properties(vast_settings PROPERTIES COMPILE_FLAGS "-fno-rtti")
+  message( FATAL_ERROR
+    "VAST does not support build without RTTI, yet. Please build LLVM with LLVM_ENABLE_RTTI."
+  )
 endif()
 
 # sanitizer options if supported by compiler

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 add_definitions(${CLANG_DEFINITIONS})
 
+llvm_map_components_to_libnames(LLVM_LIBS
+  ${LLVM_TARGETS_TO_BUILD} support target option
+)
+
 #
 # VAST build settings
 #
@@ -204,6 +208,8 @@ if (VAST_INSTALL)
     vast_settings
     vast_translation_api
     vast_codegen
+    vast_frontend
+    vast_frontend_tool
 
     MLIRCore
     MLIRMeta

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ cmake --preset ninja-multi-default \
 
 To use a specific `llvm` provide `-DCMAKE_PREFIX_PATH=<llvm & mlir instalation paths>` option, where `CMAKE_PREFIX_PATH` points to directory containing `LLVMConfig.cmake` and `MLIRConfig.cmake`.
 
+Note: vast requires LLVM with RTTI enabled. Use `LLVM_ENABLE_RTTI=ON` if you build your own LLVM.
+
 
 Finally build the project:
 

--- a/lib/vast/Translation/CMakeLists.txt
+++ b/lib/vast/Translation/CMakeLists.txt
@@ -11,22 +11,18 @@ add_library( vast_translation_api STATIC
 )
 
 target_link_libraries( vast_translation_api
-    PRIVATE
-        clangAST
-        clangASTMatchers
-        clangBasic
+  PRIVATE
+    clangAST
+    clangASTMatchers
+    clangBasic
 
-        MLIRMeta
-        MLIRHighLevel
-        MLIRSupport
+    MLIRMeta
+    MLIRHighLevel
+    MLIRSupport
 
-        vast::settings
-        vast::codegen
+    vast::settings
+    vast::codegen
 )
-
-if (NOT LLVM_ENABLE_RTTI)
-  set_target_properties(vast_translation_api PROPERTIES COMPILE_FLAGS "-fno-rtti")
-endif()
 
 add_library(vast::translation_api ALIAS vast_translation_api)
 
@@ -36,21 +32,18 @@ add_library( FromSourceParser
 )
 
 target_link_libraries( FromSourceParser
-    PRIVATE
-        clangAST
-        clangASTMatchers
-        clangBasic
-        clangFrontend
-        clangSerialization
-        clangTooling
+  PRIVATE
+    clangAST
+    clangASTMatchers
+    clangBasic
+    clangFrontend
+    clangSerialization
+    clangTooling
 
-        MLIRSupport
+    MLIRSupport
 
-        vast::settings
-        vast::translation_api
+    vast::settings
+    vast::translation_api
 )
 
-if (NOT LLVM_ENABLE_RTTI)
-  set_target_properties(FromSourceParser PROPERTIES COMPILE_FLAGS "-fno-rtti")
-endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(VAST_TEST_DEPENDS
   vast-query
   vast-opt
   vast-cc
+  vast-front
 )
 
 add_lit_testsuite(check-vast "Running the VAST regression tests"

--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -1,33 +1,26 @@
 #
 # VAST Frontend Praser
 #
-link_directories(${LLVM_LIBRARY_DIR})
-
-set( LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Option
-  Support
-  TargetParser
-)
 
 get_property(DIALECT_LIBS GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(CONVERSION_LIBS GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 add_library(vast_frontend_tool
-    compiler_invocation.cpp
+  compiler_invocation.cpp
 )
 
 target_link_libraries(vast_frontend_tool
-    PRIVATE
-      clangBasic
-      clangDriver
-      clangFrontend
+  PUBLIC
+    clangBasic
+    clangDriver
+    clangFrontend
 
-      LLVMSupport
+    ${LLVM_LIBS}
 
-      vast::codegen
-      vast::frontend
-      vast::settings
+    vast::codegen
+    vast::frontend
+  PRIVATE
+    vast::settings
 )
 
 add_library(vast::frontend_tool ALIAS vast_frontend_tool)
@@ -38,32 +31,26 @@ add_executable(vast-front
 )
 
 target_link_libraries(vast-front
-    PRIVATE
-        ${DIALECT_LIBS}
-        ${CONVERSION_LIBS}
+  PRIVATE
+    ${DIALECT_LIBS}
+    ${CONVERSION_LIBS}
 
-        MLIRHighLevel
-        MLIRHighLevelTransforms
+    MLIRHighLevel
+    MLIRHighLevelTransforms
 
-        MLIRIR
-        MLIRParser
-        MLIRPass
-        MLIRSupport
+    MLIRIR
+    MLIRParser
+    MLIRPass
+    MLIRSupport
 
-        LLVMTarget
-        LLVMSupport
+    FromSourceParser
 
-        FromSourceParser
+    clangAST
+    clangCodeGen
+    clangFrontend
+    clangSerialization
+    clangTooling
 
-        clangAST
-        clangBasic
-        clangCodeGen
-        clangDriver
-        clangFrontend
-        clangSerialization
-        clangTooling
-
-        vast::frontend
-        vast::frontend_tool
-        vast::settings
+    vast::frontend_tool
+    vast::settings
 )

--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(vast-front
         MLIRPass
         MLIRSupport
 
-        LLVM
+        LLVMTarget
         LLVMSupport
 
         FromSourceParser

--- a/tools/vast-query/CMakeLists.txt
+++ b/tools/vast-query/CMakeLists.txt
@@ -7,13 +7,11 @@ add_executable(vast-query vast-query.cpp)
 llvm_update_compile_flags(vast-query)
 
 target_link_libraries(vast-query
-    PRIVATE
-        ${DIALECT_LIBS}
-        MLIRHighLevel
+  PRIVATE
+    ${DIALECT_LIBS}
+    MLIRHighLevel
+
+    vast::settings
 )
 
 mlir_check_all_link_libraries(vast-query)
-
-if (NOT LLVM_ENABLE_RTTI)
-  set_target_properties(vast-query PROPERTIES COMPILE_FLAGS "-fno-rtti")
-endif()

--- a/tools/vast-repl/CMakeLists.txt
+++ b/tools/vast-repl/CMakeLists.txt
@@ -24,7 +24,3 @@ target_link_libraries(vast-repl
 )
 
 mlir_check_all_link_libraries(vast-repl)
-
-if (NOT LLVM_ENABLE_RTTI)
-  set_target_properties(vast-repl PROPERTIES COMPILE_FLAGS "-fno-rtti")
-endif()


### PR DESCRIPTION
Update vast-front linking library to use LLVMTarget instead of linking to LLVM. This is to fix build error with vcpkg. 