### PR TITLE
Additional lowering to LLVM

### DIFF
--- a/include/vast/Conversion/Common/Rewriter.hpp
+++ b/include/vast/Conversion/Common/Rewriter.hpp
@@ -64,6 +64,9 @@ namespace vast::conv
         }
     };
 
+    template< typename I >
+    rewriter_wrapper_t( I & ) -> rewriter_wrapper_t< I >;
+
     auto guarded( auto &bld, auto &&fn )
     {
         auto g = mlir::OpBuilder::InsertionGuard( bld );

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -9,7 +9,7 @@ include "vast/Dialect/Core/CoreTraits.td"
 
 class ControlFlowOp< string mnemonic, list< Trait > traits = [] >
     : HighLevel_Op< mnemonic, !listconcat(traits,
-        [SingleBlock, NoTerminator, NoRegionArguments]
+        [NoTerminator, NoRegionArguments]
       ) >
 {
     let summary = "VAST control flow operation";
@@ -348,7 +348,7 @@ def HighLevel_LabelStmt
   : ControlFlowOp< "label" >
   , Arguments<(ins LabelType:$label)>
 {
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region AnyRegion:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -348,7 +348,7 @@ def HighLevel_LabelStmt
   : ControlFlowOp< "label" >
   , Arguments<(ins LabelType:$label)>
 {
-  let regions = (region SizedRegion<1>:$substmt);
+  let regions = (region SizedRegion<1>:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -358,7 +358,7 @@ def HighLevel_LabelStmt
     )>
   ];
 
-  let assemblyFormat = [{ $label $substmt attr-dict }];
+  let assemblyFormat = [{ $label $body attr-dict }];
 }
 
 def HighLevel_GotoStmt

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.td
@@ -419,7 +419,9 @@ def ArrayType : CVRQualifiedType< "Array", "array",
   let assemblyFormat = "`<` $size `,` $elementType (`,` $quals^ )? `>`";
 }
 
-def DecayedType : HighLevelType< "Decayed", [MemRefElementTypeInterface] > {
+def DecayedType : HighLevelType< "Decayed",
+                                 [SubElementTypeInterface, MemRefElementTypeInterface] >
+{
   let mnemonic = "decayed";
   let parameters = (ins "Type":$elementType);
   let assemblyFormat = "`<` $elementType `>`";

--- a/include/vast/Util/LLVMTypeConverter.hpp
+++ b/include/vast/Util/LLVMTypeConverter.hpp
@@ -42,6 +42,7 @@ namespace vast::util::tc
         template< typename ... Args >
         LLVMTypeConverter(Args && ... args) : parent_t(std::forward< Args >(args) ... )
         {
+            addConversion([&](hl::LabelType t) { return t; });
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
             addConversion([&](hl::PointerType t) { return this->convert_pointer_type(t); });
             addConversion([&](mlir::MemRefType t) { return this->convert_memref_type(t); });

--- a/include/vast/Util/LLVMTypeConverter.hpp
+++ b/include/vast/Util/LLVMTypeConverter.hpp
@@ -43,6 +43,7 @@ namespace vast::util::tc
         LLVMTypeConverter(Args && ... args) : parent_t(std::forward< Args >(args) ... )
         {
             addConversion([&](hl::LabelType t) { return t; });
+            addConversion([&](hl::DecayedType t) { return this->convert_decayed(t); });
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
             addConversion([&](hl::PointerType t) { return this->convert_pointer_type(t); });
             addConversion([&](mlir::MemRefType t) { return this->convert_memref_type(t); });
@@ -84,6 +85,12 @@ namespace vast::util::tc
                 VAST_ASSERT(!t.template isa< mlir::NoneType >());
                 return mlir::LLVM::LLVMPointerType::get(t);
             };
+        }
+
+        maybe_type_t convert_decayed(hl::DecayedType t)
+        {
+            VAST_UNREACHABLE("We should encounter decayed this late in the pipeline, {0}", t);
+            return {};
         }
 
         maybe_type_t convert_lvalue_type(hl::LValueType t)

--- a/lib/vast/Conversion/Common/Common.hpp
+++ b/lib/vast/Conversion/Common/Common.hpp
@@ -42,6 +42,13 @@ namespace vast::conv::irstollvm
         // Some operations want more fine-grained control, and we really just
         // want to set entire dialects as illegal.
         static void legalize(conversion_target &) {}
+
+        auto convert(mlir::Type t) const -> mlir::Type
+        {
+            auto trg_type = tc.convert_type_to_type(t);
+            VAST_CHECK(trg_type, "Failed to convert type: {0}", t);
+            return *trg_type;
+        }
     };
 
     template< typename src_t, typename trg_t >

--- a/lib/vast/Conversion/Common/Common.hpp
+++ b/lib/vast/Conversion/Common/Common.hpp
@@ -94,11 +94,7 @@ namespace vast::conv::irstollvm
                     src_t op, typename src_t::Adaptor ops,
                     mlir::ConversionPatternRewriter &rewriter) const override
         {
-            auto trg_type = this->tc.convert_type_to_type(op.getType());
-            VAST_PATTERN_CHECK(trg_type, "Could not convert type, {0}", op);
-
-            auto undef = rewriter.create< mlir::LLVM::UndefOp >(op.getLoc(), *trg_type);
-            rewriter.replaceOp(op, { undef });
+            rewriter.eraseOp(op);
             return mlir::success();
         }
 

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -614,15 +614,38 @@ namespace vast::conv::irstollvm
                 return rewriter.create< mlir::LLVM::CallOp >(op.getLoc(), args ...);
             };
 
+            auto coerce_arg = [&](std::size_t idx) -> mlir::Value
+            {
+                auto original_arg = op.getOperands()[idx];
+                auto conv_arg = ops.getOperands()[idx];
+
+                if (auto lvalue = mlir::dyn_cast< hl::LValueType >(original_arg.getType()))
+                {
+                    auto loc = original_arg.getLoc();
+                    auto trg_type = convert(lvalue.getElementType());
+                    // `LvalueType` is really a pointer?
+                    return rewriter.create< mlir::LLVM::LoadOp >(loc, trg_type, conv_arg);
+                }
+                return conv_arg;
+            };
+
+            auto coerced_args = [&]() -> std::vector< mlir::Value >
+            {
+                std::vector< mlir::Value > out;
+                for (std::size_t i = 0; i < ops.getOperands().size(); ++i)
+                    out.push_back(coerce_arg(i));
+                return out;
+            }();
+
             if (rtys->empty() || rtys->front().isa< mlir::LLVM::LLVMVoidType >())
             {
                 // We cannot pass in void type as some internal check inside `mlir::LLVM`
                 // dialect will fire - it would create a value of void type, which is
                 // not allowed.
-                mk_call(std::vector< mlir::Type >{}, op.getCallee(), ops.getOperands());
+                mk_call(std::vector< mlir::Type >{}, op.getCallee(), coerced_args);
                 rewriter.eraseOp(op);
             } else {
-                auto call = mk_call(*rtys, op.getCallee(), ops.getOperands());
+                auto call = mk_call(*rtys, op.getCallee(), coerced_args);
                 rewriter.replaceOp(op, call.getResults());
             }
 

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -716,8 +716,12 @@ namespace vast::conv::irstollvm
                 {
                     auto loc = original_arg.getLoc();
                     auto trg_type = convert(lvalue.getElementType());
-                    // `LvalueType` is really a pointer?
-                    return rewriter.create< mlir::LLVM::LoadOp >(loc, trg_type, conv_arg);
+                    // TODO(conv:irstollvm): First of all, sometimes we got lvalue argument
+                    //                       but the function expects the element type.
+                    //                       I am not 100% sure if the bitcast is correct
+                    //                       solution, but it solves the string literal
+                    //                       problem.
+                    return rewriter.create< mlir::LLVM::BitcastOp >(loc, trg_type, conv_arg);
                 }
                 return conv_arg;
             };

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -466,7 +466,22 @@ namespace vast::conv::irstollvm
                     return logical_result::success();
                 }
             }
-            return logical_result::failure();
+
+            if (op.getKind() == hl::CastKind::ArrayToPointerDecay)
+            {
+                auto cast = rewriter.create< mlir::LLVM::BitcastOp >(op.getLoc(),
+                                                                     *trg_type,
+                                                                     ops.getOperands()[0]);
+                rewriter.replaceOp(op, {cast});
+                return mlir::success();
+            }
+
+            if (op.getKind() == hl::CastKind::NoOp)
+            {
+                rewriter.replaceOp(op, { ops.getOperands()[0] });
+                return mlir::success();
+            }
+            return mlir::failure();
         }
     };
 

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -194,7 +194,8 @@ namespace vast::conv::irstollvm
             // Type converter failed.
             if (!maybe_target_type || !*maybe_target_type || !maybe_signature)
             {
-                VAST_PATTERN_FAIL("Failed to convert function type.");
+                VAST_PATTERN_FAIL("Failed to convert function type: {0}",
+                                  func_op.getFunctionType());
             }
 
             auto target_type = *maybe_target_type;

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -118,9 +118,11 @@ namespace vast::conv::irstollvm::ll_cf
             }
 
             auto op_entry_block = &*op.getBody().begin();
+            rewriter.setInsertionPointToEnd(head_block);
+            rewriter.create< mlir::LLVM::BrOp >(op.getLoc(), std::vector< mlir::Value >{},
+                                                op_entry_block);
             inline_region_blocks(rewriter, op.getBody(), mlir::Region::iterator(tail_block));
 
-            rewriter.mergeBlocks(op_entry_block, head_block, std::nullopt);
             rewriter.eraseOp(op);
             return mlir::success();
         }

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -67,6 +67,72 @@ namespace vast::conv::irstollvm::ll_cf
 
     };
 
+    template< typename Op >
+    struct scope_like : base_pattern< Op >
+    {
+        using op_t = Op;
+        using base = base_pattern< op_t >;
+        using base::base;
+
+        using adaptor_t = typename op_t::Adaptor;
+
+        // TODO(conv:irstollvm): Should be handled on the operation api level.
+        virtual mlir::Block *start_block(Op op) const = 0;
+
+        // TODO(conv:irstollvm): Separate terminator types should be CRTP hookable.
+        mlir::LogicalResult replace_terminator(auto &rewriter, mlir::Block &block,
+                                               mlir::Block &start, mlir::Block &end) const
+        {
+            auto &last = block.back();
+            std::vector< mlir::Value > no_vals;
+
+            if (auto ret = mlir::dyn_cast< ll::ScopeRet >(last)) {
+                make_after_op< LLVM::BrOp >(rewriter, &last, last.getLoc(), no_vals, &end);
+            } else if (auto ret = mlir::isa< ll::ScopeRecurse >(last)) {
+                make_after_op< LLVM::BrOp >(rewriter, &last, last.getLoc(),
+                                            no_vals, &start);
+            } else if (auto ret = mlir::dyn_cast< ll::CondScopeRet >(last)) {
+                make_after_op< LLVM::CondBrOp >(rewriter, &last, last.getLoc(),
+                                                ret.getCond(),
+                                                ret.getDest(), ret.getDestOperands(),
+                                                &end, no_vals);
+            } else {
+                // Nothing to do (do not erase, since it is a standard branching).
+                return mlir::success();
+            }
+
+            rewriter.eraseOp(&last);
+            return mlir::success();
+        }
+
+
+        mlir::LogicalResult handle_multiblock(
+                    op_t op, adaptor_t ops,
+                    mlir::ConversionPatternRewriter &rewriter) const
+        {
+            auto [head_block, tail_block] = split_at_op(op, rewriter);
+
+            if (!start_block(op))
+                return mlir::failure();
+
+            for ( auto &block : op.getBody() )
+            {
+                auto s = replace_terminator(rewriter, block, *start_block(op), *tail_block);
+                if (mlir::failed(s))
+                    return mlir::failure();
+            }
+
+            auto op_entry_block = &*op.getBody().begin();
+            rewriter.setInsertionPointToEnd(head_block);
+            rewriter.create< mlir::LLVM::BrOp >(op.getLoc(), std::vector< mlir::Value >{},
+                                                op_entry_block);
+            inline_region_blocks(rewriter, op.getBody(), mlir::Region::iterator(tail_block));
+
+            rewriter.eraseOp(op);
+            return mlir::success();
+        }
+    };
+
     struct scope : base_pattern< ll::Scope >
     {
         using base = base_pattern< ll::Scope >;

--- a/lib/vast/Conversion/FromHL/EmitLazyRegions.cpp
+++ b/lib/vast/Conversion/FromHL/EmitLazyRegions.cpp
@@ -106,7 +106,7 @@ namespace vast
             auto yielded_val = yield.op().getResult();
             auto select = rewriter.create< core::SelectOp >(
                     op.getLoc(),
-                    yielded_val.getType(), yielded_val,
+                    then_region.getType(), yielded_val,
                     then_region, else_region);
 
             rewriter.eraseOp(yield.op());

--- a/lib/vast/Conversion/FromHL/ToLLCF.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLCF.cpp
@@ -255,7 +255,6 @@ namespace vast::conv
             {
                 auto bld = rewriter_wrapper_t( rewriter );
 
-                //auto [ head, body, tail ] = extract_as_block( op, rewriter );
                 auto [ original_block, tail_block ] = split_at_op( op, rewriter );
                 VAST_CHECK( original_block && tail_block,
                             "Failed extraction of ifop into block." );

--- a/lib/vast/Conversion/FromHL/ToLLVars.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLVars.cpp
@@ -105,7 +105,10 @@ namespace vast
 
             mlir::ConversionTarget trg(mctx);
             trg.markUnknownOpDynamicallyLegal( [](auto) { return true; } );
-            trg.addIllegalOp< hl::VarDeclOp >();
+            trg.addDynamicallyLegalOp< hl::VarDeclOp >([&](hl::VarDeclOp op)
+            {
+                return mlir::isa< vast_module >(op->getParentOp());
+            });
 
             const auto &dl_analysis = this->getAnalysis< mlir::DataLayoutAnalysis >();
 

--- a/lib/vast/Dialect/HighLevel/Transforms/HLLowerTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/HLLowerTypes.cpp
@@ -106,6 +106,7 @@ namespace vast::hl
             addConversion([&](mlir::Type t) { return this->try_convert_floatlike(t); });
 
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
+            addConversion([&](hl::DecayedType t) { return this->convert_decayed_type(t); });
 
             // Use provided data layout to get the correct type.
             addConversion([&](hl::PointerType t) { return this->convert_ptr_type(t); });
@@ -226,6 +227,14 @@ namespace vast::hl
             return Maybe(t).keep_if(isFloatingType)
                            .and_then(make_float_type())
                            .take_wrapped< maybe_type_t >();
+        }
+
+        maybe_type_t convert_decayed_type(hl::DecayedType t)
+        {
+            return Maybe(t.getElementType())
+                .and_then(convert_type_to_type())
+                .unwrap()
+                .take_wrapped< maybe_type_t >();
         }
 
         maybe_type_t convert_ptr_type(hl::PointerType t)

--- a/lib/vast/Target/LLVMIR/Convert.cpp
+++ b/lib/vast/Target/LLVMIR/Convert.cpp
@@ -84,11 +84,16 @@ namespace vast::target::llvmir
         // TODO(target:llvmir): This should be refactored out as a pipeline so we
         //                      can run it from command line as well.
         // TODO(target:llvmir): Add missing passes.
-        pm.addPass(hl::createDCEPass());
         pm.addPass(hl::createHLLowerTypesPass());
+        pm.addPass(hl::createDCEPass());
+        pm.addPass(hl::createResolveTypeDefsPass());
         pm.addPass(createHLToLLCFPass());
         pm.addPass(createHLToLLVarsPass());
+        pm.addPass(createHLEmitLazyRegionsPass());
+        pm.addPass(createHLToLLGEPsPass());
+        pm.addPass(createHLStructsToLLVMPass());
         pm.addPass(createIRsToLLVMPass());
+        pm.addPass(createCoreToLLVMPass());
 
         auto run_result = pm.run(op);
 

--- a/test/vast/Compile/SingleSource/argc.c
+++ b/test/vast/Compile/SingleSource/argc.c
@@ -1,0 +1,7 @@
+// RUN: vast-front -o %t %s && (%t 1 3 4; test $? -eq 4)
+// RUN: vast-front -o %t %s && (%t; test $? -eq 1)
+
+int main(int argc, char **)
+{
+    return argc;
+}

--- a/test/vast/Compile/SingleSource/argv-a.c
+++ b/test/vast/Compile/SingleSource/argv-a.c
@@ -1,0 +1,14 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 121)
+// RUN: vast-front -o %t %s && (%t hello; test $? -eq 108)
+
+int third( const char *arr )
+{
+    return arr[ 2 ];
+}
+
+int main(int argc, char **argv)
+{
+    if ( argc <= 1 )
+        return 121;
+    return third( argv[ 1 ] );
+}

--- a/test/vast/Compile/SingleSource/label-a.c
+++ b/test/vast/Compile/SingleSource/label-a.c
@@ -1,0 +1,11 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 2)
+// RUN: vast-front -o %t %s && (%t 1 2 3; test $? -eq 4)
+
+int main(int argc, char **argv)
+{
+    int x = 1;
+begin:
+    x += argc;
+end:
+    return x;
+}

--- a/test/vast/Compile/SingleSource/strlit-a.c
+++ b/test/vast/Compile/SingleSource/strlit-a.c
@@ -1,0 +1,11 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 8)
+int third( const char *arr )
+{
+    return arr[ 2 ];
+}
+
+int main()
+{
+    // 'l' - 'd' = 108 - 100
+    return third("Hello")- third("ddd");
+}


### PR DESCRIPTION
Implements lowering of more operations to llvm
 * constant string
 * subscript operation

Fixes some bugs encountered along the way, most notably there was an issue in control flow lowering when `ll.scope` was nested directly in `hl.scope`.

Still need to add more tests ^ before merging.