### PR TITLE
Fix errors/bugs in `vast-front` function types

### DIFF
--- a/include/vast/Translation/CodeGen.hpp
+++ b/include/vast/Translation/CodeGen.hpp
@@ -171,6 +171,7 @@ namespace vast::cg
         }
 
         mlir_type convert(qual_type type) { return _visitor->Visit(type); }
+        mlir_type convert_to_lvalue(qual_type type) { return _visitor->VisitLValueType(type); }
 
         void update_completed_type(clang::TagDecl */* decl */) {
             VAST_UNIMPLEMENTED;
@@ -693,6 +694,7 @@ namespace vast::cg
         owning_module_ref freeze() { return codegen.freeze(); }
 
         mlir_type convert(qual_type type) { return codegen.convert(type); }
+        mlir_type convert_to_lvalue(qual_type type) { return codegen.convert_to_lvalue(type); }
 
         void update_completed_type(clang::TagDecl *decl) {
             codegen.update_completed_type(decl);

--- a/include/vast/Translation/CodeGenTypeDriver.hpp
+++ b/include/vast/Translation/CodeGenTypeDriver.hpp
@@ -26,6 +26,7 @@ namespace vast::cg
         mlir::FunctionType get_function_type(const function_info_t &info);
 
         // Convert type into a mlir_type.
+        template< bool lvalue = false >
         mlir_type convert_type(qual_type type);
 
         void update_completed_type(const clang::TagDecl *tag);

--- a/lib/vast/CodeGen/TypeInfo.cpp
+++ b/lib/vast/CodeGen/TypeInfo.cpp
@@ -44,6 +44,8 @@ namespace vast::cg
         }
 
         auto fty = fn->getType().getTypePtr();
+        if (auto parent_fty = llvm::dyn_cast< clang::ParenType >(fty))
+            fty = parent_fty->desugar().getTypePtr();
 
         VAST_ASSERT(llvm::isa< clang::FunctionType >(fty));
         // TODO: setCUDAKernelCallingConvention

--- a/test/vast/Dialect/HighLevel/fun-type-a.c
+++ b/test/vast/Dialect/HighLevel/fun-type-a.c
@@ -1,0 +1,5 @@
+// RUN: vast-front -x c -vast-emit-mlir=hl -o - %s | FileCheck %s
+
+// CHECK: hl.func external @fun (%arg0: !hl.lvalue<!hl.int>, %arg1: !hl.lvalue<!hl.int>) -> !hl.ptr<!hl.int> {
+int *(fun)(int a, int b){int c = a + b; return &c;}
+int main() {return 0;}


### PR DESCRIPTION
- Extract types from ParenType when needed
- Make argument types `lvalue`s