### PR TITLE
cmake: fix vast export name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ if (VAST_INSTALL)
     PATTERN "CMakeFiles" EXCLUDE
   )
 
-  set(VAST_EXPORT_NAME vastTargets)
+  set(VAST_EXPORT_NAME VASTTargets)
 
   install(TARGETS ${VAST_INSTALL_TARGETS}
     EXPORT ${VAST_EXPORT_NAME}


### PR DESCRIPTION
PR fixes the `VAST_EXPORT_NAME` to avoid issue on case-sensitive filesystem. The issue occurs because the project name is updated to `VAST`. 