### PR TITLE
Fix lua lexer example bugs (BinComma bug)

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -741,11 +741,20 @@ def BinLAndOp : LogicBinOp< "bin.land", [] >;
 def BinLOrOp  : LogicBinOp<  "bin.lor", [] >;
 
 def BinComma
-  : HighLevel_Op< "bin.comma", [NoSideEffect] >
-  , Arguments< (ins AnyType:$lhs, AnyType:$rhs) >
+  : HighLevel_Op< "bin.comma", [NoSideEffect, SameVariadicOperandSize] >
+  , Arguments< (ins Optional<AnyType>:$lhs, Optional<AnyType>:$rhs) >
   , Results< (outs AnyType:$result) >
 {
     let summary = "VAST binary operation";
+
+    let skipDefaultBuilders = 1;
+    let builders = [
+        OpBuilder<(ins
+            "Type":$type,
+            "Operation *":$lhsop,
+            "Operation *":$rhsop
+        )>
+    ];
 
     let assemblyFormat = [{ $lhs `,` $rhs attr-dict `:` functional-type(operands, results) }];
 }

--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -291,10 +291,10 @@ namespace vast::cg {
         }
 
         Operation* VisitBinComma(const clang::BinaryOperator *op) {
-            auto lhs = visit(op->getLHS())->getResult(0);
-            auto rhs = visit(op->getRHS())->getResult(0);
+            auto lhs_op = visit(op->getLHS());
+            auto rhs_op = visit(op->getRHS());
             auto ty  = visit(op->getType());
-            return make< hl::BinComma >(meta_location(op), ty, lhs, rhs);
+            return make< hl::BinComma >(meta_location(op), ty, lhs_op, rhs_op);
         }
 
         //

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -44,7 +44,9 @@ namespace vast::hl
                 << "' linkage";
         }
 
-        if (isExternal()) {
+        // isExternal(FunctionOpInterface) only checks for empty bodyonly checks for empty body...
+        // We need to be able to handle functions with internal linkage without body.
+        if (linkage != GlobalLinkageKind::InternalLinkage && isExternal()) {
             constexpr auto external = GlobalLinkageKind::ExternalLinkage;
             constexpr auto weak_external = GlobalLinkageKind::ExternalWeakLinkage;
             if (linkage != external && linkage != weak_external) {

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -270,6 +270,15 @@ namespace vast::hl
         build_logic_op(bld, st, type, lhs, rhs);
     }
 
+    void BinComma::build(Builder &bld, State &st, Type type, Operation *lhsop, Operation *rhsop)
+    {
+        if (lhsop->getNumResults() > 0)
+            st.addOperands(lhsop->getResult(0));
+        if (rhsop->getNumResults() > 0)
+            st.addOperands(rhsop->getResult(0));
+        st.addTypes(type);
+    }
+
     void IfOp::build(Builder &bld, State &st, BuilderCallback condBuilder, BuilderCallback thenBuilder, BuilderCallback elseBuilder)
     {
         VAST_ASSERT(condBuilder && "the builder callback for 'condition' region must be present");


### PR DESCRIPTION
Fix #277 
- Fixes linkage for static functions without body
- Fixes BinComma bug
    -  Might consider different solutions
- Requires tests for `hl.bin.comma`
