### PR TITLE
Add `hl::FuncOp hl::getCallee(hl::CallOp)` utility function

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelOps.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.hpp
@@ -82,3 +82,8 @@ namespace vast::hl
 
 #define GET_OP_CLASSES
 #include "vast/Dialect/HighLevel/HighLevel.h.inc"
+
+namespace vast::hl
+{
+    FuncOp getCallee(CallOp call);
+}

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2021-present, Trail of Bits, Inc.
 
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
 #include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
@@ -399,7 +400,11 @@ namespace vast::hl
         st.addTypes(rty);
     }
 
-
+    FuncOp getCallee(CallOp call)
+    {
+        auto coi = mlir::cast<mlir::CallOpInterface>(call.getOperation());
+        return mlir::dyn_cast_or_null<FuncOp>(coi.resolveCallable());
+    }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
As the name suggests, this PR adds a small utility function that gets the callee of a hl::CallOp.