### PR TITLE
Initial prototype of the `tower` component.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Makefile
 .cproject
 .project
 .settings
+.vast-repl.history
 cmake-build-debug
 cmake-build-release
 compile_commands.json

--- a/include/vast/CMakeLists.txt
+++ b/include/vast/CMakeLists.txt
@@ -9,6 +9,7 @@ if (VAST_BUILD_CONVERSIONS)
     add_subdirectory(Conversion)
 endif()
 
+add_subdirectory(Tower)
 add_subdirectory(Util)
 
 configure_file(Version.hpp.in Version.hpp @ONLY)

--- a/include/vast/Conversion/Passes.td
+++ b/include/vast/Conversion/Passes.td
@@ -73,7 +73,7 @@ def IRsToLLVM : Pass<"vast-irs-to-llvm", "mlir::ModuleOp"> {
 }
 
 def CoreToLLVM : Pass<"vast-core-to-llvm", "mlir::ModuleOp"> {
-  let summary = "VAST Core dialec to LLVM Dialect conversion";
+  let summary = "VAST Core dialect to LLVM Dialect conversion";
   let description = [{
     Converts core dialect operations to LLVM dialect.
     }];

--- a/include/vast/Tower/CMakeLists.txt
+++ b/include/vast/Tower/CMakeLists.txt
@@ -1,0 +1,1 @@
+# Copyright (c) 2022-present, Trail of Bits, Inc.

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -10,12 +10,6 @@ VAST_UNRELAX_WARNINGS
 
 namespace vast::tw {
 
-    struct handle_t
-    {
-        std::size_t id;
-        vast_module mod;
-    };
-
     struct default_loc_rewriter_t
     {
         static auto insert(mlir::Operation *op) -> void;
@@ -29,6 +23,12 @@ namespace vast::tw {
     struct tower
     {
         using loc_rewriter = loc_rewriter_t;
+
+        struct handle_t
+        {
+            std::size_t id;
+            vast_module mod;
+        };
 
         static auto get(mcontext_t &ctx, owning_module_ref mod)
             -> std::tuple< tower, handle_t > {

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -48,6 +48,13 @@ namespace vast::tower {
             return { id, mod };
         }
 
+        auto apply(handle_t handle, pipeline_t &pipeline) -> handle_t {
+            for (auto &pass : pipeline) {
+                handle = apply(handle, std::move(pass));
+            }
+            return handle;
+        }
+
       private:
         using module_storage_t = llvm::SmallVector< owning_module_ref, 2 >;
 

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -9,13 +9,15 @@ VAST_RELAX_WARNINGS
 VAST_UNRELAX_WARNINGS
 
 namespace vast::tw {
-    
-    struct handle_t {
+
+    struct handle_t
+    {
         std::size_t id;
         vast_module mod;
     };
 
-    struct default_loc_rewriter_t {
+    struct default_loc_rewriter_t
+    {
         static auto insert(mlir::Operation *op) -> void;
         static auto remove(mlir::Operation *op) -> void;
         static auto prev(mlir::Operation *op) -> mlir::Operation *;
@@ -24,7 +26,8 @@ namespace vast::tw {
     using pass_ptr_t = std::unique_ptr< mlir::Pass >;
 
     template< typename loc_rewriter_t >
-    struct tower {
+    struct tower
+    {
         using loc_rewriter = loc_rewriter_t;
 
         static auto get(mcontext_t &ctx, owning_module_ref mod)

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -46,7 +46,7 @@ namespace vast::tw {
             auto mod = _modules.back().get();
 
             if (mlir::failed(pm.run(mod))) {
-                VAST_UNREACHABLE("Some pass in apply() failed");
+                VAST_UNREACHABLE("error: some pass in apply() failed");
             }
 
             handle.mod.walk(loc_rewriter::remove);

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -45,7 +45,9 @@ namespace vast::tw {
             auto id  = _modules.size() - 1;
             auto mod = _modules.back().get();
 
-            VAST_CHECK(mlir::succeeded(pm.run(mod)), "Some pass in apply() failed");
+            if (mlir::failed(pm.run(mod))) {
+                VAST_UNREACHABLE("Some pass in apply() failed");
+            }
 
             handle.mod.walk(loc_rewriter::remove);
 

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -3,7 +3,10 @@
 #pragma once
 
 #include "vast/Util/Common.hpp"
-#include "mlir/Pass/PassManager.h"
+
+VAST_RELAX_WARNINGS
+#include <mlir/Pass/PassManager.h>
+VAST_UNRELAX_WARNINGS
 
 namespace vast::tower {
     struct handle_t {

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -24,12 +24,12 @@ namespace vast::tw {
     using pass_ptr_t = std::unique_ptr< mlir::Pass >;
 
     template< typename loc_rewriter_t >
-    struct manager_t {
+    struct tower {
         using loc_rewriter = loc_rewriter_t;
 
         static auto get(mcontext_t &ctx, owning_module_ref mod)
-            -> std::tuple< manager_t, handle_t > {
-            manager_t m(ctx, std::move(mod));
+            -> std::tuple< tower, handle_t > {
+            tower m(ctx, std::move(mod));
             handle_t h{ .id = 0, .mod = m._modules[0].get() };
             return { std::move(m), h };
         }
@@ -61,11 +61,11 @@ namespace vast::tw {
         mcontext_t &_ctx;
         module_storage_t _modules;
 
-        manager_t(mcontext_t &ctx, owning_module_ref mod) : _ctx(ctx) {
+        tower(mcontext_t &ctx, owning_module_ref mod) : _ctx(ctx) {
             _modules.emplace_back(std::move(mod));
         }
     };
 
-    using default_manager_t = manager_t< default_loc_rewriter_t >;
+    using default_tower = tower< default_loc_rewriter_t >;
 
 } // namespace vast::tw

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -1,17 +1,17 @@
 // Copyright (c) 2022-present, Trail of Bits, Inc.
 
-#include "vast/Util/Common.hpp"
+#pragma once
 
-namespace mlir
-{
-    class Pass;
-}
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Pass/Pass.h"
+#include "vast/Util/Common.hpp"
 
 namespace vast::tower
 {
     struct handle_t {
         std::size_t id;
         vast_module mod;
+        mlir::IRMapping prev;
     };
 
     using pass_ptr_t = std::unique_ptr< mlir::Pass >;

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -53,7 +53,7 @@ namespace vast::tw {
         }
 
         auto apply(handle_t handle, pass_ptr_t pass) -> handle_t {
-            mlir::PassManager pm(&_ctx);
+            mlir::PassManager pm(_ctx);
             pm.addPass(std::move(pass));
             return apply(handle, pm);
         }
@@ -61,10 +61,10 @@ namespace vast::tw {
       private:
         using module_storage_t = llvm::SmallVector< owning_module_ref, 2 >;
 
-        mcontext_t &_ctx;
+        mcontext_t *_ctx;
         module_storage_t _modules;
 
-        tower(mcontext_t &ctx, owning_module_ref mod) : _ctx(ctx) {
+        tower(mcontext_t &ctx, owning_module_ref mod) : _ctx(&ctx) {
             _modules.emplace_back(std::move(mod));
         }
     };

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -32,9 +32,9 @@ namespace vast::tw {
 
         static auto get(mcontext_t &ctx, owning_module_ref mod)
             -> std::tuple< tower, handle_t > {
-            tower m(ctx, std::move(mod));
-            handle_t h{ .id = 0, .mod = m._modules[0].get() };
-            return { std::move(m), h };
+            tower t(ctx, std::move(mod));
+            handle_t h{ .id = 0, .mod = t._modules[0].get() };
+            return { std::move(t), h };
         }
 
         auto apply(handle_t handle, mlir::PassManager &pm) -> handle_t {
@@ -57,6 +57,8 @@ namespace vast::tw {
             pm.addPass(std::move(pass));
             return apply(handle, pm);
         }
+
+        auto top() -> handle_t { return { _modules.size(), _modules.back().get() }; }
 
       private:
         using module_storage_t = llvm::SmallVector< owning_module_ref, 2 >;

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -8,7 +8,8 @@ VAST_RELAX_WARNINGS
 #include <mlir/Pass/PassManager.h>
 VAST_UNRELAX_WARNINGS
 
-namespace vast::tower {
+namespace vast::tw {
+    
     struct handle_t {
         std::size_t id;
         vast_module mod;
@@ -66,4 +67,5 @@ namespace vast::tower {
     };
 
     using default_manager_t = manager_t< default_loc_rewriter_t >;
-} // namespace vast::tower
+
+} // namespace vast::tw

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -2,11 +2,10 @@
 
 #pragma once
 
-#include "mlir/Pass/PassManager.h"
 #include "vast/Util/Common.hpp"
+#include "mlir/Pass/PassManager.h"
 
-namespace vast::tower
-{
+namespace vast::tower {
     struct handle_t {
         std::size_t id;
         vast_module mod;
@@ -20,10 +19,12 @@ namespace vast::tower
 
     using pass_ptr_t = std::unique_ptr< mlir::Pass >;
 
+    using pipeline_t = std::vector< pass_ptr_t >;
+
     template< typename loc_rewriter_t >
     struct manager_t {
         using loc_rewriter = loc_rewriter_t;
-        
+
         static auto get(mcontext_t &ctx, owning_module_ref mod)
             -> std::tuple< manager_t, handle_t > {
             manager_t m(ctx, std::move(mod));
@@ -32,7 +33,7 @@ namespace vast::tower
         }
 
         auto apply(handle_t handle, pass_ptr_t pass) -> handle_t {
-            handle.mod.walk(loc_rewriter_t::insert);
+            handle.mod.walk(loc_rewriter::insert);
 
             _modules.emplace_back(mlir::cast< vast_module >(handle.mod->clone()));
 
@@ -53,11 +54,10 @@ namespace vast::tower
         mcontext_t &_ctx;
         module_storage_t _modules;
 
-        manager_t(mcontext_t &ctx, owning_module_ref mod)
-            : _ctx(ctx) {
+        manager_t(mcontext_t &ctx, owning_module_ref mod) : _ctx(ctx) {
             _modules.emplace_back(std::move(mod));
         }
     };
 
-    using default_manager_t = manager_t<default_loc_rewriter_t>;
+    using default_manager_t = manager_t< default_loc_rewriter_t >;
 } // namespace vast::tower

--- a/include/vast/Tower/Tower.hpp
+++ b/include/vast/Tower/Tower.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#include "vast/Util/Common.hpp"
+
+namespace mlir
+{
+    class Pass;
+}
+
+namespace vast::tower
+{
+    struct handle_t {
+        std::size_t id;
+        vast_module mod;
+    };
+
+    using pass_ptr_t = std::unique_ptr< mlir::Pass >;
+
+    struct manager_t {
+        static auto get(mcontext_t &ctx, owning_module_ref mod)
+            -> std::tuple< manager_t, handle_t > {
+            manager_t m(ctx, std::move(mod));
+            handle_t h{ .id = 0, .mod = m._modules[0].get() };
+            return { std::move(m), h };
+        }
+
+        auto apply(handle_t handle, pass_ptr_t pass) -> handle_t;
+
+      private:
+        using module_storage_t = llvm::SmallVector< owning_module_ref, 2 >;
+
+        mcontext_t &_ctx;
+        module_storage_t _modules;
+
+        manager_t(mcontext_t &ctx, owning_module_ref mod)
+            : _ctx(ctx) {
+            _modules.emplace_back(std::move(mod));
+        }
+    };
+} // namespace vast::tower

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -220,8 +220,8 @@ namespace vast::repl
         //
         // apply command
         //
-        struct apply : base {
-            static constexpr string_ref name() { return "apply"; }
+        struct raise : base {
+            static constexpr string_ref name() { return "raise"; }
 
             static constexpr inline char pass_param[] = "pass_name";
 
@@ -231,15 +231,15 @@ namespace vast::repl
 
             using params_storage = command_params::as_tuple;
 
-            apply(const params_storage &params) : params(params) {}
-            apply(params_storage &&params) : params(std::move(params)) {}
+            raise(const params_storage &params) : params(params) {}
+            raise(params_storage &&params) : params(std::move(params)) {}
 
             void run(state_t &state) const override;
 
             params_storage params;
         };
 
-        using command_list = util::type_list< exit, help, load, show, meta, apply >;
+        using command_list = util::type_list< exit, help, load, show, meta, raise >;
 
     } // namespace command
 

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -217,7 +217,29 @@ namespace vast::repl
             params_storage params;
         };
 
-        using command_list = util::type_list< exit, help, load, show, meta >;
+        //
+        // apply command
+        //
+        struct apply : base {
+            static constexpr string_ref name() { return "apply"; }
+
+            static constexpr inline char pass_param[] = "pass_name";
+
+            using command_params = util::type_list<
+                named_param< pass_param, string_param >
+            >;
+
+            using params_storage = command_params::as_tuple;
+
+            apply(const params_storage &params) : params(params) {}
+            apply(params_storage &&params) : params(std::move(params)) {}
+
+            void run(state_t &state) const override;
+
+            params_storage params;
+        };
+
+        using command_list = util::type_list< exit, help, load, show, meta, apply >;
 
     } // namespace command
 

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -223,11 +223,10 @@ namespace vast::repl
         struct raise : base {
             static constexpr string_ref name() { return "raise"; }
 
-            static constexpr inline char pass_param[] = "pass_name";
+            static constexpr inline char pipeline_param[] = "pipeline_name";
 
-            using command_params = util::type_list<
-                named_param< pass_param, string_param >
-            >;
+            using command_params =
+                util::type_list< named_param< pipeline_param, string_param > >;
 
             using params_storage = command_params::as_tuple;
 

--- a/include/vast/repl/state.hpp
+++ b/include/vast/repl/state.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "vast/Tower/Tower.hpp"
 #include "vast/repl/common.hpp"
 
 namespace vast::repl {
@@ -14,7 +15,7 @@ namespace vast::repl {
         std::optional< std::string > source;
 
         mcontext_t &ctx;
-        owning_module_ref mod;
+        std::optional< tw::default_tower > tower;
     };
 
 } // namespace vast::repl

--- a/lib/vast/CMakeLists.txt
+++ b/lib/vast/CMakeLists.txt
@@ -15,4 +15,5 @@ if (VAST_BUILD_FRONTEND)
     add_subdirectory(CC1)
 endif()
 
+add_subdirectory(Tower)
 add_subdirectory(Util)

--- a/lib/vast/Tower/CMakeLists.txt
+++ b/lib/vast/Tower/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_library( vast_tower STATIC
-  Tower.cpp
-)
+# Copyright (c) 2022-present, Trail of Bits, Inc.
 
-add_library(vast::tower ALIAS vast_tower)
+add_vast_library(Tower
+    Tower.cpp
+)

--- a/lib/vast/Tower/CMakeLists.txt
+++ b/lib/vast/Tower/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library( vast_tower STATIC
+  Tower.cpp
+)
+
+add_library(vast::tower ALIAS vast_tower)

--- a/lib/vast/Tower/Tower.cpp
+++ b/lib/vast/Tower/Tower.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#include "vast/Tower/Tower.hpp"
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace vast::tower
+{
+    auto manager_t::apply(handle_t handle, pass_ptr_t pass) -> handle_t {
+        _modules.emplace_back(mlir::cast< vast_module >(handle.mod->clone()));
+
+        auto id  = _modules.size() - 1;
+        auto mod = _modules.back().get();
+
+        mlir::PassManager pm(&_ctx);
+        pm.addPass(std::move(pass));
+
+        auto run_result = pm.run(_modules.back().get());
+        VAST_CHECK(mlir::succeeded(run_result), "Some pass in apply() failed");
+
+        return { id, mod };
+    }
+} // namespace vast::tower

--- a/lib/vast/Tower/Tower.cpp
+++ b/lib/vast/Tower/Tower.cpp
@@ -2,8 +2,7 @@
 
 #include "vast/Tower/Tower.hpp"
 
-namespace vast::tower
-{
+namespace vast::tower {
     auto default_loc_rewriter_t::insert(mlir::Operation *op) -> void {
         auto ctx = op->getContext();
         auto ol  = mlir::OpaqueLoc::get< mlir::Operation  *>(op, ctx);

--- a/lib/vast/Tower/Tower.cpp
+++ b/lib/vast/Tower/Tower.cpp
@@ -2,12 +2,31 @@
 
 #include "vast/Tower/Tower.hpp"
 
-#include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "vast/Util/Common.hpp"
 
 namespace vast::tower
 {
+    static auto insert_op_ptr_loc(mlir::Operation *op) -> void {
+        auto ctx = op->getContext();
+        auto ol  = mlir::OpaqueLoc::get< mlir::Operation  *>(op, ctx);
+        op->setLoc(mlir::FusedLoc::get({ op->getLoc() }, ol, ctx));
+    }
+
+    static auto get_op_ptr_loc(mlir::Operation *op) -> mlir::Operation * {
+        auto fl = mlir::cast< mlir::FusedLoc >(op->getLoc());
+        auto ol = mlir::cast< mlir::OpaqueLoc >(fl.getMetadata());
+        return mlir::OpaqueLoc::getUnderlyingLocation< mlir::Operation * >(ol);
+    }
+
+    static auto remove_op_ptr_loc(mlir::Operation *op) -> void {
+        auto fl = mlir::cast< mlir::FusedLoc >(op->getLoc());
+        op->setLoc(fl.getLocations().front());
+    }
+
     auto manager_t::apply(handle_t handle, pass_ptr_t pass) -> handle_t {
+        handle.mod.walk(insert_op_ptr_loc);
+
         _modules.emplace_back(mlir::cast< vast_module >(handle.mod->clone()));
 
         auto id  = _modules.size() - 1;
@@ -16,9 +35,15 @@ namespace vast::tower
         mlir::PassManager pm(&_ctx);
         pm.addPass(std::move(pass));
 
-        auto run_result = pm.run(_modules.back().get());
-        VAST_CHECK(mlir::succeeded(run_result), "Some pass in apply() failed");
+        VAST_CHECK(mlir::succeeded(pm.run(mod)), "Some pass in apply() failed");
 
-        return { id, mod };
+        mlir::IRMapping prev;
+
+        mod.walk([&prev](mlir::Operation *op) {
+            prev.map(op, get_op_ptr_loc(op));
+            remove_op_ptr_loc(op);
+        });
+
+        return { id, mod, prev };
     }
 } // namespace vast::tower

--- a/lib/vast/Tower/Tower.cpp
+++ b/lib/vast/Tower/Tower.cpp
@@ -2,48 +2,22 @@
 
 #include "vast/Tower/Tower.hpp"
 
-#include "mlir/Pass/PassManager.h"
-#include "vast/Util/Common.hpp"
-
 namespace vast::tower
 {
-    static auto insert_op_ptr_loc(mlir::Operation *op) -> void {
+    auto default_loc_rewriter_t::insert(mlir::Operation *op) -> void {
         auto ctx = op->getContext();
         auto ol  = mlir::OpaqueLoc::get< mlir::Operation  *>(op, ctx);
         op->setLoc(mlir::FusedLoc::get({ op->getLoc() }, ol, ctx));
     }
 
-    static auto get_op_ptr_loc(mlir::Operation *op) -> mlir::Operation * {
-        auto fl = mlir::cast< mlir::FusedLoc >(op->getLoc());
-        auto ol = mlir::cast< mlir::OpaqueLoc >(fl.getMetadata());
-        return mlir::OpaqueLoc::getUnderlyingLocation< mlir::Operation * >(ol);
-    }
-
-    static auto remove_op_ptr_loc(mlir::Operation *op) -> void {
+    auto default_loc_rewriter_t::remove(mlir::Operation *op) -> void {
         auto fl = mlir::cast< mlir::FusedLoc >(op->getLoc());
         op->setLoc(fl.getLocations().front());
     }
 
-    auto manager_t::apply(handle_t handle, pass_ptr_t pass) -> handle_t {
-        handle.mod.walk(insert_op_ptr_loc);
-
-        _modules.emplace_back(mlir::cast< vast_module >(handle.mod->clone()));
-
-        auto id  = _modules.size() - 1;
-        auto mod = _modules.back().get();
-
-        mlir::PassManager pm(&_ctx);
-        pm.addPass(std::move(pass));
-
-        VAST_CHECK(mlir::succeeded(pm.run(mod)), "Some pass in apply() failed");
-
-        mlir::IRMapping prev;
-
-        mod.walk([&prev](mlir::Operation *op) {
-            prev.map(op, get_op_ptr_loc(op));
-            remove_op_ptr_loc(op);
-        });
-
-        return { id, mod, prev };
+    auto default_loc_rewriter_t::prev(mlir::Operation *op) -> mlir::Operation * {
+        auto fl = mlir::cast< mlir::FusedLoc >(op->getLoc());
+        auto ol = mlir::cast< mlir::OpaqueLoc >(fl.getMetadata());
+        return mlir::OpaqueLoc::getUnderlyingLocation< mlir::Operation * >(ol);
     }
 } // namespace vast::tower

--- a/lib/vast/Tower/Tower.cpp
+++ b/lib/vast/Tower/Tower.cpp
@@ -2,7 +2,7 @@
 
 #include "vast/Tower/Tower.hpp"
 
-namespace vast::tower {
+namespace vast::tw {
     auto default_loc_rewriter_t::insert(mlir::Operation *op) -> void {
         auto ctx = op->getContext();
         auto ol  = mlir::OpaqueLoc::get< mlir::Operation  *>(op, ctx);
@@ -19,4 +19,4 @@ namespace vast::tower {
         auto ol = mlir::cast< mlir::OpaqueLoc >(fl.getMetadata());
         return mlir::OpaqueLoc::getUnderlyingLocation< mlir::Operation * >(ol);
     }
-} // namespace vast::tower
+} // namespace vast::tw

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -48,7 +48,7 @@ config.test_exec_root = os.path.join(config.vast_obj_root, 'test')
 config.vast_test_util = os.path.join(config.vast_src_root, 'test/utils')
 config.vast_tools_dir = os.path.join(config.vast_obj_root, 'tools')
 
-tools = [ 'vast-opt', 'vast-cc', 'vast-query', 'vast-front' ]
+tools = [ 'vast-opt', 'vast-cc', 'vast-query', 'vast-front', 'vast-repl' ]
 
 if 'BUILD_TYPE' in lit_config.params:
     config.vast_build_type = lit_config.params['BUILD_TYPE']

--- a/test/repl/apply.c
+++ b/test/repl/apply.c
@@ -1,0 +1,3 @@
+// RUN: printf "load %s\n apply\n exit" | vast-repl | FileCheck %s
+// CHECK: ll.return %0 : !hl.int
+int main(void) { return 0; }

--- a/test/repl/apply.c
+++ b/test/repl/apply.c
@@ -1,3 +1,0 @@
-// RUN: printf "load %s\n apply\n exit" | vast-repl | FileCheck %s
-// CHECK: ll.return %0 : !hl.int
-int main(void) { return 0; }

--- a/test/repl/raise.c
+++ b/test/repl/raise.c
@@ -1,3 +1,3 @@
-// RUN: printf "load %s\n raise\n exit" | vast-repl | FileCheck %s
+// RUN: printf "load %s\n raise vast-hl-to-ll-cf\n exit" | vast-repl | FileCheck %s
 // CHECK: ll.return %0 : !hl.int
 int main(void) { return 0; }

--- a/test/repl/raise.c
+++ b/test/repl/raise.c
@@ -1,3 +1,3 @@
-// RUN: printf "load %s\n raise vast-hl-to-ll-cf\n exit" | vast-repl | FileCheck %s
+// RUN: printf "load %s\n raise vast-hl-to-ll-cf\n show module\n exit" | vast-repl | FileCheck %s
 // CHECK: ll.return %0 : !hl.int
 int main(void) { return 0; }

--- a/test/repl/raise.c
+++ b/test/repl/raise.c
@@ -1,0 +1,3 @@
+// RUN: printf "load %s\n raise\n exit" | vast-repl | FileCheck %s
+// CHECK: ll.return %0 : !hl.int
+int main(void) { return 0; }

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -124,7 +124,7 @@ namespace vast::repl::cmd {
     void raise::run(state_t &state) const {
         check_and_emit_module(state);
 
-        auto [tm, th] = tower::default_manager_t::get(state.ctx, std::move(state.mod));
+        auto [tm, th] = tw::default_manager_t::get(state.ctx, std::move(state.mod));
 
         std::string pipeline = get_param< pipeline_param >(params).value;
         llvm::SmallVector< llvm::StringRef, 2 > passes;

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -121,7 +121,7 @@ namespace vast::repl::cmd {
     //
     // apply command
     //
-    void apply::run(state_t &state) const {
+    void raise::run(state_t &state) const {
         check_and_emit_module(state);
 
         auto [tm, th] = tower::default_manager_t::get(state.ctx, std::move(state.mod));

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -2,9 +2,9 @@
 
 #include "vast/repl/command.hpp"
 
-#include "mlir/Pass/PassManager.h"
 #include "vast/Conversion/Passes.hpp"
 #include "vast/repl/common.hpp"
+#include "vast/Tower/Tower.hpp"
 
 namespace vast::repl::cmd {
 
@@ -124,17 +124,9 @@ namespace vast::repl::cmd {
     void apply::run(state_t &state) const {
         check_and_emit_module(state);
 
-        mlir::PassManager pm(&state.ctx);
+        auto [tm, th] = tower::manager_t::get(state.ctx, std::move(state.mod));
 
-        // auto pp = get_param< pass_param >(params);
-       
-        pm.addPass(vast::createHLToLLCFPass());
-
-        auto run_result = pm.run(state.mod.get());
-
-        VAST_CHECK(mlir::succeeded(run_result), "Some pass in apply() failed");
-
-        llvm::outs() << state.mod.get() << "\n";
+        llvm::outs() << tm.apply(th, createHLToLLCFPass()).mod << "\n";
     }
 
 } // namespace vast::repl::cmd

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -124,7 +124,7 @@ namespace vast::repl::cmd {
     void apply::run(state_t &state) const {
         check_and_emit_module(state);
 
-        auto [tm, th] = tower::manager_t::get(state.ctx, std::move(state.mod));
+        auto [tm, th] = tower::default_manager_t::get(state.ctx, std::move(state.mod));
 
         llvm::outs() << tm.apply(th, createHLToLLCFPass()).mod << "\n";
     }

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -122,7 +122,7 @@ namespace vast::repl::cmd {
     }
 
     //
-    // apply command
+    // raise command
     //
     void raise::run(state_t &state) const {
         check_and_emit_module(state);
@@ -139,8 +139,6 @@ namespace vast::repl::cmd {
             }
             th = state.tower->apply(th, pm);
         }
-        
-        llvm::outs() << th.mod << '\n';
     }
 
 } // namespace vast::repl::cmd

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -124,7 +124,7 @@ namespace vast::repl::cmd {
     void raise::run(state_t &state) const {
         check_and_emit_module(state);
 
-        auto [tm, th] = tw::default_manager_t::get(state.ctx, std::move(state.mod));
+        auto [tm, th] = tw::default_tower::get(state.ctx, std::move(state.mod));
 
         std::string pipeline = get_param< pipeline_param >(params).value;
         llvm::SmallVector< llvm::StringRef, 2 > passes;

--- a/tools/vast-repl/vast-repl.cpp
+++ b/tools/vast-repl/vast-repl.cpp
@@ -83,7 +83,6 @@ namespace vast::repl
 int main(int argc, char **argv) try {
     mlir::registerAllPasses();
     // Register VAST passes here
-    vast::hl::registerPasses();
     vast::registerConversionPasses();
 
     mlir::DialectRegistry registry;

--- a/tools/vast-repl/vast-repl.cpp
+++ b/tools/vast-repl/vast-repl.cpp
@@ -11,11 +11,13 @@ VAST_RELAX_WARNINGS
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "vast/repl/linenoise.hpp"
 VAST_UNRELAX_WARNINGS
 
 #include "vast/Dialect/Dialects.hpp"
 #include "vast/Dialect/HighLevel/Passes.hpp"
+#include "vast/Conversion/Passes.hpp"
 #include "vast/Util/Common.hpp"
 #include "vast/repl/cli.hpp"
 #include "vast/repl/command.hpp"
@@ -79,9 +81,18 @@ namespace vast::repl
 } // namespace vast::repl
 
 int main(int argc, char **argv) try {
+    mlir::registerAllPasses();
+    // Register VAST passes here
+    vast::hl::registerPasses();
+    vast::registerConversionPasses();
+
     mlir::DialectRegistry registry;
     vast::registerAllDialects(registry);
     mlir::registerAllDialects(registry);
+
+    // register conversions
+    mlir::registerAllToLLVMIRTranslations(registry);
+    vast::hl::registerHLToLLVMIR(registry);
 
     args_t args = load_args(argc, argv);
 


### PR DESCRIPTION
The `tower` component provides an API for applying passes while maintaining a history with provenance information for every operation. This is done by propagating `mlir::Operation *` of the old operation to the new operation via `mlir::FusedLoc` and `mlir::OpaqueLoc`.