### PR TITLE
cg: Deduplicate functions using their mangled name.

### DIFF
--- a/include/vast/Translation/CodeGen.hpp
+++ b/include/vast/Translation/CodeGen.hpp
@@ -102,7 +102,7 @@ namespace vast::cg
         using EnumDeclsScope     = ScopedSymbolTable< const clang::EnumDecl *, hl::EnumDeclOp >;
         using EnumConstantsScope = ScopedSymbolTable< const clang::EnumConstantDecl *, hl::EnumConstantOp >;
         using LabelTable         = ScopedSymbolTable< const clang::LabelDecl*, hl::LabelDeclOp >;
-        using FunctionsScope     = ScopedSymbolTable< const clang::FunctionDecl *, hl::FuncOp >;
+        using FunctionsScope     = ScopedSymbolTable< mangled_name_ref, hl::FuncOp >;
         using VariablesScope     = ScopedSymbolTable< const clang::VarDecl *, Value >;
 
         struct CodegenScope {

--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -565,7 +565,8 @@ namespace vast::cg {
 
         Operation* VisitFunctionDeclRefExpr(const clang::DeclRefExpr *expr) {
             auto decl = clang::cast< clang::FunctionDecl >( expr->getDecl()->getUnderlyingDecl() );
-            auto fn = context().lookup_function(decl);
+            auto mangled = derived().get_mangled_name(decl);
+            auto fn = context().lookup_function(mangled);
             auto rty = getLValueReturnType(expr);
 
             return make< hl::FuncRefOp >(meta_location(expr), rty, mlir::SymbolRefAttr::get(fn));
@@ -774,7 +775,8 @@ namespace vast::cg {
         hl::FuncOp VisitDirectCallee(const clang::FunctionDecl *callee) {
             InsertionGuard guard(builder());
 
-            if (auto fn = context().lookup_function(callee, false /* with error */)) {
+            auto mangled = derived().get_mangled_name(callee);
+            if (auto fn = context().lookup_function(mangled, false /* with error */)) {
                 return fn;
             }
 

--- a/include/vast/Translation/CodeGenVisitorBase.hpp
+++ b/include/vast/Translation/CodeGenVisitorBase.hpp
@@ -17,6 +17,10 @@ namespace vast::cg {
             : ctx(ctx), meta(meta), mangler(ctx.actx.createMangleContext())
         {}
 
+        mangled_name_ref get_mangled_name(clang::GlobalDecl decl) {
+            return mangler.get_mangled_name(decl, ctx.actx.getTargetInfo(), /* module name hash */ "");
+        }
+
         CodeGenContext &ctx;
         MetaGenerator &meta;
         CodeGenMangler mangler;

--- a/lib/vast/Translation/Mangler.cpp
+++ b/lib/vast/Translation/Mangler.cpp
@@ -96,3 +96,12 @@ namespace vast::cg
         return std::string(out.str());
     }
 } // namespace vast::cg
+
+
+namespace llvm {
+
+    [[nodiscard]] hash_code hash_value(vast::cg::mangled_name_ref mangled) {
+        return hash_value(mangled.name);
+    }
+
+} // llvm


### PR DESCRIPTION
- tries to deduplicate function definitions using their mangled names

- fixes #265 