### PR TITLE
Fixup `goto`'s in `vast-front`

### DIFF
--- a/include/vast/Dialect/HighLevel/Passes.hpp
+++ b/include/vast/Dialect/HighLevel/Passes.hpp
@@ -24,6 +24,8 @@ namespace vast::hl
 
     std::unique_ptr< mlir::Pass > createResolveTypeDefsPass();
 
+    std::unique_ptr< mlir::Pass > createSpliceTrailingScopes();
+
     void registerHLToLLVMIR(mlir::DialectRegistry &);
     void registerHLToLLVMIR(mlir::MLIRContext &);
 

--- a/include/vast/Dialect/HighLevel/Passes.td
+++ b/include/vast/Dialect/HighLevel/Passes.td
@@ -72,4 +72,14 @@ def ResolveTypeDefs : Pass<"vast-hl-resolve-typedefs", "mlir::ModuleOp"> {
   let dependentDialects = ["vast::hl::HighLevelDialect"];
 }
 
+def SpliceTrailingScopes : Pass<"vast-hl-splice-trailing-scopes", "mlir::ModuleOp"> {
+  let summary = "Remove trailing `hl::Scope`s.";
+  let description = [{
+    Removes trailing scopes.
+  }];
+
+  let constructor = "vast::hl::createSpliceTrailingScopes()";
+  let dependentDialects = ["vast::hl::HighLevelDialect"];
+}
+
 #endif // VAST_DIALECT_HIGHLEVEL_PASSES_TD

--- a/include/vast/Translation/CodeGen.hpp
+++ b/include/vast/Translation/CodeGen.hpp
@@ -270,9 +270,8 @@ namespace vast::cg
                 // Emit the standard function prologue.
                 start_function(decl, fn, fty_info, args, loc, options);
 
-                filter< clang::LabelDecl >(function_decl->decls(), [this] (auto lab) {
-                    this->_visitor->Visit(lab);
-                });
+                for(const auto lab : filter< clang::LabelDecl >(function_decl->decls()))
+                    _visitor->Visit(lab);
 
                 // Initialize lexical scope information.
 

--- a/include/vast/Translation/CodeGen.hpp
+++ b/include/vast/Translation/CodeGen.hpp
@@ -270,6 +270,10 @@ namespace vast::cg
                 // Emit the standard function prologue.
                 start_function(decl, fn, fty_info, args, loc, options);
 
+                filter< clang::LabelDecl >(function_decl->decls(), [this] (auto lab) {
+                    this->_visitor->Visit(lab);
+                });
+
                 // Initialize lexical scope information.
 
                 // Save parameters for coroutine function.

--- a/include/vast/Translation/CodeGenBuilder.hpp
+++ b/include/vast/Translation/CodeGenBuilder.hpp
@@ -268,8 +268,6 @@ namespace vast::cg {
         auto make_region_builder(const clang::Stmt *stmt) {
             return [stmt, this](auto &bld, auto) {
                 if (stmt) visit(stmt);
-                // TODO let other pass remove trailing scopes?
-                splice_trailing_scopes(*bld.getBlock()->getParent());
             };
         }
 

--- a/include/vast/Translation/CodeGenDeclVisitor.hpp
+++ b/include/vast/Translation/CodeGenDeclVisitor.hpp
@@ -351,9 +351,6 @@ namespace vast::cg {
                     visit(decl->getBody());
                 }
 
-                // TODO make as pass
-                splice_trailing_scopes(fn);
-
                 auto &last_block = fn.getBlocks().back();
                 auto &ops        = last_block.getOperations();
                 set_insertion_point_to_end(&last_block);

--- a/include/vast/Translation/CodeGenDeclVisitor.hpp
+++ b/include/vast/Translation/CodeGenDeclVisitor.hpp
@@ -337,9 +337,8 @@ namespace vast::cg {
                     // emit label declarations
                     llvm::ScopedHashTableScope labels_scope(context().labels);
 
-                    filter< clang::LabelDecl >(decl->decls(), [this] (auto lab) {
-                        this->visit(lab);
-                    });
+                    for (const auto label : filter< clang::LabelDecl >(decl->decls()))
+                        this->visit(label);
 
                     visit(decl->getBody());
                 }

--- a/include/vast/Translation/CodeGenDeclVisitor.hpp
+++ b/include/vast/Translation/CodeGenDeclVisitor.hpp
@@ -359,7 +359,7 @@ namespace vast::cg {
                 while (scope) {
                     auto parent = scope->getParentRegion();
                     if (parent->hasOneBlock()
-                        && parent->back().begin() == --parent->back().end())
+                        && parent->back().begin() == std::prev(parent->back().end()))
                     {
                         last_op = get_last_op(scope);
                         set_insertion_point_to_end(&scope.getBody());

--- a/include/vast/Translation/CodeGenDeclVisitor.hpp
+++ b/include/vast/Translation/CodeGenDeclVisitor.hpp
@@ -62,15 +62,6 @@ namespace vast::cg {
             return this->template create< Op >(std::forward< Args >(args)...);
         }
 
-        template< typename T >
-        void filter(const auto &decls, auto &&yield) {
-            for ( auto decl : decls) {
-                if (auto s = clang::dyn_cast< T >(decl)) {
-                    yield(s);
-                }
-            }
-        }
-
         static bool is_defaulted_method(const clang::FunctionDecl *function_decl)  {
             if (function_decl->isDefaulted() && clang::isa< clang::CXXMethodDecl >(function_decl)) {
                 auto method = clang::cast< clang::CXXMethodDecl >(function_decl);

--- a/include/vast/Translation/Util.hpp
+++ b/include/vast/Translation/Util.hpp
@@ -15,11 +15,10 @@ VAST_UNRELAX_WARNINGS
 namespace vast::cg
 {
     template< typename T >
-    gap::generator< T * > filter(const auto &decls) {
-        for (auto decl : decls) {
-            if (auto s = clang::dyn_cast< T >(decl)) {
+    gap::generator< T * > filter(auto from) {
+        for (auto x : from) {
+            if (auto s = clang::dyn_cast< T >(x))
                 co_yield s;
-            }
         }
     }
 } // namespace vast::cg

--- a/include/vast/Translation/Util.hpp
+++ b/include/vast/Translation/Util.hpp
@@ -22,47 +22,4 @@ namespace vast::cg
             }
         }
     }
-
-    inline void splice_trailing_scopes(mlir::Region::BlockListType &blocks) {
-        auto has_trailing_scope = [&] {
-            if (blocks.empty())
-                return false;
-            auto &last_block = blocks.back();
-            if (last_block.empty())
-                return false;
-            return mlir::isa< hl::ScopeOp >(last_block.back());
-        };
-
-        while (has_trailing_scope()) {
-            auto &last_block = blocks.back();
-
-            auto scope  = mlir::cast< hl::ScopeOp >(last_block.back());
-            auto parent = scope.getBody().getParentRegion();
-            scope->remove();
-
-            auto &prev = parent->getBlocks().back();
-
-            mlir::IRMapping mapping;
-            scope.getBody().cloneInto(parent, mapping);
-
-            auto next = prev.getNextNode();
-
-            auto &ops = last_block.getOperations();
-            ops.splice(ops.end(), next->getOperations());
-
-            next->erase();
-            scope.erase();
-        }
-    }
-
-    inline void splice_trailing_scopes(hl::FuncOp &fn) {
-        if (fn.empty())
-            return;
-        splice_trailing_scopes(fn.getBlocks());
-    }
-
-    inline void splice_trailing_scopes(mlir::Region &reg) {
-        splice_trailing_scopes(reg.getBlocks());
-    }
-
 } // namespace vast::cg

--- a/include/vast/Translation/Util.hpp
+++ b/include/vast/Translation/Util.hpp
@@ -14,6 +14,15 @@ VAST_UNRELAX_WARNINGS
 
 namespace vast::cg
 {
+    template< typename T >
+    void filter(const auto &decls, auto &&yield) {
+        for ( auto decl : decls) {
+            if (auto s = clang::dyn_cast< T >(decl)) {
+                yield(s);
+            }
+        }
+    }
+
     inline void splice_trailing_scopes(mlir::Region::BlockListType &blocks) {
         auto has_trailing_scope = [&] {
             if (blocks.empty())

--- a/include/vast/Translation/Util.hpp
+++ b/include/vast/Translation/Util.hpp
@@ -10,15 +10,15 @@ VAST_RELAX_WARNINGS
 #include <mlir/IR/Region.h>
 VAST_UNRELAX_WARNINGS
 
-#include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
+#include <gap/core/generator.hpp>
 
 namespace vast::cg
 {
     template< typename T >
-    void filter(const auto &decls, auto &&yield) {
-        for ( auto decl : decls) {
+    gap::generator< T * > filter(const auto &decls) {
+        for (auto decl : decls) {
             if (auto s = clang::dyn_cast< T >(decl)) {
-                yield(s);
+                co_yield s;
             }
         }
     }

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2021-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include <vast/Util/Common.hpp>
+
+namespace vast
+{
+    bool has_trailing_scope(mlir::Region::BlockListType &blocks) {
+        if (blocks.empty())
+            return false;
+        auto &last_block = blocks.back();
+        if (last_block.empty())
+            return false;
+        return mlir::isa< hl::ScopeOp >(last_block.back());
+    }
+
+    bool has_trailing_scope(Region &r) { return has_trailing_scope(r.getBlocks()); }
+
+    bool has_trailing_scope(operation op){
+        for (auto &r : op->getRegions())
+            if (has_trailing_scope(r))
+                return true;
+        return false;
+    }
+} //namespace vast

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -12,7 +12,7 @@ namespace vast
         if (auto parent = op->getParentRegion()) {
             if(parent->hasOneBlock()) {
                 auto &block = parent->back();
-                auto &last = --block.end();
+                auto last = --block.end();
 
                 // vast-cc adds UnreachableOp if it doesn't see a proper terminator
                 // But the real terminator might be enclosed in the scope

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -12,7 +12,7 @@ namespace vast
         if (auto parent = op->getParentRegion()) {
             if(parent->hasOneBlock()) {
                 auto &block = parent->back();
-                auto last = --block.end();
+                auto last = std::prev(block.end());
                 return block.begin() == last;
             }
         }

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -6,19 +6,13 @@
 
 namespace vast
 {
-    bool is_trailing_scope(operation op) {
+    inline bool is_trailing_scope(operation op) {
         if (!mlir::isa< hl::ScopeOp >(op))
             return false;
         if (auto parent = op->getParentRegion()) {
             if(parent->hasOneBlock()) {
                 auto &block = parent->back();
                 auto last = --block.end();
-
-                // vast-cc adds UnreachableOp if it doesn't see a proper terminator
-                // But the real terminator might be enclosed in the scope
-                if (mlir::isa< hl::UnreachableOp >(block.back()))
-                        --last;
-                // check if we have only the scope operation in the block
                 return block.begin() == last;
             }
         }

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -6,7 +6,7 @@
 
 namespace vast
 {
-    inline bool is_trailing_scope(operation op) {
+    static inline bool is_trailing_scope(operation op) {
         if (!mlir::isa< hl::ScopeOp >(op))
             return false;
         if (auto parent = op->getParentRegion()) {
@@ -19,7 +19,7 @@ namespace vast
         return false;
     }
 
-    inline operation get_last_op(hl::ScopeOp scope) {
+    static inline operation get_last_op(hl::ScopeOp scope) {
         auto &last_block = scope.getBody().back();
         if (last_block.empty())
             return nullptr;

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -18,4 +18,11 @@ namespace vast
         }
         return false;
     }
+
+    inline operation get_last_op(hl::ScopeOp scope) {
+        auto &last_block = scope.getBody().back();
+        if (last_block.empty())
+            return nullptr;
+        return &last_block.back();
+    }
 } //namespace vast

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -12,8 +12,14 @@ namespace vast
         if (auto parent = op->getParentRegion()) {
             if(parent->hasOneBlock()) {
                 auto &block = parent->back();
+                auto &last = --block.end();
+
+                // vast-cc adds UnreachableOp if it doesn't see a proper terminator
+                // But the real terminator might be enclosed in the scope
+                if (mlir::isa< hl::UnreachableOp >(block.back()))
+                        --last;
                 // check if we have only the scope operation in the block
-                return &block.front() == &block.back();
+                return block.begin() == last;
             }
         }
         return false;

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -6,21 +6,16 @@
 
 namespace vast
 {
-    bool has_trailing_scope(mlir::Region::BlockListType &blocks) {
-        if (blocks.empty())
+    bool is_trailing_scope(operation op) {
+        if (!mlir::isa< hl::ScopeOp >(op))
             return false;
-        auto &last_block = blocks.back();
-        if (last_block.empty())
-            return false;
-        return mlir::isa< hl::ScopeOp >(last_block.back());
-    }
-
-    bool has_trailing_scope(Region &r) { return has_trailing_scope(r.getBlocks()); }
-
-    bool has_trailing_scope(operation op){
-        for (auto &r : op->getRegions())
-            if (has_trailing_scope(r))
-                return true;
+        if (auto parent = op->getParentRegion()) {
+            if(parent->hasOneBlock()) {
+                auto &block = parent->back();
+                // check if we have only the scope operation in the block
+                return &block.front() == &block.back();
+            }
+        }
         return false;
     }
 } //namespace vast

--- a/lib/vast/CodeGen/Passes.cpp
+++ b/lib/vast/CodeGen/Passes.cpp
@@ -7,6 +7,7 @@ VAST_RELAX_WARNINGS
 #include <mlir/Pass/PassManager.h>
 VAST_UNRELAX_WARNINGS
 
+#include "vast/Dialect/HighLevel/Passes.hpp"
 #include "vast/CodeGen/Passes.hpp"
 
 namespace vast::cg {
@@ -17,6 +18,7 @@ namespace vast::cg {
         mlir::PassManager mgr(mctx);
 
         // TODO: setup vast intermediate codegen passes
+        mgr.addPass(hl::createSpliceTrailingScopes());
 
         mgr.enableVerifier(enable_verifier);
         return mgr.run(mod);

--- a/lib/vast/Dialect/HighLevel/Transforms/CMakeLists.txt
+++ b/lib/vast/Dialect/HighLevel/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(vast_high_level_transforms STATIC
   LLVMDump.cpp
   DCE.cpp
   ResolveTypeDefs.cpp
+  SpliceTrailingScopes.cpp
 )
 
 target_link_libraries(vast_high_level_transforms

--- a/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#include "vast/Conversion/Passes.hpp"
+
+VAST_RELAX_WARNINGS
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
+
+#include <mlir/Transforms/DialectConversion.h>
+#include <mlir/Rewrite/FrozenRewritePatternSet.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <mlir/Transforms/DialectConversion.h>
+VAST_UNRELAX_WARNINGS
+
+#include "vast/Conversion/Common/Passes.hpp"
+#include "vast/Conversion/Common/Patterns.hpp"
+
+#include "vast/Util/Common.hpp"
+#include "vast/Util/DialectConversion.hpp"
+#include "vast/Util/Scopes.hpp"
+
+#include "vast/Conversion/Common/Rewriter.hpp"
+
+#include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
+#include "vast/Dialect/HighLevel/Passes.hpp"
+
+#include "PassesDetails.hpp"
+
+namespace vast::hl
+{
+    namespace
+    {
+        namespace pattern
+        {
+            using type_converter = mlir::TypeConverter;
+
+            struct splice_trailing_scopes : generic_conversion_pattern
+            {
+                using base = generic_conversion_pattern;
+                using base::base;
+
+                splice_trailing_scopes(type_converter &tc, mcontext_t &mctx)
+                    : base(tc, mctx) {}
+
+                inline void splice(Region &reg, conversion_rewriter &rewriter) const
+                {
+                    auto &blocks = reg.getBlocks();
+                    while (has_trailing_scope(blocks))
+                    {
+                        auto &last_block = blocks.back();
+
+                        auto scope  = mlir::cast< hl::ScopeOp >(last_block.back());
+                        auto parent = scope.getBody().getParentRegion();
+
+                        auto &prev = parent->getBlocks().back();
+
+                        rewriter.inlineRegionBefore(scope.getBody(), *parent, parent->end());
+
+                        auto next = prev.getNextNode();
+
+                        // The next here is wrong
+                        rewriter.mergeBlockBefore(next, &last_block.back());
+
+                        rewriter.eraseOp(scope);
+                    }
+                }
+
+                logical_result matchAndRewrite(
+                        operation op, mlir::ArrayRef< Value >, conversion_rewriter &rewriter) const override
+                {
+
+                    for (auto &r : op->getRegions())
+                        splice(r, rewriter);
+                    return logical_result::success();
+                }
+            };
+        } // namespace pattern
+    } // namespace
+
+    struct SpliceTrailingScopes : ModuleConversionPassMixin< SpliceTrailingScopes, SpliceTrailingScopesBase >
+    {
+        using base = ModuleConversionPassMixin< SpliceTrailingScopes, SpliceTrailingScopesBase >;
+        using config_t = typename base::config_t;
+
+        static auto create_conversion_target(mcontext_t &mctx)
+        {
+            conversion_target target(mctx);
+
+            auto is_legal = [](operation op)
+            {
+                return !has_trailing_scope(op);
+            };
+
+            target.markUnknownOpDynamicallyLegal(is_legal);
+            return target;
+        }
+
+        void runOnOperation() override
+        {
+            auto &mctx = getContext();
+            auto target = create_conversion_target(mctx);
+            vast_module op = getOperation();
+
+            rewrite_pattern_set patterns(&mctx);
+
+            auto tc = pattern::type_converter();
+            patterns.template add< pattern::splice_trailing_scopes >(tc, mctx);
+
+            if (mlir::failed(mlir::applyPartialConversion(op,
+                                                          target,
+                                                          std::move(patterns))))
+            {
+                return signalPassFailure();
+            }
+        }
+
+    };
+
+} // namespace vast::hl
+
+std::unique_ptr< mlir::Pass > vast::hl::createSpliceTrailingScopes()
+{
+    return std::make_unique< vast::hl::SpliceTrailingScopes >();
+}

--- a/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
@@ -57,7 +57,12 @@ namespace vast::hl
                     auto target = scope->getBlock();
 
                     rewriter.inlineRegionBefore(body, *op->getParentRegion(), target->getIterator());
-                    rewriter.mergeBlocks(&start, target, mlir::ValueRange());
+                    rewriter.mergeBlocks(&start, target, start.getArguments());
+
+                    // we need to explicitly unlink the scope op from the block otherwise
+                    // it breaks nested scopes... MLIR keeps the operation around for some
+                    // (unspecified) time
+                    op->remove();
                     rewriter.eraseOp(op);
 
                     return logical_result::success();

--- a/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
@@ -56,11 +56,6 @@ namespace vast::hl
                     auto &start = body.front();
                     auto target = scope->getBlock();
 
-                    // vast-cc adds UnreachableOp as a terminator because
-                    // the real terminator is hidden inside the scope
-                    if (isa< hl::UnreachableOp >(target->back()))
-                        rewriter.eraseOp(&target->back());
-
                     rewriter.inlineRegionBefore(body, *op->getParentRegion(), target->getIterator());
                     rewriter.mergeBlocks(&start, target, mlir::ValueRange());
                     rewriter.eraseOp(op);

--- a/test/vast/Conversion/Common/CoreToLLVM/binland-a.c
+++ b/test/vast/Conversion/Common/CoreToLLVM/binland-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
 
 int fun(int arg1, int arg2) {
     int res = arg1 && arg2;

--- a/test/vast/Conversion/Common/CoreToLLVM/binlor-a.c
+++ b/test/vast/Conversion/Common/CoreToLLVM/binlor-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
 
 int fun(int arg1, int arg2) {
     int res = arg1 || arg2;

--- a/test/vast/Conversion/Common/IRsToLLVM/add-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/add-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/addfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/addfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/array-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/array-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/array-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/array-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/divfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/divsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/divunsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divunsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 unsigned int fn(unsigned int arg0, unsigned int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/float-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/float-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/fn-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/fn-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn() {
 void fn()

--- a/test/vast/Conversion/Common/IRsToLLVM/fn-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/fn-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn() -> i32 {
 int fn()

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @count([[ARG:%arg[0-9]+]]: i32)
 void count(int arg)

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @count([[ARG:%arg[0-9]+]]: i32)
 void count(int arg)

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-c.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/mul-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/mul-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/mulfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/mulfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/not-float.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/not-float.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     float a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/not.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/not.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     int a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/remsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/remsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/remunsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/remunsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 unsigned int fn(unsigned int arg0, unsigned int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/sub-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/sub-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/subfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/subfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/FromHL/ToFunc/fn-decl-a.c
+++ b/test/vast/Conversion/FromHL/ToFunc/fn-decl-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-func | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-to-func | FileCheck %s
 
 // CHECK: func.func private @foo()
 void foo();

--- a/test/vast/Conversion/FromHL/ToFunc/fn-decl-b.c
+++ b/test/vast/Conversion/FromHL/ToFunc/fn-decl-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-func | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-func | FileCheck %s
 
 // CHECK: func.func private @foo()
 void foo();

--- a/test/vast/Conversion/FromHL/ToLLCF/for-a.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Conversion/FromHL/ToLLCF/for-b.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
 
 int fn()
 {

--- a/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
+++ b/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
 
 int main()
 {

--- a/test/vast/Dialect/Core/binlop-a.c
+++ b/test/vast/Dialect/Core/binlop-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-lazy-regions | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-to-lazy-regions | FileCheck %s
 
 void logic_assign_to_different_type() {
     // CHECK: [[L:%[0-9]+]] = core.lazy.op {

--- a/test/vast/Dialect/Core/binlop-b.c
+++ b/test/vast/Dialect/Core/binlop-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-lazy-regions | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-to-lazy-regions | FileCheck %s
 
 void logic_assign_to_different_type() {
     // CHECK: [[L:%[0-9]+]] = core.lazy.op {

--- a/test/vast/Dialect/HighLevel/branch-a.c
+++ b/test/vast/Dialect/HighLevel/branch-a.c
@@ -82,6 +82,7 @@ int branch_else_empty(int a, int b)
     // CHECK: hl.cond.yield [[V1]]
     if (a <= b) {
         // CHECK: } then {
+        // CHECK-NEXT: hl.scope
         // CHECK-NEXT: hl.var "c" : !hl.lvalue<!hl.int> =
         // CHECK: [[V2:%[0-9]+]] = hl.const #hl.integer<7> : !hl.int
         // CHECK: hl.value.yield [[V2]]

--- a/test/vast/Dialect/HighLevel/scope-a.c
+++ b/test/vast/Dialect/HighLevel/scope-a.c
@@ -1,5 +1,4 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes | FileCheck %s
 
 // CHECK-LABEL: hl.func external @test1 () -> !hl.int
 int test1()
@@ -29,7 +28,7 @@ void test2()
         int a;
     }
 
-    // CHECK-NOT: hl.scope
+    // CHECK: hl.scope
     // CHECK: hl.var "a" : !hl.lvalue<!hl.int>
     {
         int a;

--- a/test/vast/Transform/FromHL/LowerTypes/array-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/array-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK: hl.var "ai" : !hl.lvalue<memref<10xsi32>>
 int ai[10];

--- a/test/vast/Transform/FromHL/LowerTypes/array-b.c
+++ b/test/vast/Transform/FromHL/LowerTypes/array-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK: hl.var "a" sc_extern : !hl.lvalue<memref<?xsi32>>
 extern int a[];

--- a/test/vast/Transform/FromHL/LowerTypes/calls-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/calls-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 int constant() { return 7; }
 

--- a/test/vast/Transform/FromHL/LowerTypes/loop.c
+++ b/test/vast/Transform/FromHL/LowerTypes/loop.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 void loop_simple()
 {

--- a/test/vast/Transform/FromHL/LowerTypes/scope-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/scope-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @test1 () -> si32 attributes {sym_visibility = "private"} {
 int test1()

--- a/test/vast/Transform/FromHL/LowerTypes/scope-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/scope-a.c
@@ -28,7 +28,7 @@ void test2()
         int a;
     }
 
-    // CHECK-NOT: hl.scope
+    // CHECK: hl.scope
     // CHECK: hl.var "a" : !hl.lvalue<si32>
     {
         int a;

--- a/test/vast/Transform/FromHL/LowerTypes/strlit-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/strlit-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/struct-access-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/struct-access-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK:  hl.struct "X" : {
 // CHECK:    hl.field "member_x" : si32

--- a/test/vast/Transform/FromHL/LowerTypes/vars-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/vars-b.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/vars-c.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/StructsToLLVM/empty-a.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/empty-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", ()>
 struct X {};

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-a.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", (i32)>
 struct X { int x; };

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-b.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.type "Y"
 struct Y;

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-c.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 struct Y;
 

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-d.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-d.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", (i32, ptr<struct<"X">>)>
 struct X { int a; struct X *x; };

--- a/test/vast/Transform/FromHL/ToLLGEPs/member-access-a.c
+++ b/test/vast/Transform/FromHL/ToLLGEPs/member-access-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-geps | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-geps | FileCheck %s
 
 struct X { int a; };
 

--- a/test/vast/Transform/HL/DCE/for-a.c
+++ b/test/vast/Transform/HL/DCE/for-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Transform/HL/DCE/for-b.c
+++ b/test/vast/Transform/HL/DCE/for-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Transform/HL/DCE/if-a.c
+++ b/test/vast/Transform/HL/DCE/if-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce | FileCheck %s
 // REQUIRES: return
 
 void fn()

--- a/test/vast/Transform/HL/ResolveTypedefs/func-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/func-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/test/vast/Transform/HL/ResolveTypedefs/struct-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/struct-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/test/vast/Transform/HL/ResolveTypedefs/var-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/var-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 


### PR DESCRIPTION
- Move splicing of trailing scopes to a separate pass
- Emit `LabelDecl`s as the first think in function generation