### PR TITLE
Turn off unsupported gcc.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   build_linux:
     strategy:
       matrix:
-        compiler: [gcc, clang-16]
+        compiler: [clang-16]
     runs-on: ubuntu-22.04
     timeout-minutes: 32
 


### PR DESCRIPTION
Due to #185 we are not able to test GCC build at the moment.