### PR TITLE
FunDeclRef lazy emit of forward declarations

### DIFF
--- a/include/vast/Translation/CodeGenStmtVisitor.hpp
+++ b/include/vast/Translation/CodeGenStmtVisitor.hpp
@@ -577,7 +577,12 @@ namespace vast::cg {
         Operation* VisitFunctionDeclRefExpr(const clang::DeclRefExpr *expr) {
             auto decl = clang::cast< clang::FunctionDecl >( expr->getDecl()->getUnderlyingDecl() );
             auto mangled = context().get_mangled_name(decl);
-            auto fn = context().lookup_function(mangled);
+            auto fn      = context().lookup_function(mangled, false);
+            if (!fn) {
+                InsertionGuard guard(builder());
+                set_insertion_point_to_start(&context().getBodyRegion());
+                fn = mlir::cast< hl::FuncOp >(visit(decl));
+            }
             auto rty = getLValueReturnType(expr);
 
             return make< hl::FuncRefOp >(meta_location(expr), rty, mlir::SymbolRefAttr::get(fn));

--- a/test/vast/Dialect/HighLevel/fun-ref-a.c
+++ b/test/vast/Dialect/HighLevel/fun-ref-a.c
@@ -1,0 +1,15 @@
+// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+
+void fun(void);
+
+void fun2(void (*f)(void)){ f(); }
+
+// CHECK: {{.*hl.func .* @fun.*}}
+// CHECK: {{.*hl.func .* @main.*}}
+int main(void) {
+    //CHECK: {{.*hl.funcref @fun.*}}
+    fun2(&fun);
+    return 0;
+}
+
+void fun(void) {}


### PR DESCRIPTION
Make FunDeclRefExpr visitor lazily emit forward declared functions.