### PR TITLE
Improvements to lower dialects

### DIFF
--- a/include/vast/Dialect/Core/Core.td
+++ b/include/vast/Dialect/Core/Core.td
@@ -23,6 +23,8 @@ def Core_Dialect : Dialect {
     let extraClassDeclaration = [{
         void registerTypes();
         void registerAttributes();
+
+        static std::string getTargetTripleAttrName() { return "vast.core.target_triple"; }
     }];
 
     let hasConstantMaterializer = 1;

--- a/include/vast/Dialect/LowLevel/LowLevelOps.td
+++ b/include/vast/Dialect/LowLevel/LowLevelOps.td
@@ -27,6 +27,10 @@ def UninitializedVar
     let description = [{ Declaration of variable that have not been initialized yet. }];
 
     let results = (outs AnyType:$result);
+
+    let assemblyFormat = [{
+        attr-dict `:` type($result)
+    }];
 }
 
 def InitializeVar
@@ -39,6 +43,10 @@ def InitializeVar
         Initialize a variable - for now this operation is a direct lowering from hl.var
         initialization section. Later there will be need to discover how this ties
         to constructors.
+    }];
+
+    let assemblyFormat = [{
+        operands attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -102,6 +110,13 @@ def CondBr
                   trueDest, falseDest);
         }] >
     ];
+
+    let assemblyFormat = [{
+        $cond `:` type($cond) `,`
+        $trueDest (`(` $trueOperands^ `:` type($trueOperands) `)`)? `,`
+        $falseDest (`(` $falseOperands^ `:` type($falseOperands) `)`)?
+        attr-dict
+    }];
 }
 
 def ScopeRet
@@ -109,6 +124,8 @@ def ScopeRet
 {
     let summary = "Terminator of scope.";
     let description = [{ Terminator of scopes (for example during lowering of loops). }];
+
+    let assemblyFormat = [{attr-dict}];
 }
 
 def ScopeRecurse
@@ -116,6 +133,8 @@ def ScopeRecurse
 {
     let summary = "Jump to first block of scope.";
     let description = [{ Modelling continue. }];
+
+    let assemblyFormat = [{attr-dict}];
 }
 
 def CondScopeRet
@@ -125,7 +144,7 @@ def CondScopeRet
     let description = [{ Terminate or branch. }];
 
     let successors = (successor AnySuccessor:$dest);
-    let arguments = (ins AnyType:$cond, Variadic<AnyType>:$cond_operands);
+    let arguments = (ins AnyType:$cond, Variadic<AnyType>:$dest_operands);
 
     let builders = [
 
@@ -134,18 +153,22 @@ def CondScopeRet
             build($_builder, $_state, cond, mlir::ValueRange(), dest);
         }] >
     ];
-}
+
+    let assemblyFormat = [{
+        $cond `:` type($cond) `,`
+        $dest (`(` $dest_operands^ `:` type($dest_operands) `)`)? attr-dict
+    }];}
 
 def ReturnOp
     : LowLevel_Op< "return", [Terminator] >
     , Arguments<(ins Variadic<AnyType>:$result)>
 {
-    let assemblyFormat = "($result^ `:` type($result))? attr-dict";
-
     // Allow building a ReturnOp with no return operand.
     let builders = [
         OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
     ];
+
+    let assemblyFormat = "($result^ `:` type($result))? attr-dict";
 }
 
 def Scope
@@ -165,6 +188,10 @@ def Scope
                 return nullptr;
             return &*std::next(getBody().begin());
         }
+    }];
+
+    let assemblyFormat = [{
+        $body attr-dict
     }];
 }
 

--- a/include/vast/Dialect/LowLevel/LowLevelOps.td
+++ b/include/vast/Dialect/LowLevel/LowLevelOps.td
@@ -20,7 +20,7 @@ def LowLevel_StructGEPOp
 }
 
 def UninitializedVar
-    : LowLevel_Op< "unintialized_var", [VastSymbol] >
+    : LowLevel_Op< "uninitialized_var", [VastSymbol] >
     , Results<(outs AnyType:$result)>
 {
     let summary = "Declaration of variable that have not been initialized yet.";

--- a/include/vast/Translation/CodeGen.hpp
+++ b/include/vast/Translation/CodeGen.hpp
@@ -17,6 +17,7 @@ VAST_RELAX_WARNINGS
 VAST_UNRELAX_WARNINGS
 
 #include "vast/Util/Common.hpp"
+#include "vast/Util/Triple.hpp"
 
 #include "vast/Translation/CodeGenVisitor.hpp"
 #include "vast/Translation/CodeGenFallBackVisitor.hpp"
@@ -602,6 +603,9 @@ namespace vast::cg
 
             // TODO(Heno): fix module location
             _module = { vast_module::create(mlir::UnknownLoc::get(_mctx)) };
+            // TODO(cg): For now we do not have our own operation, so we cannot
+            //           introduce new ctor.
+            set_triple(*_module, actx.getTargetInfo().getTriple().str());
 
             _cgctx = std::make_unique< CodeGenContext >(*_mctx, actx, _module);
 

--- a/include/vast/Util/Triple.hpp
+++ b/include/vast/Util/Triple.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Trail of Bits, Inc.
+ */
+
+#pragma once
+
+#include "vast/Util/Warnings.hpp"
+
+VAST_RELAX_WARNINGS
+#include <llvm/Support/FormatVariadic.h>
+#include <llvm/Support/Debug.h>
+
+#include <mlir/IR/Builders.h>
+VAST_UNRELAX_WARNINGS
+
+#include "vast/Dialect/Core/CoreDialect.hpp"
+
+#include <string>
+
+namespace vast
+{
+    void set_triple(auto op, std::string triple)
+    {
+        mlir::OpBuilder bld(op);
+        auto attr = bld.getAttr< mlir::StringAttr >(triple);
+        op->setAttr(core::CoreDialect::getTargetTripleAttrName(), attr);
+    }
+} // namespace vast

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -89,7 +89,7 @@ namespace vast::conv::irstollvm::ll_cf
             } else if (auto ret = mlir::dyn_cast< ll::CondScopeRet >(last)) {
                 make_after_op< LLVM::CondBrOp >(rewriter, &last, last.getLoc(),
                                                 ret.getCond(),
-                                                ret.getDest(), ret.getOperands(),
+                                                ret.getDest(), ret.getDestOperands(),
                                                 &end, no_vals);
             } else {
                 // Nothing to do (do not erase, since it is a standard branching).

--- a/test/vast/Compile/SingleSource/fib-a.c
+++ b/test/vast/Compile/SingleSource/fib-a.c
@@ -1,0 +1,23 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 42)
+int fib( int x )
+{
+    if ( x == 0 )
+        return 0;
+    if ( x <= 2 )
+        return 1;
+
+    return fib( x - 1 ) + fib( x - 2 );
+}
+
+int main()
+{
+    if ( fib( 0 ) != 0 )
+        return 1;
+    if ( fib( 3 ) != 2 )
+        return 2;
+    if ( fib( 4 ) != 3 )
+        return 3;
+    if ( fib( 5 ) != 5 )
+        return 4;
+    return 42;
+}

--- a/test/vast/Conversion/FromHL/ToLLCF/for-a.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-a.c
@@ -2,16 +2,16 @@
 
 void fn()
 {
-    // CHECK: "ll.scope"() ({
+    // CHECK: ll.scope {
     // CHECK-NEXT: ll.br ^bb1
 
     // CHECK: ^bb1:  // pred: ^bb0
-    // CHECK: "ll.cond_scope_ret"(%5)[^bb2] : (i1) -> ()
+    // CHECK: ll.cond_scope_ret [[V1:%[0-9]+]] : i1, ^bb2
 
     // CHECK: ^bb2:  // pred: ^bb1
-    // CHECK: "ll.scope_ret"() : () -> ()
+    // CHECK: ll.scope_ret
 
-    // CHECK: }) : () -> ()
+    // CHECK: }
     for (int i = 0; i < 15; ++i)
     {
         ++i;

--- a/test/vast/Conversion/FromHL/ToLLCF/for-b.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-b.c
@@ -1,0 +1,26 @@
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+
+int fn()
+{
+    // CHECK: hl.scope {
+    // CHECK:   ll.scope {
+    // CHECK:     ll.br ^bb2
+    // CHECK:   ^bb1:  // pred: ^bb4
+    // CHECK:     ll.br ^bb2
+    // CHECK:   ^bb2:  // 2 preds: ^bb0, ^bb1
+    // CHECK:     ll.cond_scope_ret [[V8:%[0-9]+]] : i1, ^bb3
+    // CHECK:   ^bb3:  // pred: ^bb2
+    // CHECK:     ll.cond_br [[V13:%[0-9]+]] : i1, ^bb5, ^bb4
+    // CHECK:   ^bb4:  // pred: ^bb3
+    // CHECK:     ll.br ^bb1
+    // CHECK:   ^bb5:  // pred: ^bb3
+    // CHECK:     ll.scope_ret
+    for ( int i = 0; i < 5; ++i )
+        if ( i == 5 )
+            break;
+        else
+            continue;
+    // CHECK:   }
+    // CHECK: }
+    return 43;
+}

--- a/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
+++ b/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
@@ -1,0 +1,12 @@
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
+
+int main()
+{
+    // CHECK: [[V0:%[0-9]+]] = ll.uninitialized_var : !hl.lvalue<si32>
+    int a;
+
+    // CHECK: [[V1:%[0-9]+]] = ll.uninitialized_var : !hl.lvalue<si32>
+    // CHECK: [[V2:%[0-9]+]] = hl.const #hl.integer<1> : si32
+    // CHECK: [[V3:%[0-9]+]] = ll.initialize [[V1]], [[V2]] : (!hl.lvalue<si32>, si32) -> !hl.lvalue<si32>
+    int b = 1;
+}


### PR DESCRIPTION
A minor PR with smaller fixes
 * Adds `target_triple` attribute to top level `mlir::ModuleOp` VAST works with (and then lowers it to the `llvm::Module` if conversion happens)
 * Add `assemblyFormat` to various `ll` operations that did not have it
 * Update tests and attempt to introduce recompilation tests