### PR TITLE
Fix csmith libraries compilation to high-level dialect

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -879,7 +879,6 @@ def Predicate : PredicateList< "Predicate", "comparison predicate", [
   ICmpPredicateUGT, ICmpPredicateUGE
 ] >;
 
-
 def CmpOp
   : HighLevel_Op< "cmp", [NoSideEffect] >
   , Arguments<(ins Predicate:$predicate, AnyType:$lhs, AnyType:$rhs)>
@@ -890,6 +889,48 @@ def CmpOp
 
   let assemblyFormat = "$predicate $lhs `,` $rhs  attr-dict `:` type(operands) `->` type($result)";
 }
+
+class FPredicateAttr< string name, int val > : I64EnumAttrCase< name, val > {}
+
+class FPredicateList< string name, string summary, list<FPredicateAttr> cases >
+  : I64EnumAttr< name, summary, cases > {}
+
+def FPredicateFalse : FPredicateAttr<"ffalse", 0>;
+def FPredicateOEQ   : FPredicateAttr<"oeq",    1>;
+def FPredicateOGT   : FPredicateAttr<"ogt",    2>;
+def FPredicateOGE   : FPredicateAttr<"oge",    3>;
+def FPredicateOLT   : FPredicateAttr<"olt",    4>;
+def FPredicateOLE   : FPredicateAttr<"ole",    5>;
+def FPredicateONE   : FPredicateAttr<"one",    6>;
+def FPredicateORD   : FPredicateAttr<"ord",    7>;
+def FPredicateUNO   : FPredicateAttr<"uno",    8>;
+def FPredicateUEQ   : FPredicateAttr<"ueq",    9>;
+def FPredicateUGT   : FPredicateAttr<"ugt",   10>;
+def FPredicateUGE   : FPredicateAttr<"uge",   11>;
+def FPredicateULT   : FPredicateAttr<"ult",   12>;
+def FPredicateULE   : FPredicateAttr<"ule",   13>;
+def FPredicateUNE   : FPredicateAttr<"une",   14>;
+def FPredicateTrue  : FPredicateAttr<"ftrue", 15>;
+
+let cppNamespace = "::vast::hl" in
+def FPredicate : FPredicateList< "FPredicate", "floating point comparison predicate", [
+  FPredicateFalse, FPredicateOEQ, FPredicateOGT, FPredicateOGE,
+  FPredicateOLT, FPredicateOLE, FPredicateONE, FPredicateORD,
+  FPredicateUNO, FPredicateUEQ, FPredicateUGT, FPredicateUGE,
+  FPredicateULT, FPredicateULE, FPredicateUNE, FPredicateTrue
+] >;
+
+def FCmpOp
+  : HighLevel_Op< "fcmp", [NoSideEffect] >
+  , Arguments<(ins FPredicate:$predicate, FloatLikeType:$lhs, FloatLikeType:$rhs)>
+  , Results<(outs IntOrBoolType:$result)>
+{
+  let summary = "VAST flaoting point comparison operation";
+  let description = [{ VAST flaoting point comparison operation }];
+
+  let assemblyFormat = "$predicate $lhs `,` $rhs  attr-dict `:` type(operands) `->` type($result)";
+}
+
 
 
 class UnInplaceOp< string mnemonic, list< Trait > traits = [] >

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -1089,4 +1089,21 @@ def AlignOfExprOp : ExprTraitOp< "alignof.expr" > {
   let description = [{ VAST expr alignof operator }];
 }
 
+def StmtExprOp
+  : HighLevel_Op< "stmt.expr", [RecursiveSideEffects, SingleBlock] >
+  , Results<(outs AnyType:$result)>
+{
+  let summary = "VAST statement expression";
+  let description = [{ VAST statement expression }];
+
+  let regions = (region SizedRegion<1>:$substmt);
+
+  let skipDefaultBuilders = 1;
+  let builders = [ OpBuilder<(ins "Type":$rty, "std::unique_ptr< Region > &&":$region)> ];
+
+  let assemblyFormat = [{
+     attr-dict `:` type($result) $substmt
+  }];
+}
+
 #endif // VAST_DIALECT_HIGHLEVEL_IR_HIGHLEVELOPS

--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -832,7 +832,8 @@ namespace vast::cg {
         // Operation* VisitParenListExpr(const clang::ParenListExpr *expr)
         Operation* VisitStmtExpr(const clang::StmtExpr *expr) {
             auto loc = meta_location(expr);
-            auto [reg, rty] = make_value_yield_region(expr->getSubStmt());
+            auto sub = llvm::cast< clang::CompoundStmt >(expr->getSubStmt());
+            auto [reg, rty] = make_value_yield_region(sub);
             return make< hl::StmtExprOp >(loc, rty, std::move(reg));
         }
 

--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -825,12 +825,16 @@ namespace vast::cg {
         // Operation* VisitOverloadExpr(const clang::OverloadExpr *expr)
 
         Operation* VisitParenExpr(const clang::ParenExpr *expr) {
-            auto [region, type] = make_value_yield_region(expr->getSubExpr());
-            return make< hl::ExprOp >(meta_location(expr), type, std::move(region));
+            auto [reg, rty] = make_value_yield_region(expr->getSubExpr());
+            return make< hl::ExprOp >(meta_location(expr), rty, std::move(reg));
         }
 
         // Operation* VisitParenListExpr(const clang::ParenListExpr *expr)
-        // Operation* VisitStmtExpr(const clang::StmtExpr *expr)
+        Operation* VisitStmtExpr(const clang::StmtExpr *expr) {
+            auto loc = meta_location(expr);
+            auto [reg, rty] = make_value_yield_region(expr->getSubStmt());
+            return make< hl::StmtExprOp >(loc, rty, std::move(reg));
+        }
 
         template< typename Op >
         Operation* ExprTypeTrait(const clang::UnaryExprOrTypeTraitExpr *expr, auto rty, auto loc) {

--- a/include/vast/Util/Warnings.hpp
+++ b/include/vast/Util/Warnings.hpp
@@ -51,11 +51,15 @@ VAST_UNRELAX_WARNINGS
 
 namespace vast
 {
-    #define VAST_UNREACHABLE(fmt, ...) llvm_unreachable( llvm::formatv(fmt __VA_OPT__(,) __VA_ARGS__).str().c_str() );
+    #define VAST_REPORT(...) llvm::dbgs() << "[vast] " << llvm::formatv(__VA_ARGS__) << "\n";
+
+    #define VAST_UNREACHABLE(...) \
+      VAST_REPORT(__VA_ARGS__) \
+      llvm_unreachable(nullptr);
 
     #define VAST_UNIMPLEMENTED VAST_UNREACHABLE("not implemented: {0}", __PRETTY_FUNCTION__);
 
-    #define VAST_DEBUG(fmt, ...) LLVM_DEBUG(llvm::dbgs() << llvm::formatv(fmt, __VA_OPT__(,) __VA_ARGS__));
+    #define VAST_DEBUG(fmt, ...) LLVM_DEBUG(VAST_REPORT(__VA_ARGS__))
 
     #define VAST_CHECK(cond, fmt, ...) if (!(cond)) { VAST_UNREACHABLE(fmt __VA_OPT__(,) __VA_ARGS__); }
 

--- a/lib/vast/Dialect/HighLevel/HighLevelLinkage.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelLinkage.cpp
@@ -140,11 +140,12 @@ namespace vast::hl {
             case GlobalLinkageKind::PrivateLinkage:
                 return Visibility::Private;
             case GlobalLinkageKind::ExternalLinkage:
+            case GlobalLinkageKind::AvailableExternallyLinkage:
             case GlobalLinkageKind::ExternalWeakLinkage:
             case GlobalLinkageKind::LinkOnceODRLinkage:
                 return Visibility::Public;
             default:
-                VAST_UNREACHABLE("unsupported linkage kind");
+                VAST_UNREACHABLE("unsupported linkage kind {0}", stringifyGlobalLinkageKind(linkage));
         }
 
         VAST_UNREACHABLE("missed linkage kind");

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -187,6 +187,12 @@ namespace vast::hl
         build_expr_trait(bld, st, rty, expr);
     }
 
+    void StmtExprOp::build(Builder &bld, State &st, Type rty, std::unique_ptr< Region > &&region) {
+        InsertionGuard guard(bld);
+        st.addRegion(std::move(region));
+        st.addTypes(rty);
+    }
+
     void VarDeclOp::build(Builder &bld, State &st, Type type, llvm::StringRef name, BuilderCallback init, BuilderCallback alloc) {
         st.addAttribute("name", bld.getStringAttr(name));
         InsertionGuard guard(bld);

--- a/test/vast/Dialect/HighLevel/stmt-expr.c
+++ b/test/vast/Dialect/HighLevel/stmt-expr.c
@@ -1,0 +1,10 @@
+// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+
+int main() {
+    // CHECK: hl.stmt.expr : !hl.int
+    // CHECK:   hl.var "x"
+    // CHECK:   hl.value.yield
+    // CHECK:   hl.value.yield
+    int v = ({int x = 4; x;});
+}


### PR DESCRIPTION
Adds missing:

- AvailableExternalLinkageKind
- Floating point comparison operations
- GNU statement expressions

fixes #246 