### PR TITLE
Add header with some hl utilities

### DIFF
--- a/include/vast/Conversion/Common/Rewriter.hpp
+++ b/include/vast/Conversion/Common/Rewriter.hpp
@@ -10,6 +10,11 @@ VAST_UNRELAX_WARNINGS
 
 #include "vast/Util/Common.hpp"
 
+#include <gap/core/generator.hpp>
+
+#include <ranges>
+#include <vector>
+
 namespace vast::conv
 {
     template< typename impl_t >
@@ -61,6 +66,24 @@ namespace vast::conv
             auto g = guard();
             bld.setInsertionPointToEnd( block );
             return bld.template create< Trg >( std::forward< Args >( args ) ... );
+        }
+
+        template< typename T >
+        void safe_erase( gap::generator< T > &&range )
+        {
+            // It is highly probable there is an ongoing iteration
+            // inside the generator, therefore we first freeze the value.
+            // TODO(c++23): Refactor.
+            std::vector< T > to_erase;
+            std::ranges::move(range.begin(), range.end(), std::back_inserter(to_erase));
+            return erase( to_erase );
+        }
+
+        template< typename O >
+        void erase( const std::vector< O > &to_erase )
+        {
+            for ( auto o : to_erase )
+                bld.eraseOp( o );
         }
     };
 

--- a/include/vast/Conversion/Common/Rewriter.hpp
+++ b/include/vast/Conversion/Common/Rewriter.hpp
@@ -75,7 +75,7 @@ namespace vast::conv
             // inside the generator, therefore we first freeze the value.
             // TODO(c++23): Refactor.
             std::vector< T > to_erase;
-            std::ranges::move(range.begin(), range.end(), std::back_inserter(to_erase));
+            std::ranges::move(range, std::back_inserter(to_erase));
             return erase( to_erase );
         }
 

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.hpp
@@ -136,6 +136,12 @@ namespace vast::hl
         return type;
     }
 
+    // Usually record types are wrapped in `elaborated` or `lvalue` - this helper
+    // takes care of traversing them.
+    // Returns no value if the type is not a record type.
+    // TODO(hl): Invent an interface/trait?
+    auto name_of_record(mlir_type t) -> std::optional< std::string >;
+
     bool isBoolType(mlir_type type);
     bool isIntegerType(mlir_type type);
     bool isFloatingType(mlir_type type);

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.hpp
@@ -38,6 +38,9 @@ namespace vast::hl
     mlir::Type strip_elaborated(mlir::Type);
     mlir::Type strip_elaborated(mlir::Value);
 
+    mlir::Type strip_value_category(mlir::Type);
+    mlir::Type strip_value_category(mlir::Value);
+
 } // namespace vast::hl
 
 #define GET_TYPEDEF_CLASSES

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -64,6 +64,17 @@ namespace vast::hl
         return {};
     }
 
+    static inline auto type_decls(hl::StructDeclOp struct_decl)
+        -> gap::generator< hl::TypeDeclOp >
+    {
+        auto module_op = struct_decl->getParentOfType< vast_module >();
+        VAST_ASSERT(module_op);
+
+        for (auto decl : get_nested< hl::TypeDeclOp >(module_op))
+            if (decl.getName() == struct_decl.getName())
+                co_yield decl;
+    }
+
     static inline type_generator field_types(mlir::Type t, vast_module mod)
     {
         auto def = definition_of(t, mod);
@@ -90,5 +101,17 @@ namespace vast::hl
                                                                as_val,
                                                                field_def.getName());
         }
+    }
+
+    std::optional< std::size_t > field_idx(auto name, auto struct_decl)
+    {
+        std::size_t out = 0;
+        for (auto field_def : field_defs(struct_decl))
+        {
+            if (field_def.getName() == name)
+                return { out };
+            ++out;
+        }
+        return {};
     }
 }

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
+#include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
+#include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
+#include "vast/Dialect/HighLevel/HighLevelOps.hpp"
+#include "vast/Interfaces/SymbolInterface.hpp"
+
+#include "gap/core/generator.hpp"
+
+/* Contains common utilities often needed to work with hl dialect. */
+
+namespace vast::hl
+{
+    template< typename T >
+    gap::generator< T > get_nested(vast_module mod)
+    {
+        auto body = mod.getBody();
+        if (!body)
+            co_return;
+
+        for (auto &op : *body)
+            if (auto casted = mlir::dyn_cast< T >(op))
+                co_yield casted;
+    }
+
+    using type_generator = gap::generator< mlir::Type >;
+
+    type_generator field_types(hl::StructDeclOp op)
+    {
+        if (op.getFields().empty())
+            co_return;
+
+        for (auto &maybe_field : op.getOps())
+        {
+            // TODO(hl): So normally only `hl.field` should be present here,
+            //           but currently also re-declarations of nested structures
+            //           are here - add hard fail if the conversion fails in the future.
+            if (mlir::isa< hl::StructDeclOp >(maybe_field))
+                continue;
+
+            auto field_decl = mlir::dyn_cast< hl::FieldDeclOp >(maybe_field);
+            VAST_ASSERT(field_decl);
+            co_yield field_decl.getType();
+        }
+    }
+
+    type_generator field_types(mlir::Type t, vast_module mod)
+    {
+        auto type_name = hl::name_of_record(t);
+        VAST_ASSERT(type_name);
+        for (auto op : get_nested< hl::StructDeclOp >(mod))
+            if (op.getName() == *type_name)
+                return field_types(op);
+        VAST_UNREACHABLE("Was not able to fetch definition of type: {0}", t);
+    }
+}

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -17,7 +17,7 @@
 namespace vast::hl
 {
     template< typename T >
-    gap::generator< T > get_nested(vast_module mod)
+    gap::generator< T > top_level_ops(vast_module module_op)
     {
         auto body = mod.getBody();
         if (!body)
@@ -58,7 +58,7 @@ namespace vast::hl
     {
         auto type_name = hl::name_of_record(t);
         VAST_CHECK(type_name, "hl::name_of_record failed with {0}", t);
-        for (auto op : get_nested< hl::StructDeclOp >(mod))
+        for (auto op : top_level_ops< hl::StructDeclOp >(module_op))
             if (op.getName() == *type_name)
                 return { op };
         return {};
@@ -70,7 +70,7 @@ namespace vast::hl
         auto module_op = struct_decl->getParentOfType< vast_module >();
         VAST_ASSERT(module_op);
 
-        for (auto decl : get_nested< hl::TypeDeclOp >(module_op))
+        for (auto decl : top_level_ops< hl::TypeDeclOp >(module_op))
             if (decl.getName() == struct_decl.getName())
                 co_yield decl;
     }

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -28,7 +28,7 @@ namespace vast::hl
 
     using type_generator = gap::generator< mlir::Type >;
 
-    type_generator field_types(hl::StructDeclOp op)
+    static inline type_generator field_types(hl::StructDeclOp op)
     {
         if (op.getFields().empty())
             co_return;
@@ -47,7 +47,7 @@ namespace vast::hl
         }
     }
 
-    type_generator field_types(mlir::Type t, vast_module mod)
+    static inline type_generator field_types(mlir::Type t, vast_module mod)
     {
         auto type_name = hl::name_of_record(t);
         VAST_ASSERT(type_name);

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -57,7 +57,7 @@ namespace vast::hl
         -> std::optional< hl::StructDeclOp >
     {
         auto type_name = hl::name_of_record(t);
-        VAST_ASSERT(type_name);
+        VAST_CHECK(type_name, "hl::name_of_record failed with {0}", t);
         for (auto op : get_nested< hl::StructDeclOp >(mod))
             if (op.getName() == *type_name)
                 return { op };

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -53,7 +53,7 @@ namespace vast::hl
             co_yield def.getType();
     }
 
-    static inline auto definiton_of(mlir::Type t, vast_module mod)
+    static inline auto definition_of(mlir::Type t, vast_module mod)
         -> std::optional< hl::StructDeclOp >
     {
         auto type_name = hl::name_of_record(t);
@@ -66,7 +66,7 @@ namespace vast::hl
 
     static inline type_generator field_types(mlir::Type t, vast_module mod)
     {
-        auto def = definiton_of(t, mod);
+        auto def = definition_of(t, mod);
         VAST_CHECK(def, "Was not able to fetch definition of type: {0}", t);
         return field_types(*def);
     }
@@ -77,7 +77,7 @@ namespace vast::hl
     {
         auto mod = root->getParentOfType< vast_module >();
         VAST_ASSERT(mod);
-        auto def = definiton_of(root->getResultTypes()[0], mod);
+        auto def = definition_of(root->getResultTypes()[0], mod);
         VAST_CHECK(def, "Was not able to fetch definition of type from: {0}", *root);
 
         for (auto field_def : field_defs(*def))

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -8,6 +8,8 @@
 #include "vast/Dialect/HighLevel/HighLevelOps.hpp"
 #include "vast/Interfaces/SymbolInterface.hpp"
 
+#include "vast/Util/Common.hpp"
+
 #include "gap/core/generator.hpp"
 
 /* Contains common utilities often needed to work with hl dialect. */
@@ -27,12 +29,10 @@ namespace vast::hl
     }
 
     using type_generator = gap::generator< mlir::Type >;
+    using value_generator = gap::generator< mlir::Value >;
 
-    static inline type_generator field_types(hl::StructDeclOp op)
+    static inline gap::generator< hl::FieldDeclOp > field_defs(hl::StructDeclOp op)
     {
-        if (op.getFields().empty())
-            co_return;
-
         for (auto &maybe_field : op.getOps())
         {
             // TODO(hl): So normally only `hl.field` should be present here,
@@ -43,17 +43,52 @@ namespace vast::hl
 
             auto field_decl = mlir::dyn_cast< hl::FieldDeclOp >(maybe_field);
             VAST_ASSERT(field_decl);
-            co_yield field_decl.getType();
+            co_yield field_decl;
         }
     }
 
-    static inline type_generator field_types(mlir::Type t, vast_module mod)
+    static inline type_generator field_types(hl::StructDeclOp op)
+    {
+        for (auto def : field_defs(op))
+            co_yield def.getType();
+    }
+
+    static inline auto definiton_of(mlir::Type t, vast_module mod)
+        -> std::optional< hl::StructDeclOp >
     {
         auto type_name = hl::name_of_record(t);
         VAST_ASSERT(type_name);
         for (auto op : get_nested< hl::StructDeclOp >(mod))
             if (op.getName() == *type_name)
-                return field_types(op);
-        VAST_UNREACHABLE("Was not able to fetch definition of type: {0}", t);
+                return { op };
+        return {};
+    }
+
+    static inline type_generator field_types(mlir::Type t, vast_module mod)
+    {
+        auto def = definiton_of(t, mod);
+        VAST_CHECK(def, "Was not able to fetch definition of type: {0}", t);
+        return field_types(*def);
+    }
+
+    // TODO(hl): Custom hook to provide a location?
+    auto traverse_record(operation root, auto &bld)
+        -> gap::generator< hl::RecordMemberOp >
+    {
+        auto mod = root->getParentOfType< vast_module >();
+        VAST_ASSERT(mod);
+        auto def = definiton_of(root->getResultTypes()[0], mod);
+        VAST_CHECK(def, "Was not able to fetch definition of type from: {0}", *root);
+
+        for (auto field_def : field_defs(*def))
+        {
+            auto as_val = root->getResult(0);
+            // `hl.member` requires type to be an lvalue.
+            auto wrap_type = hl::LValueType::get(mod.getContext(), field_def.getType());
+            co_yield bld.template create< hl::RecordMemberOp >(root->getLoc(),
+                                                               wrap_type,
+                                                               as_val,
+                                                               field_def.getName());
+        }
     }
 }

--- a/include/vast/Dialect/LowLevel/LowLevelOps.td
+++ b/include/vast/Dialect/LowLevel/LowLevelOps.td
@@ -50,6 +50,59 @@ def InitializeVar
     }];
 }
 
+def Concat
+    : LowLevel_Op< "concat" >
+    , Arguments<(ins Variadic<AnyType>:$args)>
+    , Results<(outs AnyType:$result)>
+{
+    let summary = "Concat integers together";
+    let description = [{
+        Concat operands together, where first argument occupies lsb.
+    }];
+
+    let assemblyFormat = [{
+        operands attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def Extract
+    : LowLevel_Op< "extract" >
+    , Arguments<(ins AnyType:$arg, TypedAttrInterface:$from, TypedAttrInterface:$to)>
+    , Results<(outs AnyType:$result)>
+{
+    let summary = "Extracts value";
+    let description = [{
+        `0` is lsb, `[inc, exc)`
+    }];
+
+    let assemblyFormat = [{
+        operands attr-dict `:` functional-type(operands, results)
+    }];
+
+    let builders = [
+        OpBuilder<(ins "mlir::Type":$type, "mlir::Type":$attr_type,
+                       "mlir::Value":$value, "std::size_t":$from, "std::size_t":$to),
+        [{
+            $_state.addOperands(value);
+            $_state.addAttribute("from", mlir::IntegerAttr::get(attr_type, from));
+            $_state.addAttribute("to", mlir::IntegerAttr::get(attr_type, to));
+            $_state.addTypes(type);
+        }] >,
+
+        OpBuilder<(ins "mlir::Type":$type,
+                       "mlir::Value":$value, "std::size_t":$from, "std::size_t":$to),
+        [{
+            build($_builder, $_state, type,
+                  mlir::IntegerType::get($_builder.getContext(),
+                                         64, mlir::IntegerType::Signless),
+                  value,
+                  from, to);
+        }] >
+    ];
+
+    // TODO(ll): Utility API like size().
+}
+
 def Br
     : LowLevel_Op< "br",
         [Terminator, DeclareOpInterfaceMethods<BranchOpInterface>]

--- a/include/vast/Util/TypeUtils.hpp
+++ b/include/vast/Util/TypeUtils.hpp
@@ -77,4 +77,14 @@ namespace vast
         auto accept = [](auto t) { return mlir::isa< Ts ... >(t); };
         return has_type_somewhere(op, accept);
     }
+
+    auto bw(const auto &dl, mlir_type type) { return dl.getTypeSizeInBits(type); }
+
+    auto bw(const auto &dl, auto type_range)
+    {
+        std::size_t acc = 0;
+        for (auto type : type_range)
+            acc += bw(dl, type);
+        return acc;
+    }
 } // namespace vast

--- a/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
@@ -26,6 +26,19 @@ namespace vast::hl
         return t;
     }
 
+    Type strip_value_category(mlir::Value v)
+    {
+        return strip_value_category(v.getType());
+    }
+
+    mlir_type strip_value_category(mlir_type t)
+    {
+        if (auto e = mlir::dyn_cast< hl::LValueType >(t))
+            return e.getElementType();
+        return t;
+    }
+
+
     Type getBottomTypedefType(TypedefType def, vast_module mod) {
         auto type = getTypedefType(def, mod);
         if (auto ty = strip_elaborated(type).dyn_cast< TypedefType >()) {

--- a/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
@@ -60,6 +60,15 @@ namespace vast::hl
         VAST_UNREACHABLE("unknown typedef name");
     }
 
+    auto name_of_record(mlir_type t) -> std::optional< std::string >
+    {
+        auto naked_type = strip_value_category(strip_elaborated(t));
+        auto record_type = mlir::dyn_cast< hl::RecordType >(naked_type);
+        if (record_type)
+            return record_type.getName().str();
+        return {};
+    }
+
     mlir::FunctionType getFunctionType(Type type, vast_module mod) {
         if (auto ty = type.dyn_cast< mlir::FunctionType >())
             return ty;

--- a/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
@@ -62,7 +62,7 @@ namespace vast::hl
 
     auto name_of_record(mlir_type t) -> std::optional< std::string >
     {
-        auto naked_type = strip_value_category(strip_elaborated(t));
+        auto naked_type = strip_elaborated(strip_value_category(t));
         auto record_type = mlir::dyn_cast< hl::RecordType >(naked_type);
         if (record_type)
             return record_type.getName().str();


### PR DESCRIPTION
Introduce a bunch of utilities for working with records. These were before randomly re-implemented in a bunch of conversions. So far I am keeping them header only as I suspect we will need to eventually change some concerte `hl::` types to templates anyway to support C++ as well.

PR also includes refactor of some of our more in-progress passes to use this newer api.

There is one sneaky `ll` commit that adds `Extract` and `Concat` operations which will be needed by abi lowering.