### PR TITLE
Fix path where `vast-front` looks for includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,7 @@ configure_file(
 #
 find_package(Clang REQUIRED CONFIG)
 
-set(CLANG_RESOURCE_DIR  ${CLANG_CMAKE_DIR}/../../clang/${LLVM_VERSION})
-message(${CLANG_RESOURCE_DIR})
+set(CLANG_RESOURCE_DIR  ${LLVM_LIBRARY_DIR}/clang/${LLVM_VERSION_MAJOR})
 
 configure_file(
   ${VAST_SOURCE_DIR}/include/vast/Config/config.h.cmake
@@ -96,7 +95,6 @@ FindAndSelectClangCompiler()
 find_package(LLVM 16 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
 #
 # MLIR
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,16 @@ configure_file(
 )
 
 # Configure Vast version info header file.
+
+
+#
+# Clang
+#
+find_package(Clang REQUIRED CONFIG)
+
+set(CLANG_RESOURCE_DIR  ${CLANG_CMAKE_DIR}/../../clang/${LLVM_VERSION})
+message(${CLANG_RESOURCE_DIR})
+
 configure_file(
   ${VAST_SOURCE_DIR}/include/vast/Config/config.h.cmake
   ${VAST_BINARY_DIR}/include/vast/Config/config.h
@@ -92,11 +102,6 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 #
 find_package(MLIR REQUIRED CONFIG)
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-
-#
-# Clang
-#
-find_package(Clang REQUIRED CONFIG)
 
 #
 # LLVM Libraries

--- a/include/vast/Config/config.h.cmake
+++ b/include/vast/Config/config.h.cmake
@@ -15,6 +15,8 @@
 #else
 #define VAST_CONFIG_H
 
+#define CLANG_RESOURCE_DIR "${CLANG_RESOURCE_DIR}"
+
 namespace vast {
 
     constexpr std::string_view version = "${VAST_VERSION}";

--- a/include/vast/Frontend/Driver.hpp
+++ b/include/vast/Frontend/Driver.hpp
@@ -23,6 +23,8 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Frontend/Diagnostics.hpp"
 #include "vast/Frontend/GenAction.hpp"
 
+#include "vast/Config/config.h"
+
 namespace vast::cc {
 
     //
@@ -101,6 +103,8 @@ namespace vast::cc {
             : cc1_entry_point(cc1), cmd_args(cmd_args), diag(cmd_args, path)
             , drv(path, llvm::sys::getDefaultTargetTriple(), diag.engine, "vast compiler")
         {
+            drv.ResourceDir = CLANG_RESOURCE_DIR;
+
             set_install_dir(cmd_args, canonical_prefixes);
 
             auto target_and_mode = toolchain::getTargetAndModeFromProgramName(cmd_args[0]);

--- a/test/vast/Dialect/HighLevel/hello-world.c
+++ b/test/vast/Dialect/HighLevel/hello-world.c
@@ -1,5 +1,4 @@
 // RUN: vast-front %s -vast-emit-high-level -o - | FileCheck %s
-// REQUIRES: vast-front-includes
 
 // CHECK: hl.func external @printf
 #include <stdio.h>

--- a/tools/vast-front/driver.cpp
+++ b/tools/vast-front/driver.cpp
@@ -19,8 +19,6 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Frontend/Driver.hpp"
 #include "vast/Frontend/Options.hpp"
 
-#include "vast/Config/config.h"
-
 // main frontend method. Lives inside cc1_main.cpp
 namespace vast::cc {
     extern int cc1(const vast_args & vargs, argv_t argv, arg_t tool, void *main_addr);


### PR DESCRIPTION
@lkorenc could you please test if this works on Mac? Building and running `vast-front -vast-emit-high-level test/vast/Dialect/HighLevel/hello-world.c -o -` should be enough.