### PR TITLE
Various lowering improvements

### DIFF
--- a/include/vast/Conversion/Common/Rewriter.hpp
+++ b/include/vast/Conversion/Common/Rewriter.hpp
@@ -64,6 +64,9 @@ namespace vast::conv
         }
     };
 
+    template< typename I >
+    rewriter_wrapper_t( I & ) -> rewriter_wrapper_t< I >;
+
     auto guarded( auto &bld, auto &&fn )
     {
         auto g = mlir::OpBuilder::InsertionGuard( bld );

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -192,8 +192,8 @@ def HighLevel_ForOp : ControlFlowOp< "for" >
 
   let regions = (region
     CondRegion:$condRegion,
-    SizedRegion<1>:$incrRegion,
-    SizedRegion<1>:$bodyRegion
+    AnyRegion:$incrRegion,
+    AnyRegion:$bodyRegion
   );
 
   let skipDefaultBuilders = 1;

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -9,7 +9,7 @@ include "vast/Dialect/Core/CoreTraits.td"
 
 class ControlFlowOp< string mnemonic, list< Trait > traits = [] >
     : HighLevel_Op< mnemonic, !listconcat(traits,
-        [SingleBlock, NoTerminator, NoRegionArguments]
+        [NoTerminator, NoRegionArguments]
       ) >
 {
     let summary = "VAST control flow operation";
@@ -348,7 +348,7 @@ def HighLevel_LabelStmt
   : ControlFlowOp< "label" >
   , Arguments<(ins LabelType:$label)>
 {
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region AnyRegion:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -348,7 +348,7 @@ def HighLevel_LabelStmt
   : ControlFlowOp< "label" >
   , Arguments<(ins LabelType:$label)>
 {
-  let regions = (region SizedRegion<1>:$substmt);
+  let regions = (region SizedRegion<1>:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -358,7 +358,7 @@ def HighLevel_LabelStmt
     )>
   ];
 
-  let assemblyFormat = [{ $label $substmt attr-dict }];
+  let assemblyFormat = [{ $label $body attr-dict }];
 }
 
 def HighLevel_GotoStmt

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.td
@@ -419,7 +419,9 @@ def ArrayType : CVRQualifiedType< "Array", "array",
   let assemblyFormat = "`<` $size `,` $elementType (`,` $quals^ )? `>`";
 }
 
-def DecayedType : HighLevelType< "Decayed", [MemRefElementTypeInterface] > {
+def DecayedType : HighLevelType< "Decayed",
+                                 [SubElementTypeInterface, MemRefElementTypeInterface] >
+{
   let mnemonic = "decayed";
   let parameters = (ins "Type":$elementType);
   let assemblyFormat = "`<` $elementType `>`";

--- a/include/vast/Util/LLVMTypeConverter.hpp
+++ b/include/vast/Util/LLVMTypeConverter.hpp
@@ -42,6 +42,7 @@ namespace vast::util::tc
         template< typename ... Args >
         LLVMTypeConverter(Args && ... args) : parent_t(std::forward< Args >(args) ... )
         {
+            addConversion([&](hl::LabelType t) { return t; });
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
             addConversion([&](hl::PointerType t) { return this->convert_pointer_type(t); });
             addConversion([&](mlir::MemRefType t) { return this->convert_memref_type(t); });

--- a/include/vast/Util/LLVMTypeConverter.hpp
+++ b/include/vast/Util/LLVMTypeConverter.hpp
@@ -43,6 +43,7 @@ namespace vast::util::tc
         LLVMTypeConverter(Args && ... args) : parent_t(std::forward< Args >(args) ... )
         {
             addConversion([&](hl::LabelType t) { return t; });
+            addConversion([&](hl::DecayedType t) { return this->convert_decayed(t); });
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
             addConversion([&](hl::PointerType t) { return this->convert_pointer_type(t); });
             addConversion([&](mlir::MemRefType t) { return this->convert_memref_type(t); });
@@ -84,6 +85,12 @@ namespace vast::util::tc
                 VAST_ASSERT(!t.template isa< mlir::NoneType >());
                 return mlir::LLVM::LLVMPointerType::get(t);
             };
+        }
+
+        maybe_type_t convert_decayed(hl::DecayedType t)
+        {
+            VAST_UNREACHABLE("We should encounter decayed this late in the pipeline, {0}", t);
+            return {};
         }
 
         maybe_type_t convert_lvalue_type(hl::LValueType t)

--- a/include/vast/Util/LLVMTypeConverter.hpp
+++ b/include/vast/Util/LLVMTypeConverter.hpp
@@ -89,7 +89,7 @@ namespace vast::util::tc
 
         maybe_type_t convert_decayed(hl::DecayedType t)
         {
-            VAST_UNREACHABLE("We should encounter decayed this late in the pipeline, {0}", t);
+            VAST_UNREACHABLE("We shouldn't encounter decayed this late in the pipeline, {0}", t);
             return {};
         }
 

--- a/lib/vast/Conversion/Common/Common.hpp
+++ b/lib/vast/Conversion/Common/Common.hpp
@@ -42,6 +42,13 @@ namespace vast::conv::irstollvm
         // Some operations want more fine-grained control, and we really just
         // want to set entire dialects as illegal.
         static void legalize(conversion_target &) {}
+
+        auto convert(mlir::Type t) const -> mlir::Type
+        {
+            auto trg_type = tc.convert_type_to_type(t);
+            VAST_CHECK(trg_type, "Failed to convert type: {0}", t);
+            return *trg_type;
+        }
     };
 
     template< typename src_t, typename trg_t >

--- a/lib/vast/Conversion/Common/Common.hpp
+++ b/lib/vast/Conversion/Common/Common.hpp
@@ -94,11 +94,7 @@ namespace vast::conv::irstollvm
                     src_t op, typename src_t::Adaptor ops,
                     mlir::ConversionPatternRewriter &rewriter) const override
         {
-            auto trg_type = this->tc.convert_type_to_type(op.getType());
-            VAST_PATTERN_CHECK(trg_type, "Could not convert type, {0}", op);
-
-            auto undef = rewriter.create< mlir::LLVM::UndefOp >(op.getLoc(), *trg_type);
-            rewriter.replaceOp(op, { undef });
+            rewriter.eraseOp(op);
             return mlir::success();
         }
 

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -614,15 +614,38 @@ namespace vast::conv::irstollvm
                 return rewriter.create< mlir::LLVM::CallOp >(op.getLoc(), args ...);
             };
 
+            auto coerce_arg = [&](std::size_t idx) -> mlir::Value
+            {
+                auto original_arg = op.getOperands()[idx];
+                auto conv_arg = ops.getOperands()[idx];
+
+                if (auto lvalue = mlir::dyn_cast< hl::LValueType >(original_arg.getType()))
+                {
+                    auto loc = original_arg.getLoc();
+                    auto trg_type = convert(lvalue.getElementType());
+                    // `LvalueType` is really a pointer?
+                    return rewriter.create< mlir::LLVM::LoadOp >(loc, trg_type, conv_arg);
+                }
+                return conv_arg;
+            };
+
+            auto coerced_args = [&]() -> std::vector< mlir::Value >
+            {
+                std::vector< mlir::Value > out;
+                for (std::size_t i = 0; i < ops.getOperands().size(); ++i)
+                    out.push_back(coerce_arg(i));
+                return out;
+            }();
+
             if (rtys->empty() || rtys->front().isa< mlir::LLVM::LLVMVoidType >())
             {
                 // We cannot pass in void type as some internal check inside `mlir::LLVM`
                 // dialect will fire - it would create a value of void type, which is
                 // not allowed.
-                mk_call(std::vector< mlir::Type >{}, op.getCallee(), ops.getOperands());
+                mk_call(std::vector< mlir::Type >{}, op.getCallee(), coerced_args);
                 rewriter.eraseOp(op);
             } else {
-                auto call = mk_call(*rtys, op.getCallee(), ops.getOperands());
+                auto call = mk_call(*rtys, op.getCallee(), coerced_args);
                 rewriter.replaceOp(op, call.getResults());
             }
 

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -40,7 +40,8 @@ VAST_UNRELAX_WARNINGS
 namespace vast::conv::irstollvm
 {
     using ignore_patterns = util::type_list<
-        ignore_pattern< hl::DeclRefOp >
+        ignore_pattern< hl::DeclRefOp >,
+        ignore_pattern< hl::PredefinedExpr >
     >;
 
     template< typename Op >

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -466,7 +466,22 @@ namespace vast::conv::irstollvm
                     return logical_result::success();
                 }
             }
-            return logical_result::failure();
+
+            if (op.getKind() == hl::CastKind::ArrayToPointerDecay)
+            {
+                auto cast = rewriter.create< mlir::LLVM::BitcastOp >(op.getLoc(),
+                                                                     *trg_type,
+                                                                     ops.getOperands()[0]);
+                rewriter.replaceOp(op, {cast});
+                return mlir::success();
+            }
+
+            if (op.getKind() == hl::CastKind::NoOp)
+            {
+                rewriter.replaceOp(op, { ops.getOperands()[0] });
+                return mlir::success();
+            }
+            return mlir::failure();
         }
     };
 

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -194,7 +194,8 @@ namespace vast::conv::irstollvm
             // Type converter failed.
             if (!maybe_target_type || !*maybe_target_type || !maybe_signature)
             {
-                VAST_PATTERN_FAIL("Failed to convert function type.");
+                VAST_PATTERN_FAIL("Failed to convert function type: {0}",
+                                  func_op.getFunctionType());
             }
 
             auto target_type = *maybe_target_type;

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -68,26 +68,37 @@ namespace vast::conv::irstollvm
     };
 
     // TODO(conv): Finish and properly test.
-    struct label_stmt : base_pattern< hl::LabelStmt >
+    struct label_stmt : ll_cf::scope_like< hl::LabelStmt >
     {
         using Op = hl::LabelStmt;
-        using base = base_pattern< Op >;
+        using base = ll_cf::scope_like< Op >;
         using base::base;
+
+        mlir::Block *start_block(Op op) const override
+        {
+            return &*op.getBody().begin();
+        }
 
         mlir::LogicalResult matchAndRewrite(
                 Op unit_op, typename Op::Adaptor ops,
                 mlir::ConversionPatternRewriter &rewriter) const override
         {
-            auto parent = unit_op->getParentRegion();
-            inline_region_blocks(rewriter, unit_op.getBody(),
-                                 mlir::Region::iterator(parent->end()));
+            // If we do not have any branching inside, we can just "inline"
+            // the op.
+            if (unit_op.getBody().hasOneBlock())
+            {
+                auto parent = unit_op->getParentRegion();
+                inline_region_blocks(rewriter, unit_op.getBody(),
+                                     mlir::Region::iterator(parent->end()));
 
-            // splice newly created translation unit block in the module
-            auto &unit_block = parent->back();
-            rewriter.mergeBlockBefore(&unit_block, unit_op, {});
+                // splice newly created translation unit block in the module
+                auto &unit_block = parent->back();
+                rewriter.mergeBlockBefore(&unit_block, unit_op, {});
 
-            rewriter.eraseOp(unit_op);
-            return mlir::success();
+                rewriter.eraseOp(unit_op);
+                return mlir::success();
+            }
+            return base::handle_multiblock(unit_op, ops, rewriter);
         }
 
         // TODO(conv): Turn on once this is completed.

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -748,8 +748,12 @@ namespace vast::conv::irstollvm
                 {
                     auto loc = original_arg.getLoc();
                     auto trg_type = convert(lvalue.getElementType());
-                    // `LvalueType` is really a pointer?
-                    return rewriter.create< mlir::LLVM::LoadOp >(loc, trg_type, conv_arg);
+                    // TODO(conv:irstollvm): First of all, sometimes we got lvalue argument
+                    //                       but the function expects the element type.
+                    //                       I am not 100% sure if the bitcast is correct
+                    //                       solution, but it solves the string literal
+                    //                       problem.
+                    return rewriter.create< mlir::LLVM::BitcastOp >(loc, trg_type, conv_arg);
                 }
                 return conv_arg;
             };

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -118,9 +118,11 @@ namespace vast::conv::irstollvm::ll_cf
             }
 
             auto op_entry_block = &*op.getBody().begin();
+            rewriter.setInsertionPointToEnd(head_block);
+            rewriter.create< mlir::LLVM::BrOp >(op.getLoc(), std::vector< mlir::Value >{},
+                                                op_entry_block);
             inline_region_blocks(rewriter, op.getBody(), mlir::Region::iterator(tail_block));
 
-            rewriter.mergeBlocks(op_entry_block, head_block, std::nullopt);
             rewriter.eraseOp(op);
             return mlir::success();
         }

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -131,6 +131,22 @@ namespace vast::conv::irstollvm::ll_cf
             rewriter.eraseOp(op);
             return mlir::success();
         }
+
+        mlir::LogicalResult handle_singleblock(
+                op_t op, adaptor_t ops,
+                mlir::ConversionPatternRewriter &rewriter) const
+        {
+            auto parent = op->getParentRegion();
+            inline_region_blocks(rewriter, op.getBody(),
+                                 mlir::Region::iterator(parent->end()));
+
+            // splice newly created translation unit block in the module
+            auto &unit_block = parent->back();
+            rewriter.mergeBlockBefore(&unit_block, op, {});
+
+            rewriter.eraseOp(op);
+            return mlir::success();
+        }
     };
 
     struct scope : scope_like< ll::Scope >

--- a/lib/vast/Conversion/FromHL/EmitLazyRegions.cpp
+++ b/lib/vast/Conversion/FromHL/EmitLazyRegions.cpp
@@ -106,7 +106,7 @@ namespace vast
             auto yielded_val = yield.op().getResult();
             auto select = rewriter.create< core::SelectOp >(
                     op.getLoc(),
-                    yielded_val.getType(), yielded_val,
+                    then_region.getType(), yielded_val,
                     then_region, else_region);
 
             rewriter.eraseOp(yield.op());

--- a/lib/vast/Conversion/FromHL/ToLLCF.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLCF.cpp
@@ -255,7 +255,6 @@ namespace vast::conv
             {
                 auto bld = rewriter_wrapper_t( rewriter );
 
-                //auto [ head, body, tail ] = extract_as_block( op, rewriter );
                 auto [ original_block, tail_block ] = split_at_op( op, rewriter );
                 VAST_CHECK( original_block && tail_block,
                             "Failed extraction of ifop into block." );

--- a/lib/vast/Conversion/FromHL/ToLLVars.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLVars.cpp
@@ -105,7 +105,12 @@ namespace vast
 
             mlir::ConversionTarget trg(mctx);
             trg.markUnknownOpDynamicallyLegal( [](auto) { return true; } );
-            trg.addIllegalOp< hl::VarDeclOp >();
+            trg.addDynamicallyLegalOp< hl::VarDeclOp >([&](hl::VarDeclOp op)
+            {
+                // TODO(conv): `!ast_node->isLocalVarDeclOrParam()` should maybe be ported
+                //             to the mlir op?
+                return mlir::isa< vast_module >(op->getParentOp());
+            });
 
             const auto &dl_analysis = this->getAnalysis< mlir::DataLayoutAnalysis >();
 

--- a/lib/vast/Dialect/HighLevel/Transforms/HLLowerTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/HLLowerTypes.cpp
@@ -106,6 +106,7 @@ namespace vast::hl
             addConversion([&](mlir::Type t) { return this->try_convert_floatlike(t); });
 
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
+            addConversion([&](hl::DecayedType t) { return this->convert_decayed_type(t); });
 
             // Use provided data layout to get the correct type.
             addConversion([&](hl::PointerType t) { return this->convert_ptr_type(t); });
@@ -226,6 +227,14 @@ namespace vast::hl
             return Maybe(t).keep_if(isFloatingType)
                            .and_then(make_float_type())
                            .take_wrapped< maybe_type_t >();
+        }
+
+        maybe_type_t convert_decayed_type(hl::DecayedType t)
+        {
+            return Maybe(t.getElementType())
+                .and_then(convert_type_to_type())
+                .unwrap()
+                .take_wrapped< maybe_type_t >();
         }
 
         maybe_type_t convert_ptr_type(hl::PointerType t)

--- a/lib/vast/Frontend/GenAction.cpp
+++ b/lib/vast/Frontend/GenAction.cpp
@@ -202,15 +202,6 @@ namespace vast::cc {
 
             auto setup_pipeline_and_execute = [&]
             {
-                // TODO: Is there any reason to ever not use vast?
-                switch (target)
-                {
-                    case target_dialect::high_level:
-                    case target_dialect::low_level:
-                    case target_dialect::llvm:
-                        compile_via_vast(mod.get(), mctx);
-                }
-
                 switch (target)
                 {
                     case target_dialect::high_level:
@@ -281,6 +272,8 @@ namespace vast::cc {
 
             auto mod  = generator->freeze();
             auto mctx = generator->take_context();
+
+            compile_via_vast(mod.get(), mctx.get());
 
             switch (action)
             {

--- a/lib/vast/Target/LLVMIR/Convert.cpp
+++ b/lib/vast/Target/LLVMIR/Convert.cpp
@@ -95,6 +95,13 @@ namespace vast::target::llvmir
         pm.addPass(createIRsToLLVMPass());
         pm.addPass(createCoreToLLVMPass());
 
+        pm.enableIRPrinting([](auto *, auto *) { return false; }, // before
+                            [](auto *, auto *) { return true; }, //after
+                            false, // module scope
+                            false, // after change
+                            true, // after failure
+                            llvm::errs());
+
         auto run_result = pm.run(op);
 
         VAST_CHECK(mlir::succeeded(run_result), "Some pass in prepare_module() failed");

--- a/lib/vast/Target/LLVMIR/Convert.cpp
+++ b/lib/vast/Target/LLVMIR/Convert.cpp
@@ -84,11 +84,16 @@ namespace vast::target::llvmir
         // TODO(target:llvmir): This should be refactored out as a pipeline so we
         //                      can run it from command line as well.
         // TODO(target:llvmir): Add missing passes.
-        pm.addPass(hl::createDCEPass());
         pm.addPass(hl::createHLLowerTypesPass());
+        pm.addPass(hl::createDCEPass());
+        pm.addPass(hl::createResolveTypeDefsPass());
         pm.addPass(createHLToLLCFPass());
         pm.addPass(createHLToLLVarsPass());
+        pm.addPass(createHLEmitLazyRegionsPass());
+        pm.addPass(createHLToLLGEPsPass());
+        pm.addPass(createHLStructsToLLVMPass());
         pm.addPass(createIRsToLLVMPass());
+        pm.addPass(createCoreToLLVMPass());
 
         auto run_result = pm.run(op);
 

--- a/test/vast/Compile/SingleSource/argc.c
+++ b/test/vast/Compile/SingleSource/argc.c
@@ -1,0 +1,7 @@
+// RUN: vast-front -o %t %s && (%t 1 3 4; test $? -eq 4)
+// RUN: vast-front -o %t %s && (%t; test $? -eq 1)
+
+int main(int argc, char **)
+{
+    return argc;
+}

--- a/test/vast/Compile/SingleSource/argv-a.c
+++ b/test/vast/Compile/SingleSource/argv-a.c
@@ -1,0 +1,14 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 121)
+// RUN: vast-front -o %t %s && (%t hello; test $? -eq 108)
+
+int third( const char *arr )
+{
+    return arr[ 2 ];
+}
+
+int main(int argc, char **argv)
+{
+    if ( argc <= 1 )
+        return 121;
+    return third( argv[ 1 ] );
+}

--- a/test/vast/Compile/SingleSource/global-a.c
+++ b/test/vast/Compile/SingleSource/global-a.c
@@ -1,0 +1,8 @@
+// RUN: vast-front -o %t %s && (%t 1 2 3; test $? -eq 5)
+
+int x = 5;
+
+int main(int argc, char **argv)
+{
+    return x;
+}

--- a/test/vast/Compile/SingleSource/label-a.c
+++ b/test/vast/Compile/SingleSource/label-a.c
@@ -1,0 +1,11 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 2)
+// RUN: vast-front -o %t %s && (%t 1 2 3; test $? -eq 5)
+
+int main(int argc, char **argv)
+{
+    int x = 1;
+begin:
+    x += argc;
+end:
+    return x;
+}

--- a/test/vast/Compile/SingleSource/putchar-a.c
+++ b/test/vast/Compile/SingleSource/putchar-a.c
@@ -1,0 +1,12 @@
+// RUN: vast-front -o %t %s && %t | FileCheck %s
+
+int putchar(int);
+
+int main()
+{
+    // CHECK: a
+    putchar('a');
+    putchar('\n');
+    // Workaround as `vast-front` and `vast-cc` behave differently.
+    return 0;
+}

--- a/test/vast/Compile/SingleSource/puts-a.c
+++ b/test/vast/Compile/SingleSource/puts-a.c
@@ -1,0 +1,17 @@
+// RUN: vast-front -o %t %s && %t hello | FileCheck %s
+
+int puts(const char *);
+
+int main(int argc, char **argv)
+{
+    if (argc < 1)
+    {
+        puts("Nothing");
+        return 0;
+    }
+
+    // CHECK: hello
+    puts(argv[1]);
+    // Workaround as `vast-front` and `vast-cc` behave differently.
+    return 0;
+}

--- a/test/vast/Compile/SingleSource/strlit-a.c
+++ b/test/vast/Compile/SingleSource/strlit-a.c
@@ -1,0 +1,11 @@
+// RUN: vast-front -o %t %s && (%t; test $? -eq 8)
+int third( const char *arr )
+{
+    return arr[ 2 ];
+}
+
+int main()
+{
+    // 'l' - 'd' = 108 - 100
+    return third("Hello")- third("ddd");
+}


### PR DESCRIPTION
Improve lowering to llvm
* string literals
* global variables (these are now also ignored by `hl-to-ll-vars` pass
* scope-like operations (scope, labels)

Fixes `vast-front` not running scope splicing when compiling.
`vast-front` should now print better debug info when some conversion pass fails.