### PR TITLE
Move `ScopeOp` from `HighLevel` to `Core` dialect

### DIFF
--- a/include/vast/CodeGen/CodeGenBuilder.hpp
+++ b/include/vast/CodeGen/CodeGenBuilder.hpp
@@ -25,7 +25,7 @@ namespace vast::cg {
         Scope scope;
     };
 
-    using HighLevelScope       = ScopeGenerator< hl::ScopeOp >;
+    using CoreScope = ScopeGenerator< core::ScopeOp >;
     using TranslationUnitScope = ScopeGenerator< hl::TranslationUnitOp >;
 
     //

--- a/include/vast/CodeGen/CodeGenContext.hpp
+++ b/include/vast/CodeGen/CodeGenContext.hpp
@@ -23,6 +23,7 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Dialect/HighLevel/HighLevelOps.hpp"
 #include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
+#include "vast/Dialect/Core/CoreOps.hpp"
 #include "vast/Util/Functions.hpp"
 #include "vast/Util/Common.hpp"
 #include "vast/Util/Triple.hpp"

--- a/include/vast/CodeGen/CodeGenDeclVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenDeclVisitor.hpp
@@ -369,13 +369,13 @@ namespace vast::cg {
                 // Making sure, that if the operation is enclosed in a trailing
                 // scope, then the termiantor is evaluated in this scope (which
                 // will then be spliced by subsequent pass)
-                auto next_scope = [](operation op) -> hl::ScopeOp {
+                auto next_scope = [](operation op) -> core::ScopeOp {
                     if (op)
-                        return mlir::dyn_cast< hl::ScopeOp >(op);
+                        return mlir::dyn_cast< core::ScopeOp >(op);
                     return {};
                 };
 
-                auto process_scope = [&](hl::ScopeOp scope) -> operation {
+                auto process_scope = [&](core::ScopeOp scope) -> operation {
                     auto parent = scope->getParentRegion();
                     if (parent->hasOneBlock()
                         && parent->back().begin() == std::prev(parent->back().end()))

--- a/include/vast/CodeGen/CodeGenStmtVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenStmtVisitor.hpp
@@ -15,6 +15,7 @@ VAST_UNRELAX_WARNINGS
 
 #include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
 #include "vast/Dialect/HighLevel/HighLevelOps.hpp"
+#include "vast/Dialect/Core/CoreOps.hpp"
 
 #include "vast/Util/Common.hpp"
 
@@ -66,7 +67,7 @@ namespace vast::cg {
         }
 
         Operation* VisitCompoundStmt(const clang::CompoundStmt *stmt) {
-            return this->template make_scoped< HighLevelScope >(meta_location(stmt), [&] {
+            return this->template make_scoped< CoreScope >(meta_location(stmt), [&] {
                 for (auto s : stmt->body()) {
                     visit(s);
                 }
@@ -681,7 +682,7 @@ namespace vast::cg {
             };
 
             if (stmt->getInit()) {
-                return this->template make_scoped< HighLevelScope >(loc, [&] {
+                return this->template make_scoped< CoreScope >(loc, [&] {
                     visit(stmt->getInit());
                     make_switch_op();
                 });
@@ -720,7 +721,7 @@ namespace vast::cg {
             };
 
             if (stmt->getInit()) {
-                return this->template make_scoped< HighLevelScope >(loc, [&] {
+                return this->template make_scoped< CoreScope >(loc, [&] {
                     visit(stmt->getInit());
                     make_loop_op();
                 });

--- a/include/vast/Dialect/Core/Core.td
+++ b/include/vast/Dialect/Core/Core.td
@@ -36,5 +36,6 @@ class Core_Op< string mnemonic, list< Trait > traits = [] >
     : Op< Core_Dialect, mnemonic, traits >;
 
 include "vast/Dialect/Core/CoreLazy.td"
+include "vast/Dialect/Core/CoreOps.td"
 
 #endif // VAST_DIALECT_CORE

--- a/include/vast/Dialect/Core/CoreOps.td
+++ b/include/vast/Dialect/Core/CoreOps.td
@@ -1,0 +1,24 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#ifndef VAST_DIALECT_CORE_OPS
+#define VAST_DIALECT_CORE_OPS
+
+include "mlir/IR/OpBase.td"
+
+include "mlir/IR/RegionKindInterface.td"
+
+def ScopeOp : Core_Op< "scope", [NoTerminator, DeclareOpInterfaceMethods<RegionKindInterface>] >
+{
+  let summary = "VAST scope declaration";
+  let description = [{
+    Scope operation servers to represent explicitly high-level code scope.
+    Other control flow operations represent scopes implicitly.  It is a
+    single-region operation.
+  }];
+
+  let regions = (region AnyRegion:$body);
+
+  let assemblyFormat = [{ $body attr-dict }];
+}
+
+#endif //VAST_DIALECT_CORE_OPS

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -26,20 +26,6 @@ def TranslationUnitOp
   let assemblyFormat = [{ $body attr-dict }];
 }
 
-def ScopeOp : HighLevel_Op< "scope", [NoTerminator, DeclareOpInterfaceMethods<RegionKindInterface>] >
-{
-  let summary = "VAST scope declaration";
-  let description = [{
-    Scope operation servers to represent explicitly high-level code scope.
-    Other control flow operations represent scopes implicitly.  It is a
-    single-region operation.
-  }];
-
-  let regions = (region AnyRegion:$body);
-
-  let assemblyFormat = [{ $body attr-dict }];
-}
-
 def HighLevel_FuncOp
   : FuncOp< HighLevel_Dialect, "func" >
 {

--- a/include/vast/Util/Scopes.hpp
+++ b/include/vast/Util/Scopes.hpp
@@ -4,13 +4,12 @@
 
 #include <vast/Util/Common.hpp>
 
-#include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
-#include "vast/Dialect/HighLevel/HighLevelOps.hpp"
+#include "vast/Dialect/Core/CoreOps.hpp"
 
 namespace vast
 {
     static inline bool is_trailing_scope(operation op) {
-        if (!mlir::isa< hl::ScopeOp >(op))
+        if (!mlir::isa< core::ScopeOp >(op))
             return false;
         if (auto parent = op->getParentRegion()) {
             if(parent->hasOneBlock()) {
@@ -22,7 +21,7 @@ namespace vast
         return false;
     }
 
-    static inline operation get_last_op(hl::ScopeOp scope) {
+    static inline operation get_last_op(core::ScopeOp scope) {
         auto &last_block = scope.getBody().back();
         if (last_block.empty())
             return nullptr;

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -94,7 +94,7 @@ namespace vast::conv::irstollvm
     };
 
     using label_stmt = hl_scopelike< hl::LabelStmt >;
-    using scope_op = hl_scopelike< hl::ScopeOp >;
+    using scope_op = hl_scopelike< core::ScopeOp >;
 
     using label_patterns = util::type_list<
         erase_pattern< hl::LabelDeclOp >,

--- a/lib/vast/Dialect/Core/CoreOps.cpp
+++ b/lib/vast/Dialect/Core/CoreOps.cpp
@@ -6,6 +6,7 @@
 #include "vast/Dialect/Core/CoreAttributes.hpp"
 
 #include "vast/Util/Common.hpp"
+#include "vast/Util/Dialect.hpp"
 
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
@@ -19,6 +20,11 @@
 
 #include <optional>
 #include <variant>
+
+namespace vast::core
+{
+    GRAPH_REGION_OP(ScopeOp);
+} // namespace vast::core
 
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -472,7 +472,6 @@ namespace vast::hl
     }
 
     GRAPH_REGION_OP(FuncOp);
-    GRAPH_REGION_OP(ScopeOp);
     GRAPH_REGION_OP(StmtExprOp);
 
     GRAPH_REGION_OP(IfOp);

--- a/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
+++ b/lib/vast/Dialect/HighLevel/Transforms/SpliceTrailingScopes.cpp
@@ -27,7 +27,7 @@ namespace vast::hl
 
         void splice_trailing_scope(operation op)
         {
-            auto scope = mlir::dyn_cast< hl::ScopeOp >(op);
+            auto scope = mlir::dyn_cast< core::ScopeOp >(op);
             VAST_ASSERT(scope && "Op is not a scope!");
 
             auto parent = scope->getParentRegion();

--- a/test/vast/Conversion/FromHL/ToLLCF/for-b.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-b.c
@@ -2,7 +2,7 @@
 
 int fn()
 {
-    // CHECK: hl.scope {
+    // CHECK: core.scope {
     // CHECK:   ll.scope {
     // CHECK:     ll.br ^bb2
     // CHECK:   ^bb1:  // pred: ^bb4

--- a/test/vast/Dialect/HighLevel/loop-a.cpp
+++ b/test/vast/Dialect/HighLevel/loop-a.cpp
@@ -4,7 +4,7 @@
 // CHECK-LABEL: hl.func external @_Z11loop_simplev
 void loop_simple()
 {
-    // CHECK: hl.scope {
+    // CHECK: core.scope {
         // CHECK: hl.var "i" : !hl.lvalue<!hl.int>
         // CHECK: hl.for {
         // CHECK:   hl.cmp slt

--- a/test/vast/Dialect/HighLevel/quirks-m.cpp
+++ b/test/vast/Dialect/HighLevel/quirks-m.cpp
@@ -9,13 +9,13 @@ int foo() {
     int* a;
     // CHECK: hl.var "b" : !hl.lvalue<!hl.ptr<!hl.int>>
     int* b;
-    // CHECK: hl.scope
+    // CHECK: core.scope
     {
         // CHECK: hl.var "foo" sc_static : !hl.lvalue<!hl.int>
         static int foo;
         a = &foo;
     }
-    // CHECK: hl.scope
+    // CHECK: core.scope
     {
         // CHECK: hl.var "foo" sc_static : !hl.lvalue<!hl.int>
         static int foo;

--- a/test/vast/Dialect/HighLevel/scope-a.c
+++ b/test/vast/Dialect/HighLevel/scope-a.c
@@ -4,7 +4,7 @@
 // CHECK-LABEL: hl.func external @test1 () -> !hl.int
 int test1()
 {
-    // CHECK: hl.scope
+    // CHECK: core.scope
     {
         int a = 0;
     }
@@ -17,19 +17,19 @@ int test1()
 // CHECK-LABEL: hl.func external @test2 ()
 void test2()
 {
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK: hl.var "a" : !hl.lvalue<!hl.int>
     {
         int a;
     }
 
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK: hl.var "a" : !hl.lvalue<!hl.int>
     {
         int a;
     }
 
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK: hl.var "a" : !hl.lvalue<!hl.int>
     {
         int a;
@@ -42,13 +42,13 @@ int test3()
     // CHECK: hl.var "b" : !hl.lvalue<!hl.int>
     int b;
 
-    // CHECK: hl.scope
+    // CHECK: core.scope
     {
         // CHECK: hl.var "a" : !hl.lvalue<!hl.int>
         int a;
     }
 
-    // CHECK-NOT: hl.scope
+    // CHECK-NOT: core.scope
     int a;
     // CHECK: return [[C3:%[0-9]+]] : !hl.int
     return 0;
@@ -57,7 +57,7 @@ int test3()
 // CHECK-LABEL: hl.func external @test4 () -> !hl.int
 int test4()
 {
-    // CHECK-NOT: hl.scope
+    // CHECK-NOT: core.scope
     {
         int a = 0;
         // CHECK: hl.return

--- a/test/vast/Dialect/HighLevel/switch-b.c
+++ b/test/vast/Dialect/HighLevel/switch-b.c
@@ -4,7 +4,7 @@
 // CHECK: hl.func external @_Z11switch_initi ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>) -> !hl.int
 int switch_init(int num)
 {
-    // CHECK: hl.scope {
+    // CHECK: core.scope {
     // CHECK:   [[V:%[0-9]+]] = hl.var "v" : !hl.lvalue<!hl.int>
     // CHECK:   hl.switch {
     // CHECK:       [[V2:%[0-9]+]] = hl.ref [[V]]

--- a/test/vast/Dialect/HighLevel/vars-c.c
+++ b/test/vast/Dialect/HighLevel/vars-c.c
@@ -25,7 +25,7 @@ int main() {
     // CHECK: hl.ref [[X]]
         int *x = malloc(sizeof(*x));
     }while(0);
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK-NEXT: [[X:%[0-9]+]] = hl.var "x" : !hl.lvalue<!hl.ptr<!hl.int>>
     // CHECK: hl.sizeof.expr
     // CHECK: hl.ref [[X]]

--- a/test/vast/Transform/FromHL/LowerTypes/scope-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/scope-a.c
@@ -3,7 +3,7 @@
 // CHECK-LABEL: hl.func external @test1 () -> si32 attributes {sym_visibility = "private"} {
 int test1()
 {
-    // CHECK: hl.scope
+    // CHECK: core.scope
     {
         int a = 0;
     }
@@ -16,19 +16,19 @@ int test1()
 // CHECK-LABEL: hl.func external @test2 ()
 void test2()
 {
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK: hl.var "a" : !hl.lvalue<si32>
     {
         int a;
     }
 
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK: hl.var "a" : !hl.lvalue<si32>
     {
         int a;
     }
 
-    // CHECK: hl.scope
+    // CHECK: core.scope
     // CHECK: hl.var "a" : !hl.lvalue<si32>
     {
         int a;
@@ -41,13 +41,13 @@ int test3()
     // CHECK: hl.var "b" : !hl.lvalue<si32>
     int b;
 
-    // CHECK: hl.scope
+    // CHECK: core.scope
     {
         // CHECK: hl.var "a" : !hl.lvalue<si32>
         int a;
     }
 
-    // CHECK-NOT: hl.scope
+    // CHECK-NOT: core.scope
     int a;
     // CHECK: return [[C3:%[0-9]+]] : si32
     return 0;
@@ -56,7 +56,7 @@ int test3()
 // CHECK-LABEL: hl.func external @test4 () -> si32 attributes {sym_visibility = "private"} {
 int test4()
 {
-    // CHECK-NOT: hl.scope
+    // CHECK-NOT: core.scope
     {
         int a = 0;
         // CHECK: hl.return


### PR DESCRIPTION
As `ScopeOp` doesn't map to any `AST` member we should move it out of `hl` dialect.