### PR TITLE
Frontend action to emit llvm/mlir and associated fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,22 @@ link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 add_definitions(${CLANG_DEFINITIONS})
 
-llvm_map_components_to_libnames(LLVM_LIBS
-  ${LLVM_TARGETS_TO_BUILD} support target option
-)
+if (LLVM_LINK_LLVM_DYLIB)
+    set(LLVM_LIBS LLVM)
+else()
+    llvm_map_components_to_libnames(LLVM_LIBS
+      ${LLVM_TARGETS_TO_BUILD} support target option
+    )
+endif()
+
+# TODO(cmake): With newer cmake there should be a better way to do this.
+function(mk_clang_libs out)
+    if (CLANG_LINK_CLANG_DYLIB)
+        set(${out} clang-cpp PARENT_SCOPE)
+    else()
+        set(${out} ${ARGN} PARENT_SCOPE)
+    endif()
+endfunction()
 
 #
 # VAST build settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,7 @@ if (VAST_INSTALL)
     vast_codegen
     vast_frontend
     vast_frontend_tool
+    vast_target_llvmir
     vast_util
 
     MLIRCore

--- a/include/vast/Conversion/Common/Passes.hpp
+++ b/include/vast/Conversion/Common/Passes.hpp
@@ -10,6 +10,7 @@ VAST_UNRELAX_WARNINGS
 
 #include "vast/Util/LLVMTypeConverter.hpp"
 #include "vast/Conversion/Common/Types.hpp"
+#include "vast/Conversion/Common/Patterns.hpp"
 
 namespace vast {
 
@@ -36,7 +37,8 @@ namespace vast {
         template< typename pattern, typename config_t >
         static void legalize(config_t &config)
         {
-            pattern::legalize(config.target);
+            if constexpr ( has_legalize< pattern > )
+                pattern::legalize(config.target);
         }
 
         auto &self() { return static_cast< self_t & >(*this); }

--- a/include/vast/Conversion/Common/Patterns.hpp
+++ b/include/vast/Conversion/Common/Patterns.hpp
@@ -25,7 +25,7 @@ namespace vast {
     //             anything.
     // If this header is ever exported, probably remove this.
     #define VAST_PATTERN_CHECK(cond, ...) \
-        VAST_CHECK( detail::is_ok(cond), __VA_ARGS__)
+        VAST_CHECK( ::vast::detail::is_ok(cond), __VA_ARGS__)
 
     #define VAST_PATTERN_FAIL(...) \
         VAST_UNREACHABLE(__VA_ARGS__)

--- a/include/vast/Conversion/Common/Patterns.hpp
+++ b/include/vast/Conversion/Common/Patterns.hpp
@@ -31,6 +31,12 @@ namespace vast {
         VAST_UNREACHABLE(__VA_ARGS__)
 
 
+    template< typename T >
+    concept has_legalize = requires ( T a )
+    {
+        a.legalize( std::declval< conversion_target & >() );
+    };
+
     template< typename derived_pattern >
     struct mlir_pattern_mixin {
 

--- a/include/vast/Conversion/Common/Patterns.hpp
+++ b/include/vast/Conversion/Common/Patterns.hpp
@@ -15,6 +15,21 @@ VAST_UNRELAX_WARNINGS
 
 namespace vast {
 
+    namespace detail
+    {
+        static inline bool is_ok( const auto &v ) { return static_cast< bool >( v ); }
+        static inline bool is_ok( logical_result r ) { return mlir::succeeded( r ); }
+    } // namespace detail
+
+    // TODO(conv): In non-debug mode return `mlir::failure()` and do not log
+    //             anything.
+    // If this header is ever exported, probably remove this.
+    #define VAST_PATTERN_CHECK(cond, ...) \
+        VAST_CHECK( detail::is_ok(cond), __VA_ARGS__)
+
+    #define VAST_PATTERN_FAIL(...) \
+        VAST_UNREACHABLE(__VA_ARGS__)
+
 
     template< typename derived_pattern >
     struct mlir_pattern_mixin {

--- a/include/vast/Conversion/Common/Rewriter.hpp
+++ b/include/vast/Conversion/Common/Rewriter.hpp
@@ -29,6 +29,9 @@ namespace vast::conv
         auto &operator*() { return bld; }
         const auto &operator*() const { return bld; }
 
+        auto *operator->() { return &bld; }
+        const auto *operator->() const { return &bld; }
+
         auto guarded( auto &&fn )
         {
             auto g = guard();

--- a/include/vast/Conversion/Common/Rewriter.hpp
+++ b/include/vast/Conversion/Common/Rewriter.hpp
@@ -8,8 +8,59 @@ VAST_RELAX_WARNINGS
 #include "mlir/Transforms/DialectConversion.h"
 VAST_UNRELAX_WARNINGS
 
+#include "vast/Util/Common.hpp"
+
 namespace vast::conv
 {
+    template< typename impl_t >
+    struct rewriter_wrapper_t
+    {
+        using self_t = rewriter_wrapper_t< impl_t >;
+        using underlying_t = impl_t;
+
+        // Sadly, it looks like mlir does not expose a generic way to retrieve guard per
+        // builder type.
+        using guard_t = InsertionGuard;
+
+        underlying_t &bld;
+
+        rewriter_wrapper_t( underlying_t &bld ) : bld( bld ) {}
+
+        auto &operator*() { return bld; }
+        const auto &operator*() const { return bld; }
+
+        auto guarded( auto &&fn )
+        {
+            auto g = guard();
+            return fn();
+        }
+
+        auto guard() { return guard_t( bld ); }
+
+        auto guarded_at_end( mlir::Block *block, auto &&fn )
+        {
+            auto g = guard();
+            bld.setInsertionPointToEnd( block );
+            return fn();
+        }
+
+        template< typename Trg, typename Bld, typename ... Args >
+        auto make_after_op( Operation *op, Args && ... args )
+        {
+            auto g = guard();
+            bld.setInsertionPointAfter( op );
+            return bld.template create< Trg >( std::forward< Args >( args ) ... );
+        }
+
+        template< typename Trg, typename ... Args >
+        auto make_at_end( mlir::Block *block, Args && ... args )
+        {
+            auto g = guard();
+            bld.setInsertionPointToEnd( block );
+            return bld.template create< Trg >( std::forward< Args >( args ) ... );
+        }
+    };
+
     auto guarded( auto &bld, auto &&fn )
     {
         auto g = mlir::OpBuilder::InsertionGuard( bld );

--- a/include/vast/Dialect/Core/CoreDialect.hpp
+++ b/include/vast/Dialect/Core/CoreDialect.hpp
@@ -14,4 +14,3 @@ VAST_RELAX_WARNINGS
 
 // Pull in the dialect definition.
 #include "vast/Dialect/Core/CoreDialect.h.inc"
-

--- a/include/vast/Dialect/Core/CoreLazy.td
+++ b/include/vast/Dialect/Core/CoreLazy.td
@@ -18,7 +18,7 @@ class LazyEval< string mnemonic, list < Trait > traits = [] >
     let description = [{ VAST lazy evaluator }];
 }
 
-def Core_LazyOp : LazyEval< "lazy.op", [] > {
+def Core_LazyOp : LazyEval< "lazy.op", [NoTerminator] > {
     let summary = "Lazily evaluate a region.";
     let description = [{
         The operation serves to encapsulate delayed evaluation in its region.

--- a/include/vast/Dialect/Core/CoreLazy.td
+++ b/include/vast/Dialect/Core/CoreLazy.td
@@ -51,4 +51,21 @@ class Core_LogicBinOp< string mnemonic, list< Trait > traits = [] >
 def Core_BinLAndOp : Core_LogicBinOp<"bin.land", []>;
 def Core_BinLOrOp  : Core_LogicBinOp< "bin.lor", []>;
 
+// TODO( core ): Probably move it outside or enforce that operands are lazy blocks.
+def Core_SelectOp
+    : Core_Op< "select" >
+    , Arguments<(ins AnyType:$cond, AnyType:$thenRegion, AnyType:$elseRegion)>
+    , Results<(outs Variadic<AnyType>:$results)>
+{
+    let summary = "Select a value based on condition.";
+    let description = [{
+        Usual select operation. First operand is selected if predicate is true, second
+        otherwise (to mirror how ternary works in C).
+
+        %result = <op> %cond %lhs, %rhs  : type
+    }];
+
+    let assemblyFormat = [{ $cond `,` $thenRegion `,` $elseRegion attr-dict `:` functional-type(operands, results) }];
+}
+
 #endif //VAST_DIALECT_CORE_CORELAZY

--- a/include/vast/Dialect/Core/CoreTraits.hpp
+++ b/include/vast/Dialect/Core/CoreTraits.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Util/Warnings.hpp"
+
+VAST_RELAX_WARNINGS
+#include <mlir/IR/OpDefinition.h>
+VAST_UNRELAX_WARNINGS
+
+namespace vast::core
+{
+    template< typename concrete_t >
+    struct soft_terminator : mlir::OpTrait::TraitBase< concrete_t,
+                                                       soft_terminator >
+    {};
+
+    static inline bool is_soft_terminator( mlir::Operation *op )
+    {
+        return op->hasTrait< soft_terminator >();
+    }
+} // namespace vast::core
+

--- a/include/vast/Dialect/Core/CoreTraits.td
+++ b/include/vast/Dialect/Core/CoreTraits.td
@@ -1,0 +1,13 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#ifndef VAST_DIALECT_CORE_CORELAZY
+#define VAST_DIALECT_CORE_CORELAZY
+
+include "mlir/IR/DialectBase.td"
+
+def soft_terminator : NativeOpTrait< "soft_terminator" >, StructuralOpTrait
+{
+    let cppNamespace = "::vast::core";
+}
+
+#endif //VAST_DIALECT_CORE_CORELAZY

--- a/include/vast/Dialect/Core/CoreTraits.td
+++ b/include/vast/Dialect/Core/CoreTraits.td
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present, Trail of Bits, Inc.
 
-#ifndef VAST_DIALECT_CORE_CORELAZY
-#define VAST_DIALECT_CORE_CORELAZY
+#ifndef VAST_DIALECT_CORE_CORETRAITS
+#define VAST_DIALECT_CORE_CORETRAITS
 
 include "mlir/IR/DialectBase.td"
 
@@ -10,4 +10,4 @@ def soft_terminator : NativeOpTrait< "soft_terminator" >, StructuralOpTrait
     let cppNamespace = "::vast::core";
 }
 
-#endif //VAST_DIALECT_CORE_CORELAZY
+#endif //VAST_DIALECT_CORE_CORETRAITS

--- a/include/vast/Dialect/Core/Utils.td
+++ b/include/vast/Dialect/Core/Utils.td
@@ -4,6 +4,7 @@
 #define VAST_DIALECT_CORE_UTILS
 
 include "mlir/IR/BuiltinTypes.td"
+include "mlir/IR/DialectBase.td"
 
 def HasOneBlock   : CPred<"$_self.hasOneBlock()">;
 

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -5,6 +5,8 @@
 
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 
+include "vast/Dialect/Core/CoreTraits.td"
+
 class ControlFlowOp< string mnemonic, list< Trait > traits = [] >
     : HighLevel_Op< mnemonic, !listconcat(traits,
         [SingleBlock, NoTerminator, NoRegionArguments, RecursiveSideEffects]
@@ -239,7 +241,7 @@ def HighLevel_DoOp : ControlFlowOp< "do" >
   }];
 }
 
-def HighLevel_BreakOp : ControlFlowOp< "break" >
+def HighLevel_BreakOp : ControlFlowOp< "break", [soft_terminator] >
 {
   let summary = "VAST break statement";
   let description = [{ VAST break statement }];
@@ -247,7 +249,7 @@ def HighLevel_BreakOp : ControlFlowOp< "break" >
   let assemblyFormat = [{ attr-dict }];
 }
 
-def HighLevel_ContinueOp : ControlFlowOp< "continue" >
+def HighLevel_ContinueOp : ControlFlowOp< "continue", [soft_terminator] >
 {
   let summary = "VAST continue statement";
   let description = [{ VAST continue statement }];

--- a/include/vast/Dialect/HighLevel/HighLevelDialect.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelDialect.hpp
@@ -13,6 +13,8 @@ VAST_RELAX_WARNINGS
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
 VAST_RELAX_WARNINGS
 
+#include "vast/Dialect/Core/CoreTraits.hpp"
+
 // Pull in the dialect definition.
 #include "vast/Dialect/HighLevel/HighLevelDialect.h.inc"
 

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -1129,4 +1129,41 @@ def StmtExprOp
   }];
 }
 
+class IdentKindAttr< string name, int val > : I64EnumAttrCase< name, val > {}
+
+class IdentKindList< string name, string summary, list< IdentKindAttr > cases >
+  : I64EnumAttr< name, summary, cases > {}
+
+def Func : IdentKindAttr<"Func", 0>;
+def Function : IdentKindAttr<"Function", 1>;
+def LFunction : IdentKindAttr<"LFunction", 2>;
+def FuncDName : IdentKindAttr<"FuncDName", 3>;
+def FuncSig : IdentKindAttr<"FuncSig", 4>;
+def LFuncSig : IdentKindAttr<"LFuncSig", 5>;
+def PrettyFunction : IdentKindAttr<"PrettyFunction", 6>;
+def PrettyFunctionNoVirtual : IdentKindAttr<"PrettyFunctionNoVirtual", 7>;
+
+let cppNamespace = "::vast::hl" in
+def IdentKind : IdentKindList< "IdentKind", "ident kind", [
+    Func,
+    Function,
+    LFunction,
+    FuncDName,
+    FuncSig,
+    LFuncSig,
+    PrettyFunction,
+    PrettyFunctionNoVirtual
+] >;
+
+def PredefinedExpr
+  : HighLevel_Op< "predefined.expr" >
+    , Arguments<(ins AnyType:$value, IdentKind:$kind)>
+    , Results<(outs AnyType:$result)>
+{
+    let summary = "VAT predefined expr ( such as __func__ )";
+    let description = [{ VAT predefined expr ( such as __func__ ) }];
+
+    let assemblyFormat = "$value $kind attr-dict `:` type($value) `->` type($result)";
+}
+
 #endif // VAST_DIALECT_HIGHLEVEL_IR_HIGHLEVELOPS

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -15,6 +15,7 @@ include "vast/Dialect/HighLevel/HighLevelLinkage.td"
 include "vast/Dialect/HighLevel/HighLevelCF.td"
 
 include "vast/Dialect/Core/Utils.td"
+include "vast/Dialect/Core/CoreTraits.td"
 
 
 def TranslationUnitOp
@@ -350,7 +351,7 @@ def ExprOp
 }
 
 def ReturnOp
-  : HighLevel_Op< "return", [NoSideEffect] >
+  : HighLevel_Op< "return", [NoSideEffect, soft_terminator] >
   , Arguments<(ins Variadic<AnyType>:$result)>
 {
   let assemblyFormat = "($result^ `:` type($result))? attr-dict";

--- a/include/vast/Frontend/Driver.hpp
+++ b/include/vast/Frontend/Driver.hpp
@@ -306,6 +306,10 @@ namespace vast::cc {
             if (vast::cc::opt::emit_only_mlir(vargs)) {
                 cmd_args.push_back("-c");
             }
+
+            if (vast::cc::opt::emit_only_llvm(vargs)) {
+                cmd_args.push_back("-emit-llvm");
+            }
         }
 
         void set_install_dir(argv_storage_base &argv, bool canonical_prefixes) {

--- a/include/vast/Frontend/FrontendAction.hpp
+++ b/include/vast/Frontend/FrontendAction.hpp
@@ -17,6 +17,7 @@ namespace vast::cc {
         emit_assembly,
         emit_high_level,
         emit_cir,
+        emit_mlir,
         emit_llvm,
         emit_obj,
         none

--- a/include/vast/Frontend/GenAction.hpp
+++ b/include/vast/Frontend/GenAction.hpp
@@ -30,6 +30,8 @@ namespace vast::cc {
         constexpr string_ref emit_cir = "emit-cir";
         constexpr string_ref emit_llvm = "emit-llvm";
 
+        constexpr string_ref emit_mlir = "emit-mlir";
+
         constexpr string_ref disable_vast_verifier = "disable-vast-verifier";
         constexpr string_ref vast_verify_diags = "verify-diags";
         constexpr string_ref disable_emit_cxx_default = "disable-emit-cxx-default";
@@ -84,6 +86,15 @@ namespace vast::cc {
     //
     struct emit_llvm_action : vast_gen_action {
         emit_llvm_action(const vast_args &vargs, mcontext_t *mcontext = nullptr);
+    private:
+        virtual void anchor();
+    };
+
+    //
+    // Emit MLIR
+    //
+    struct emit_mlir_action : vast_gen_action {
+        emit_mlir_action(const vast_args &vargs, mcontext_t *mcontext = nullptr);
     private:
         virtual void anchor();
     };

--- a/include/vast/Frontend/GenAction.hpp
+++ b/include/vast/Frontend/GenAction.hpp
@@ -28,17 +28,16 @@ namespace vast::cc {
     namespace opt {
         constexpr string_ref emit_high_level = "emit-high-level";
         constexpr string_ref emit_cir = "emit-cir";
+        constexpr string_ref emit_llvm = "emit-llvm";
 
         constexpr string_ref disable_vast_verifier = "disable-vast-verifier";
         constexpr string_ref vast_verify_diags = "verify-diags";
         constexpr string_ref disable_emit_cxx_default = "disable-emit-cxx-default";
 
         bool emit_only_mlir(const vast_args &vargs);
+        bool emit_only_llvm(const vast_args &vargs);
 
     } // namespace opt
-
-
-
 
     struct vast_gen_consumer;
 

--- a/include/vast/Frontend/Options.hpp
+++ b/include/vast/Frontend/Options.hpp
@@ -30,7 +30,11 @@ namespace vast::cc
 
     constexpr string_ref vast_option_prefix = "-vast-";
 
-    struct vast_args {
+    struct vast_args
+    {
+        using option_list = std::vector< string_ref >;
+        using maybe_option_list = std::optional< option_list >;
+
         argv_storage args;
 
         // detects the presence of an option in one of formats:
@@ -42,7 +46,7 @@ namespace vast::cc
         std::optional< string_ref > get_option(string_ref opt) const;
 
         // from option of form -vast-"name"="value1;value2;value3" returns list of values
-        std::optional< std::vector< string_ref > > get_options_list(string_ref opt) const;
+        maybe_option_list get_options_list(string_ref opt) const;
 
         void push_back(arg_t arg);
     };

--- a/include/vast/Target/LLVMIR/Convert.hpp
+++ b/include/vast/Target/LLVMIR/Convert.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "vast/Util/Warnings.hpp"
+#include "vast/Util/Common.hpp"
 
 VAST_RELAX_WARNINGS
 #include <mlir/IR/DialectRegistry.h>

--- a/include/vast/Target/LLVMIR/Convert.hpp
+++ b/include/vast/Target/LLVMIR/Convert.hpp
@@ -4,6 +4,10 @@
 
 #include "vast/Util/Warnings.hpp"
 
+VAST_RELAX_WARNINGS
+#include <mlir/IR/DialectRegistry.h>
+VAST_UNRELAX_WARNINGS
+
 #include <memory>
 #include <string>
 
@@ -30,5 +34,8 @@ namespace vast::target::llvmir
     // Run all passes needed to go from a product of vast frontend (module in `hl` dialect)
     // to a module in lowest representation (mostly LLVM dialect right now).
     void prepare_hl_module(mlir::Operation *op);
+
+    void register_vast_to_llvm_ir(mlir::DialectRegistry &registry);
+    void register_vast_to_llvm_ir(mcontext_t &mctx);
 
 } // namespace vast::target::llvmir

--- a/include/vast/Translation/CodeGenBuilder.hpp
+++ b/include/vast/Translation/CodeGenBuilder.hpp
@@ -235,8 +235,9 @@ namespace vast::cg {
             return [stmt, this](auto &bld, auto loc) {
                 visit(stmt);
                 auto &op = bld.getBlock()->back();
-                VAST_ASSERT(op.getNumResults() == 1);
-                create< YieldType >(loc, op.getResult(0));
+                VAST_ASSERT(op.getNumResults() <= 1);
+                if (op.getNumResults() > 0)
+                    create< YieldType >(loc, op.getResult(0));
             };
         }
 

--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -21,6 +21,7 @@ VAST_UNRELAX_WARNINGS
 namespace vast::hl {
 
     CastKind cast_kind(const clang::CastExpr *expr);
+    IdentKind ident_kind(const clang::PredefinedExpr *expr);
 
 } // namespace vast::hl
 
@@ -590,6 +591,18 @@ namespace vast::cg {
             }
 
             VAST_UNREACHABLE("unknown underlying declaration to be referenced");
+        }
+
+        Operation *VisitPredefinedExpr(const clang::PredefinedExpr *expr)
+        {
+            auto name = expr->getFunctionName();
+            VAST_CHECK(name, "clang::PredefinedExpr without name has missing support.");
+
+            auto name_as_op = this->VisitStringLiteral(name)->getResult(0);
+            auto kind = hl::ident_kind( expr );
+
+            return make< hl::PredefinedExpr >(meta_location(expr),
+                                              name_as_op.getType(), name_as_op, kind);
         }
 
         //

--- a/lib/vast/Conversion/Common/Common.hpp
+++ b/lib/vast/Conversion/Common/Common.hpp
@@ -10,15 +10,6 @@
 
 namespace vast::conv::irstollvm
 {
-    // TODO(conv:irs-to-llvm): In non-debug mode return `mlir::failure()` and do not log
-    //                         anything.
-    // If this header is ever exported, probably remove this.
-    #define VAST_PATTERN_CHECK(cond, fmt, ...) \
-        VAST_CHECK(cond, fmt, __VA_ARGS__)
-
-    #define VAST_PATTERN_FAIL(...) \
-        VAST_UNREACHABLE(__VA_ARGS__)
-
     // I would consider to just use the entire namespace, everything
     // has (unfortunately) prefixed name with `LLVM` anyway.
     namespace LLVM = mlir::LLVM;

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -406,7 +406,35 @@ namespace vast::conv::irstollvm
             }
             return mlir::failure();
         }
+    };
 
+    struct cstyle_cast : base_pattern< hl::CStyleCastOp >
+    {
+        using op_t = hl::CStyleCastOp;
+        using base = base_pattern< op_t >;
+        using base::base;
+
+        logical_result matchAndRewrite(
+                    op_t op, typename op_t::Adaptor ops,
+                    conversion_rewriter &rewriter) const override
+        {
+            // TODO: According to what clang does, this will need more handling
+            //       based on different value categories. For now, just lower types.
+            auto to_void = [&]
+            {
+                rewriter.replaceOp(op, ops.getOperands());
+                return mlir::success();
+            };
+
+            switch (op.getKind())
+            {
+                case hl::CastKind::ToVoid:
+                    return to_void();
+                default:
+                    return mlir::failure();
+            }
+            return mlir::success();
+        }
     };
 
 
@@ -675,6 +703,7 @@ namespace vast::conv::irstollvm
         func_op< hl::FuncOp >,
         constant_int,
         implicit_cast,
+        cstyle_cast,
         call,
         cmp,
         deref,

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -27,6 +27,7 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Util/TypeConverter.hpp"
 #include "vast/Util/LLVMTypeConverter.hpp"
 #include "vast/Util/Symbols.hpp"
+#include "vast/Util/Terminator.hpp"
 #include "vast/Util/TypeList.hpp"
 
 #include "vast/Conversion/Common/Passes.hpp"
@@ -645,6 +646,30 @@ namespace vast::conv::irstollvm
         }
     };
 
+    template< typename op_t, typename yield_op_t >
+    struct propagate_yield : base_pattern< op_t >
+    {
+        using base = base_pattern< op_t >;
+        using base::base;
+
+        mlir::LogicalResult matchAndRewrite(
+                    op_t op, typename op_t::Adaptor ops,
+                    mlir::ConversionPatternRewriter &rewriter) const override
+        {
+            auto body = op.getBody();
+            if (!body)
+                return mlir::success();
+
+            auto yield = terminator_t< yield_op_t >::get(*body);
+            VAST_PATTERN_CHECK(yield, "Expected yield in: {0}", op);
+
+            rewriter.mergeBlockBefore(body, op);
+            rewriter.replaceOp(op, yield.op().getResult());
+            rewriter.eraseOp(yield.op());
+            return mlir::success();
+        }
+    };
+
     using base_op_conversions = util::type_list<
         func_op< mlir::func::FuncOp >,
         func_op< hl::FuncOp >,
@@ -652,7 +677,8 @@ namespace vast::conv::irstollvm
         implicit_cast,
         call,
         cmp,
-        deref
+        deref,
+        propagate_yield< hl::ExprOp, hl::ValueYieldOp >
     >;
 
     // Drop types of operations that will be processed by pass for core(lazy) operations.

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -241,7 +241,7 @@ namespace vast::conv::irstollvm
                 return mlir::failure();
 
             if (fn.empty())
-                return mlir::failure();
+                return mlir::success();
 
             auto &block = fn.front();
             if (!block.isEntryBlock())

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -80,12 +80,16 @@ namespace vast::conv::irstollvm::ll_cf
             auto &last = block.back();
             std::vector< mlir::Value > no_vals;
 
-            if (mlir::isa< ll::ScopeRet >(last)) {
+            if (auto ret = mlir::dyn_cast< ll::ScopeRet >(last)) {
                 make_after_op< LLVM::BrOp >(rewriter, &last, last.getLoc(), no_vals, &end);
-            } else if (mlir::isa< ll::ScopeRecurse >(last)) {
-                make_after_op< LLVM::BrOp >(rewriter, &last, last.getLoc(), no_vals, &start);
-            } else if (mlir::isa< ll::CondScopeRet >(last)) {
-                make_after_op< LLVM::BrOp >(rewriter, &last, last.getLoc(), no_vals, &start);
+            } else if (auto ret = mlir::isa< ll::ScopeRecurse >(last)) {
+                make_after_op< LLVM::BrOp >(rewriter, &last, last.getLoc(),
+                                            no_vals, &start);
+            } else if (auto ret = mlir::dyn_cast< ll::CondScopeRet >(last)) {
+                make_after_op< LLVM::CondBrOp >(rewriter, &last, last.getLoc(),
+                                                ret.cond(),
+                                                ret.dest(), ret.operands(),
+                                                &end, no_vals);
             } else {
                 // Nothing to do (do not erase, since it is a standard branching).
                 return mlir::success();

--- a/lib/vast/Dialect/Core/CMakeLists.txt
+++ b/lib/vast/Dialect/Core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_dialect_library(MLIRCore
     CoreDialect.cpp
     CoreOps.cpp
     CoreTypes.cpp
+    CoreTraits.cpp
     CoreAttributes.cpp
 
     ADDITIONAL_HEADER_DIRS

--- a/lib/vast/Dialect/Core/CoreTraits.cpp
+++ b/lib/vast/Dialect/Core/CoreTraits.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#include "vast/Dialect/Core/CoreTraits.hpp"
+
+namespace vast::core {
+
+} // namespace vast::core
+
+//#define  GET_TYPEDEF_CLASSES
+//#include "vast/Dialect/Core/CoreTraits.cpp.inc"

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -297,6 +297,12 @@ namespace vast::hl
     bool CondOp::typesMatch(mlir::Type lhs, mlir::Type rhs)
     {
         namespace tt = mlir::TypeTrait;
+
+        if (!lhs)
+            return !rhs || rhs.isa< hl::VoidType, mlir::NoneType >();
+        if (!rhs)
+            return !lhs || lhs.isa< hl::VoidType, mlir::NoneType >();
+
         return lhs == rhs
             || all_with_trait< tt::IntegralTypeTrait >(lhs, rhs)
             || any_with_trait< tt::TypedefTrait >(lhs, rhs)
@@ -307,10 +313,6 @@ namespace vast::hl
     {
         auto then_type = get_maybe_yielded_type(getThenRegion());
         auto else_type = get_maybe_yielded_type(getElseRegion());
-        if ( !then_type )
-            return mlir::success(!else_type || else_type.isa< hl::VoidType >());
-        if ( !else_type )
-            return mlir::success(!then_type || then_type.isa< hl::VoidType >());
 
         bool compatible = typesMatch(then_type, else_type);
         if (!compatible)

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -305,8 +305,13 @@ namespace vast::hl
 
     logical_result CondOp::verifyRegions()
     {
-        auto then_type = get_yielded_type(getThenRegion());
-        auto else_type = get_yielded_type(getElseRegion());
+        auto then_type = get_maybe_yielded_type(getThenRegion());
+        auto else_type = get_maybe_yielded_type(getElseRegion());
+        if ( !then_type )
+            return mlir::success(!else_type || else_type.isa< hl::VoidType >());
+        if ( !else_type )
+            return mlir::success(!then_type || then_type.isa< hl::VoidType >());
+
         bool compatible = typesMatch(then_type, else_type);
         if (!compatible)
         {

--- a/lib/vast/Dialect/HighLevel/Transforms/HLEmitLazyRegions.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/HLEmitLazyRegions.cpp
@@ -24,6 +24,7 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Util/TypeList.hpp"
 #include "vast/Util/DialectConversion.hpp"
 #include "vast/Util/Terminator.hpp"
+#include "vast/Util/Region.hpp"
 
 namespace vast::hl
 {
@@ -31,11 +32,6 @@ namespace vast::hl
 
     struct lazy_utils
     {
-        static auto region_value_yield_type(Region &region)
-        {
-            return region.back().back().getOperand(0).getType();
-        }
-
         static auto lazy_side(auto &&rewriter, mlir::Location loc, mlir::Region &side)
         {
             // Passed by val, we are expecting only mlir lightweight objects.
@@ -50,7 +46,7 @@ namespace vast::hl
                 {
                     return mk_lazy_op(mlir::NoneType::get(rewriter.getContext()));
                 }
-                return mk_lazy_op(region_value_yield_type(side));
+                return mk_lazy_op(get_yielded_type(side));
             }();
 
             auto &lazy_region = lazy_op.getLazy();

--- a/lib/vast/Dialect/HighLevel/Transforms/HLEmitLazyRegions.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/HLEmitLazyRegions.cpp
@@ -11,6 +11,7 @@ VAST_RELAX_WARNINGS
 VAST_UNRELAX_WARNINGS
 
 #include "PassesDetails.hpp"
+#include "vast/Conversion/Common/Block.hpp"
 #include "vast/Conversion/Common/Passes.hpp"
 #include "vast/Conversion/Common/Patterns.hpp"
 
@@ -22,50 +23,112 @@ VAST_UNRELAX_WARNINGS
 
 #include "vast/Util/TypeList.hpp"
 #include "vast/Util/DialectConversion.hpp"
+#include "vast/Util/Terminator.hpp"
 
 namespace vast::hl
 {
     using conversion_rewriter = mlir::ConversionPatternRewriter;
 
+    struct lazy_utils
+    {
+        static auto region_value_yield_type(Region &region)
+        {
+            return region.back().back().getOperand(0).getType();
+        }
+
+        static auto lazy_side(auto &&rewriter, mlir::Location loc, mlir::Region &side)
+        {
+            // Passed by val, we are expecting only mlir lightweight objects.
+            auto mk_lazy_op = [&](auto ... args)
+            {
+                return rewriter.template create< core::LazyOp >( loc, args ... );
+            };
+
+            auto lazy_op = [&]
+            {
+                if (!terminator_t< hl::ValueYieldOp >::get(side.front()))
+                {
+                    return mk_lazy_op(mlir::NoneType::get(rewriter.getContext()));
+                }
+                return mk_lazy_op(region_value_yield_type(side));
+            }();
+
+            auto &lazy_region = lazy_op.getLazy();
+            rewriter.inlineRegionBefore(side, lazy_region, lazy_region.end());
+            return lazy_op;
+        }
+    };
+
     template< typename source, typename LOp >
-    struct bin_lop_pattern : operation_conversion_pattern< source > {
+    struct bin_lop_pattern : operation_conversion_pattern< source >,
+                             lazy_utils
+    {
         using base = operation_conversion_pattern< source >;
         using base::base;
         using adaptor_t = typename source::Adaptor;
 
-        auto region_value_yield_type(Region &region) const {
-            return region.back().back().getOperand(0).getType();
-        }
-
         logical_result matchAndRewrite(
             source op, adaptor_t adaptor, conversion_rewriter &rewriter) const override
         {
-            auto lazy_side = [&] (Region &side) {
-                auto lazy_op = rewriter.create< core::LazyOp >(
-                    op.getLoc(), region_value_yield_type(side)
-                );
-                auto &lazy_region = lazy_op.getLazy();
-                rewriter.inlineRegionBefore(side, lazy_region, lazy_region.end());
-                return lazy_op;
-            };
+            auto lhs_lazy = lazy_side(rewriter, op.getLoc(), op.getLhs());
+            auto rhs_lazy = lazy_side(rewriter, op.getLoc(), op.getRhs());
 
-            auto lhs_lazy = lazy_side(op.getLhs());
-            auto rhs_lazy = lazy_side(op.getRhs());
-
-            auto logical = rewriter.create< LOp >(op.getLoc(), op.getType(), lhs_lazy, rhs_lazy);
+            auto logical = rewriter.create< LOp >(op.getLoc(), op.getType(),
+                                                  lhs_lazy, rhs_lazy);
             rewriter.replaceOp(op, { logical });
             return logical_result::success();
         }
 
         static void legalize(conversion_target &target) {
-            target.addLegalOp< core::BinLAndOp, core::BinLOrOp >();
-            target.addIllegalOp< hl::BinLAndOp, hl::BinLOrOp >();
+            target.addLegalOp< LOp >();
+            target.addIllegalOp< source >();
+        }
+    };
+
+    struct cond_op : operation_conversion_pattern< hl::CondOp >,
+                     lazy_utils
+    {
+        using source = hl::CondOp;
+        using base = operation_conversion_pattern< source >;
+        using base::base;
+        using adaptor_t = typename source::Adaptor;
+
+        logical_result matchAndRewrite(source op, adaptor_t adaptor,
+                                       conversion_rewriter &rewriter) const override
+        {
+            auto &cond_block = op.getCondRegion().front();
+            VAST_PATTERN_CHECK(conv::size(op.getCondRegion()) == 1,
+                               "Unsupported shape of cond region of hl::CondOp");
+
+            auto yield = terminator_t< hl::CondYieldOp >::get(cond_block);
+            VAST_PATTERN_CHECK(yield, "Was not able to retrieve cond yield, {0}.", op);
+
+            rewriter.mergeBlockBefore(&cond_block, op, llvm::None);
+
+            auto then_region = lazy_side(rewriter, op.getLoc(), op.getThenRegion());
+            auto else_region = lazy_side(rewriter, op.getLoc(), op.getElseRegion());
+
+            auto yielded_val = yield.op().getResult();
+            auto select = rewriter.create< core::SelectOp >(
+                    op.getLoc(),
+                    yielded_val.getType(), yielded_val,
+                    then_region, else_region);
+
+            rewriter.eraseOp(yield.op());
+            rewriter.replaceOp(op, select.getResults());
+            return mlir::success();
+        }
+
+        static void legalize(conversion_target &target) {
+            target.addLegalOp< core::SelectOp >();
+            target.addIllegalOp< hl::CondOp >();
         }
     };
 
     using bin_lop_conversions = util::type_list<
         bin_lop_pattern< hl::BinLAndOp, core::BinLAndOp >,
-        bin_lop_pattern< hl::BinLOrOp,  core::BinLOrOp >
+        bin_lop_pattern< hl::BinLOrOp,  core::BinLOrOp >,
+        cond_op
     >;
 
     struct HLEmitLazyRegionsPass

--- a/lib/vast/Dialect/HighLevel/Transforms/HLEmitLazyRegions.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/HLEmitLazyRegions.cpp
@@ -94,7 +94,7 @@ namespace vast::hl
         {
             auto &cond_block = op.getCondRegion().front();
             VAST_PATTERN_CHECK(conv::size(op.getCondRegion()) == 1,
-                               "Unsupported shape of cond region of hl::CondOp");
+                               "Unsupported shape of cond region of hl::CondOp:\n{0}", op);
 
             auto yield = terminator_t< hl::CondYieldOp >::get(cond_block);
             VAST_PATTERN_CHECK(yield, "Was not able to retrieve cond yield, {0}.", op);

--- a/lib/vast/Frontend/CMakeLists.txt
+++ b/lib/vast/Frontend/CMakeLists.txt
@@ -5,9 +5,12 @@ add_library(vast_frontend
     Options.cpp
 )
 
+mk_clang_libs(frontend_clang_libs clangCodeGen)
 target_link_libraries(vast_frontend
     PUBLIC
         vast::target_llvmir
+
+        ${frontend_clang_libs}
     PRIVATE
         vast::settings)
 

--- a/lib/vast/Frontend/CMakeLists.txt
+++ b/lib/vast/Frontend/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(vast_frontend
     Options.cpp
 )
 
-target_link_libraries(vast_frontend PRIVATE vast::settings)
+target_link_libraries(vast_frontend
+    PUBLIC
+        vast::target_llvmir
+    PRIVATE
+        vast::settings)
 
 add_library(vast::frontend ALIAS vast_frontend)

--- a/lib/vast/Frontend/GenAction.cpp
+++ b/lib/vast/Frontend/GenAction.cpp
@@ -34,6 +34,10 @@ namespace vast::cc {
             return false;
         }
 
+        bool emit_only_llvm(const vast_args &vargs) {
+            return vargs.has_option(emit_llvm);
+        }
+
     } // namespace opt
 
     using output_stream_ptr = std::unique_ptr< llvm::raw_pwrite_stream >;

--- a/lib/vast/Target/LLVMIR/CMakeLists.txt
+++ b/lib/vast/Target/LLVMIR/CMakeLists.txt
@@ -8,3 +8,5 @@ target_link_libraries( vast_target_llvmir
 
         vast_settings
 )
+
+add_library( vast::target_llvmir ALIAS vast_target_llvmir )

--- a/lib/vast/Target/LLVMIR/Convert.cpp
+++ b/lib/vast/Target/LLVMIR/Convert.cpp
@@ -76,7 +76,7 @@ namespace vast::target::llvmir
         return lmodule;
     }
 
-    void prepare_module(mlir::Operation *op)
+    void prepare_hl_module(mlir::Operation *op)
     {
         auto mctx = op->getContext();
         mlir::PassManager pm(mctx);

--- a/lib/vast/Target/LLVMIR/Convert.cpp
+++ b/lib/vast/Target/LLVMIR/Convert.cpp
@@ -9,6 +9,7 @@ VAST_RELAX_WARNINGS
 
 #include <mlir/ExecutionEngine/ExecutionEngine.h>
 #include <mlir/Target/LLVMIR/Export.h>
+#include <mlir/Target/LLVMIR/Dialect/All.h>
 #include <mlir/Target/LLVMIR/LLVMTranslationInterface.h>
 #include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
 
@@ -92,6 +93,19 @@ namespace vast::target::llvmir
         auto run_result = pm.run(op);
 
         VAST_CHECK(mlir::succeeded(run_result), "Some pass in prepare_module() failed");
+    }
+
+    void register_vast_to_llvm_ir(mlir::DialectRegistry &registry)
+    {
+        registry.insert< hl::HighLevelDialect >();
+        mlir::registerAllToLLVMIRTranslations(registry);
+    }
+
+    void register_vast_to_llvm_ir(mcontext_t &mctx)
+    {
+        mlir::DialectRegistry registry;
+        register_vast_to_llvm_ir(registry);
+        mctx.appendDialectRegistry(registry);
     }
 
 } // namespace vast::target::llvmir

--- a/lib/vast/Translation/CodeGenStmtVisitor.cpp
+++ b/lib/vast/Translation/CodeGenStmtVisitor.cpp
@@ -89,4 +89,21 @@ namespace vast::hl
         VAST_UNREACHABLE( "unsupported cast kind" );
     }
 
+    IdentKind ident_kind(const clang::PredefinedExpr *expr)
+    {
+        switch(expr->getIdentKind())
+        {
+            case clang::PredefinedExpr::IdentKind::Func : return IdentKind::Func;
+            case clang::PredefinedExpr::IdentKind::Function : return IdentKind::Function;
+            case clang::PredefinedExpr::IdentKind::LFunction : return IdentKind::LFunction;
+            case clang::PredefinedExpr::IdentKind::FuncDName : return IdentKind::FuncDName;
+            case clang::PredefinedExpr::IdentKind::FuncSig : return IdentKind::FuncSig;
+            case clang::PredefinedExpr::IdentKind::LFuncSig : return IdentKind::LFuncSig;
+            case clang::PredefinedExpr::IdentKind::PrettyFunction :
+                return IdentKind::PrettyFunction;
+            case clang::PredefinedExpr::IdentKind::PrettyFunctionNoVirtual :
+                return IdentKind::PrettyFunctionNoVirtual;
+        }
+    }
+
 } // namespace vast::hl

--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -9,17 +9,16 @@ add_library(vast_frontend_tool
   compiler_invocation.cpp
 )
 
+
+mk_clang_libs(frontend_tool_clang_libs clangBasic clangDriver clangFrontend)
 target_link_libraries(vast_frontend_tool
   PUBLIC
-    clangBasic
-    clangDriver
-    clangFrontend
+    ${frontend_tool_clang_libs}
 
     ${LLVM_LIBS}
 
     vast::codegen
     vast::frontend
-    vast::target_llvmir
   PRIVATE
     vast::settings
 )
@@ -31,6 +30,7 @@ add_executable(vast-front
   cc1.cpp
 )
 
+mk_clang_libs(front_clang_libs clangAST clangFrontend clangSerialization clangTooling)
 target_link_libraries(vast-front
   PRIVATE
     ${DIALECT_LIBS}
@@ -46,13 +46,8 @@ target_link_libraries(vast-front
 
     FromSourceParser
 
-    clangAST
-    clangCodeGen
-    clangFrontend
-    clangSerialization
-    clangTooling
+    ${front_clang_libs}
 
     vast::frontend_tool
-    vast::target_llvmir
     vast::settings
 )

--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -53,5 +53,6 @@ target_link_libraries(vast-front
     clangTooling
 
     vast::frontend_tool
+    vast::target_llvmir
     vast::settings
 )

--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(vast_frontend_tool
 
     vast::codegen
     vast::frontend
+    vast::target_llvmir
   PRIVATE
     vast::settings
 )

--- a/tools/vast-front/cc1.cpp
+++ b/tools/vast-front/cc1.cpp
@@ -112,9 +112,16 @@ namespace vast::cc {
         }
 
         // Execute the frontend actions.
-        {
+        try {
             llvm::TimeTraceScope TimeScope("ExecuteCompiler");
             success = execute_compiler_invocation(comp.get(), vargs);
+        } catch ( ... ) {
+            // TODO( vast-front ): This is required as `~clang::CompilerInstance` would
+            //                     fire an assert as stack unwinds.
+            comp->setSema(nullptr);
+            comp->setASTConsumer(nullptr);
+            comp->clearOutputFiles(true);
+            throw;
         }
 
         // If any timers were active but haven't been destroyed yet, print their

--- a/tools/vast-front/compiler_invocation.cpp
+++ b/tools/vast-front/compiler_invocation.cpp
@@ -33,6 +33,10 @@ namespace vast::cc
             return std::make_unique< vast::cc::emit_cir_action >(vargs);
         }
 
+        if (vargs.has_option(opt::emit_mlir)) {
+            return std::make_unique< vast::cc::emit_mlir_action >(vargs);
+        }
+
         switch (act) {
             case ASTDump:  return std::make_unique< clang::ASTDumpAction >();
             case EmitAssembly: return std::make_unique< vast::cc::emit_assembly_action >(vargs);


### PR DESCRIPTION
Add support to `vast-front` to emit llvm IR (`-vast-emit-llvm`) or some selected mlir dialects (`-vast-emit-mlir=[hl,llvm]`).

Fixes
 * Bug in control flow lowering that improperly routed `hl.continue` to `init` instead of `incr`.
 * Ternary operator in case its operands are `void`.