### PR TITLE
Add check for the decl in lookup table

### DIFF
--- a/include/vast/CodeGen/CodeGenStmtVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenStmtVisitor.hpp
@@ -581,7 +581,7 @@ namespace vast::cg {
 
         Operation* VisitFileVarDeclRefExpr(const clang::DeclRefExpr *expr) {
             auto decl = getDeclForVarRef(expr);
-            if (auto file_var = context().vars.lookup(decl); !file_var) {
+            if (!context().vars.lookup(decl)) {
                 // Ref: https://github.com/trailofbits/vast/issues/384
                 // github issue to avoid emitting error if declaration is missing
                 context().error("error: missing global variable declaration " + decl->getName());

--- a/lib/vast/Dialect/Unsupported/UnsupportedOps.cpp
+++ b/lib/vast/Dialect/Unsupported/UnsupportedOps.cpp
@@ -25,15 +25,18 @@ namespace vast::unsup {
     }
 
     void UnsupportedStmt::build(
-        Builder &bld, State &st, llvm::StringRef name, Type rty, const std::vector< BuilderCallBackFn > &builders
+        Builder &bld, State &st, llvm::StringRef name, Type rty,
+        const std::vector< BuilderCallBackFn > &builders
     ) {
         InsertionGuard guard(bld);
-        st.addTypes(rty);
+        // Optional, add a check if rty exist.
+        if (rty) {
+            st.addTypes(rty);
+        }
         st.addAttribute(getNameAttrName(st.name), bld.getStringAttr(name));
         for (auto child : builders) {
             build_region(bld, st, child);
         }
     }
-
 
 } // namespace vast::unsup


### PR DESCRIPTION
Changelog:

- Emit an error if the Var decl is not present in the lookup table. During code generation,  while lowering `DeclRefExpr`, it searches for the declaration in the lookup table that may not be present. This situation could arise if the Decl node is not visited before. A potential solution could be visiting the Decl node if it is not present in the lookup table.

- Check for the null result type before setting the type in Unsupported Stmt Dialect