### PR TITLE
Integrate splicing pass into `vast-cc`.

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -158,7 +158,7 @@ def HighLevel_WhileOp : ControlFlowOp< "while", [NoTerminator] >
     }
   }];
 
-  let regions = (region CondRegion:$condRegion, SizedRegion<1>:$bodyRegion);
+  let regions = (region CondRegion:$condRegion, AnyRegion:$bodyRegion);
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -226,7 +226,7 @@ def HighLevel_DoOp : ControlFlowOp< "do" >
     }
   }];
 
-  let regions = (region SizedRegion<1>:$bodyRegion, CondRegion:$condRegion);
+  let regions = (region AnyRegion:$bodyRegion, CondRegion:$condRegion);
 
   let skipDefaultBuilders = 1;
   let builders = [

--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -93,7 +93,7 @@ def HighLevel_IfOp : ControlFlowOp< "if" >
     bool hasElse() { return !getElseRegion().empty(); }
   }];
 
-  let assemblyFormat = [{ $condRegion `then` $thenRegion (`else` $elseRegion^)? attr-dict }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def HighLevel_CondOp : ControlFlowOp< "cond" >

--- a/test/vast/Conversion/Common/CoreToLLVM/binland-a.c
+++ b/test/vast/Conversion/Common/CoreToLLVM/binland-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
 
 int fun(int arg1, int arg2) {
     int res = arg1 && arg2;

--- a/test/vast/Conversion/Common/CoreToLLVM/binlor-a.c
+++ b/test/vast/Conversion/Common/CoreToLLVM/binlor-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
 
 int fun(int arg1, int arg2) {
     int res = arg1 || arg2;

--- a/test/vast/Conversion/Common/IRsToLLVM/add-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/add-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/addfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/addfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/array-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/array-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/array-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/array-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/divfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/divsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/divunsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divunsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 unsigned int fn(unsigned int arg0, unsigned int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/float-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/float-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/fn-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/fn-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn() {
 void fn()

--- a/test/vast/Conversion/Common/IRsToLLVM/fn-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/fn-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn() -> i32 {
 int fn()

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @count([[ARG:%arg[0-9]+]]: i32)
 void count(int arg)

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @count([[ARG:%arg[0-9]+]]: i32)
 void count(int arg)

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-c.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/mul-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/mul-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/mulfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/mulfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/not-float.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/not-float.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     float a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/not.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/not.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     int a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/remsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/remsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/remunsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/remunsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 unsigned int fn(unsigned int arg0, unsigned int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/sub-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/sub-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/subfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/subfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/FromHL/ToFunc/fn-decl-a.c
+++ b/test/vast/Conversion/FromHL/ToFunc/fn-decl-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-to-func | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-func | FileCheck %s
 
 // CHECK: func.func private @foo()
 void foo();

--- a/test/vast/Conversion/FromHL/ToFunc/fn-decl-b.c
+++ b/test/vast/Conversion/FromHL/ToFunc/fn-decl-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-func | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-func | FileCheck %s
 
 // CHECK: func.func private @foo()
 void foo();

--- a/test/vast/Conversion/FromHL/ToLLCF/for-a.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Conversion/FromHL/ToLLCF/for-b.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
 
 int fn()
 {

--- a/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
+++ b/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
 
 int main()
 {

--- a/test/vast/Dialect/Core/binlop-a.c
+++ b/test/vast/Dialect/Core/binlop-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-to-lazy-regions | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-lazy-regions | FileCheck %s
 
 void logic_assign_to_different_type() {
     // CHECK: [[L:%[0-9]+]] = core.lazy.op {

--- a/test/vast/Dialect/Core/binlop-b.c
+++ b/test/vast/Dialect/Core/binlop-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-to-lazy-regions | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-lazy-regions | FileCheck %s
 
 void logic_assign_to_different_type() {
     // CHECK: [[L:%[0-9]+]] = core.lazy.op {

--- a/test/vast/Dialect/HighLevel/branch-a.c
+++ b/test/vast/Dialect/HighLevel/branch-a.c
@@ -82,7 +82,6 @@ int branch_else_empty(int a, int b)
     // CHECK: hl.cond.yield [[V1]]
     if (a <= b) {
         // CHECK: } then {
-        // CHECK-NEXT: hl.scope
         // CHECK-NEXT: hl.var "c" : !hl.lvalue<!hl.int> =
         // CHECK: [[V2:%[0-9]+]] = hl.const #hl.integer<7> : !hl.int
         // CHECK: hl.value.yield [[V2]]

--- a/test/vast/Dialect/HighLevel/scope-a.c
+++ b/test/vast/Dialect/HighLevel/scope-a.c
@@ -1,4 +1,5 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes | FileCheck %s
+// RUN: vast-cc --from-source %s | FileCheck %s
+// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @test1 () -> !hl.int
 int test1()

--- a/test/vast/Transform/FromHL/LowerTypes/array-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/array-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK: hl.var "ai" : !hl.lvalue<memref<10xsi32>>
 int ai[10];

--- a/test/vast/Transform/FromHL/LowerTypes/array-b.c
+++ b/test/vast/Transform/FromHL/LowerTypes/array-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK: hl.var "a" sc_extern : !hl.lvalue<memref<?xsi32>>
 extern int a[];

--- a/test/vast/Transform/FromHL/LowerTypes/calls-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/calls-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 int constant() { return 7; }
 

--- a/test/vast/Transform/FromHL/LowerTypes/loop.c
+++ b/test/vast/Transform/FromHL/LowerTypes/loop.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 void loop_simple()
 {

--- a/test/vast/Transform/FromHL/LowerTypes/scope-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/scope-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @test1 () -> si32 attributes {sym_visibility = "private"} {
 int test1()

--- a/test/vast/Transform/FromHL/LowerTypes/strlit-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/strlit-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/struct-access-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/struct-access-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK:  hl.struct "X" : {
 // CHECK:    hl.field "member_x" : si32

--- a/test/vast/Transform/FromHL/LowerTypes/vars-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/vars-b.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/vars-c.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/StructsToLLVM/empty-a.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/empty-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", ()>
 struct X {};

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-a.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", (i32)>
 struct X { int x; };

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-b.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.type "Y"
 struct Y;

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-c.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 struct Y;
 

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-d.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-d.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", (i32, ptr<struct<"X">>)>
 struct X { int a; struct X *x; };

--- a/test/vast/Transform/FromHL/ToLLGEPs/member-access-a.c
+++ b/test/vast/Transform/FromHL/ToLLGEPs/member-access-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-geps | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-geps | FileCheck %s
 
 struct X { int a; };
 

--- a/test/vast/Transform/HL/DCE/for-a.c
+++ b/test/vast/Transform/HL/DCE/for-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Transform/HL/DCE/for-b.c
+++ b/test/vast/Transform/HL/DCE/for-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Transform/HL/DCE/if-a.c
+++ b/test/vast/Transform/HL/DCE/if-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
 // REQUIRES: return
 
 void fn()

--- a/test/vast/Transform/HL/ResolveTypedefs/func-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/func-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/test/vast/Transform/HL/ResolveTypedefs/struct-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/struct-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/test/vast/Transform/HL/ResolveTypedefs/var-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/var-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 


### PR DESCRIPTION
- Makes `vast-cc` behave as before the patch that added the splicing scope pass
- Adds option to disable the pass in `vast-cc` using `--disable-scope-splicing-pass`