### PR TITLE
Make array to ptr decay strip `lvalue` from type

### DIFF
--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -401,8 +401,9 @@ namespace vast::cg {
             auto to_rvalue_cast     = [&] { return visit(expr->getType()); };
             auto lvalue_cast        = [&] { return visit_as_lvalue_type(expr->getType()); };
             auto non_lvalue_cast    = [&] { return visit(expr->getType()); };
+            auto array_to_ptr_cast  = [&] { return visit(expr->getType()); };
             auto keep_category_cast = [&] {
-                if (from.isa< hl::LValueType >())
+                if (mlir::isa< hl::LValueType >(from))
                     return lvalue_cast();
                 return non_lvalue_cast();
             };
@@ -422,7 +423,7 @@ namespace vast::cg {
                 case clang::CastKind::CK_ToUnion:                return lvalue_cast();
 
                 case clang::CastKind::CK_NullToPointer:          return non_lvalue_cast();
-                case clang::CastKind::CK_ArrayToPointerDecay:
+                case clang::CastKind::CK_ArrayToPointerDecay:    return array_to_ptr_cast();
                 case clang::CastKind::CK_FunctionToPointerDecay:
                 // case clang::CastKind::CK_NullToMemberPointer:        return;
                 // case clang::CastKind::CK_BaseToDerivedMemberPointer: return;

--- a/test/vast/Dialect/HighLevel/array-d.c
+++ b/test/vast/Dialect/HighLevel/array-d.c
@@ -8,9 +8,9 @@ int main() {
     int arr[3];
     // CHECK: hl.var "v0" : !hl.lvalue<!hl.int> = {
     // CHECK:   [[V1:%[0-9]+]] = hl.ref [[ARR]] : !hl.lvalue<!hl.array<3, !hl.int>>
-    // CHECK:   [[V2:%[0-9]+]] = hl.implicit_cast [[V1]] ArrayToPointerDecay : !hl.lvalue<!hl.array<3, !hl.int>> -> !hl.lvalue<!hl.ptr<!hl.int>>
+    // CHECK:   [[V2:%[0-9]+]] = hl.implicit_cast [[V1]] ArrayToPointerDecay : !hl.lvalue<!hl.array<3, !hl.int>> -> !hl.ptr<!hl.int>
     // CHECK:   [[V3:%[0-9]+]] = hl.const #hl.integer<0> : !hl.int
-    // CHECK:   hl.subscript [[V2]] at {{.*}}[[V3]] : !hl.int] : !hl.lvalue<!hl.ptr<!hl.int>> -> !hl.lvalue<!hl.int>
+    // CHECK:   hl.subscript [[V2]] at {{.*}}[[V3]] : !hl.int] : !hl.ptr<!hl.int> -> !hl.lvalue<!hl.int>
     // CHECK: }
     int v0 = arr[0];
 
@@ -18,10 +18,10 @@ int main() {
     int idx = 2;
     // CHECK: hl.var "v2" : !hl.lvalue<!hl.int> = {
     // CHECK:   [[V1:%[0-9]+]] = hl.ref [[ARR]] : !hl.lvalue<!hl.array<3, !hl.int>>
-    // CHECK:   [[V2:%[0-9]+]] = hl.implicit_cast [[V1]] ArrayToPointerDecay : !hl.lvalue<!hl.array<3, !hl.int>> -> !hl.lvalue<!hl.ptr<!hl.int>>
+    // CHECK:   [[V2:%[0-9]+]] = hl.implicit_cast [[V1]] ArrayToPointerDecay : !hl.lvalue<!hl.array<3, !hl.int>> -> !hl.ptr<!hl.int>
     // CHECK:   [[V3:%[0-9]+]] = hl.ref [[IDX]] : !hl.lvalue<!hl.int>
     // CHECK:   [[V4:%[0-9]+]] = hl.implicit_cast [[V3]] LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-    // CHECK:   hl.subscript [[V2]] at {{.*}}[[V4]] : !hl.int] : !hl.lvalue<!hl.ptr<!hl.int>> -> !hl.lvalue<!hl.int>
+    // CHECK:   hl.subscript [[V2]] at {{.*}}[[V4]] : !hl.int] : !hl.ptr<!hl.int> -> !hl.lvalue<!hl.int>
     // CHECK: }
     int v2 = arr[idx];
 }

--- a/test/vast/Dialect/HighLevel/pointers-c.c
+++ b/test/vast/Dialect/HighLevel/pointers-c.c
@@ -2,11 +2,11 @@
 // RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<2, !hl.int>> -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<2, !hl.int>> -> !hl.ptr<!hl.int>
 int a[2];
 int *p = a; // pointer to a[0]
 
 // CHECK: hl.var "row" : !hl.lvalue<!hl.ptr<!hl.paren<!hl.array<3, !hl.int>>>>
-// CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<3, !hl.array<3, !hl.int>>> -> !hl.lvalue<!hl.ptr<!hl.array<3, !hl.int>>>
+// CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<3, !hl.array<3, !hl.int>>> -> !hl.ptr<!hl.array<3, !hl.int>>
 int b[3][3];
 int (*row)[3] = b; // pointer to b[0]

--- a/test/vast/Dialect/HighLevel/string-a.c
+++ b/test/vast/Dialect/HighLevel/string-a.c
@@ -3,5 +3,5 @@
 
 // CHECK: hl.var "gstr" : !hl.lvalue<!hl.ptr<!hl.char< const >>>
 // CHECK: hl.const #hl.strlit<"global"> : !hl.lvalue<!hl.array<7, !hl.char>>
-// CHECK: ArrayToPointerDecay : !hl.lvalue<!hl.array<7, !hl.char>> -> !hl.lvalue<!hl.ptr<!hl.char>>
+// CHECK: ArrayToPointerDecay : !hl.lvalue<!hl.array<7, !hl.char>> -> !hl.ptr<!hl.char>
 const char *gstr = "global";

--- a/test/vast/Dialect/HighLevel/string-b.c
+++ b/test/vast/Dialect/HighLevel/string-b.c
@@ -3,5 +3,5 @@
 
 // CHECK: hl.var "gstr" : !hl.lvalue<!hl.ptr<!hl.char< const >>>
 // CHECK:   hl.const #hl.strlit<"global\n"> : !hl.lvalue<!hl.array<8, !hl.char>>
-// CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<8, !hl.char>> -> !hl.lvalue<!hl.ptr<!hl.char>>
+// CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<8, !hl.char>> -> !hl.ptr<!hl.char>
 const char *gstr = "global\n";


### PR DESCRIPTION
According to the C standard the result of array to ptr decay is not an lvalue.