### PR TITLE
Extract type from `lvalue` when verifying `CondOp` types

### DIFF
--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -315,10 +315,19 @@ namespace vast::hl
     bool CondOp::typesMatch(mlir::Type lhs, mlir::Type rhs)
     {
         namespace tt = mlir::TypeTrait;
-        return lhs == rhs
-            || all_with_trait< tt::IntegralTypeTrait >(lhs, rhs)
-            || any_with_trait< tt::TypedefTrait >(lhs, rhs)
-            || all_with_trait< tt::PointerTypeTrait >(lhs, rhs);
+        auto normalize = [](mlir::Type type) {
+            auto type_casted = type.dyn_cast< hl::LValueType >();
+            if (type_casted)
+                return type_casted.getElementType();
+            return type;
+        };
+        auto lhs_norm = normalize(lhs);
+        auto rhs_norm = normalize(rhs);
+
+        return lhs_norm == rhs_norm
+            || all_with_trait< tt::IntegralTypeTrait >(lhs_norm, rhs_norm)
+            || any_with_trait< tt::TypedefTrait >(lhs_norm, rhs_norm)
+            || all_with_trait< tt::PointerTypeTrait >(lhs_norm, rhs_norm);
     }
 
     logical_result CondOp::verifyRegions()

--- a/test/vast/Dialect/HighLevel/ternary-b.c
+++ b/test/vast/Dialect/HighLevel/ternary-b.c
@@ -1,0 +1,15 @@
+// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+typedef struct TValue { struct TString *value_ ; unsigned char tt_ ; } TValue ;
+
+typedef struct TString { char contents [ 1 ] ; } TString ;
+
+static void kname ( const TValue * p , const char * * name ) {
+    // CHECK: hl.cond {
+    // CHECK: } ? {
+    // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.lvalue<!hl.ptr<!hl.char>>
+    // CHECK: } : {
+    // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.ptr<!hl.char>
+    // CHECK: } : !hl.ptr<!hl.char>
+    * name = ( ( p -> tt_ ) & 0x0F ) == 4 ? ( p -> value_ ) -> contents : "?" ;
+}


### PR DESCRIPTION
We now have a test case which I believe requires the type extraction. 
Fix #288 