### PR TITLE
CC1 tool and output options.

### DIFF
--- a/include/vast/CodeGen/FunctionInfo.hpp
+++ b/include/vast/CodeGen/FunctionInfo.hpp
@@ -235,21 +235,10 @@ namespace vast::cg
         // If function decl is not null, this will consider pass_object_size
         // params in function decl.
         static required_args for_prototype_plus(
-            const clang::FunctionProtoType *prototype, unsigned additional
+            const clang::FunctionProtoType *prototype, unsigned /* additional */
         ) {
-            if (!prototype->isVariadic())
-                return require_all_args;
-
-            if (prototype->hasExtParameterInfos()) {
-                additional += llvm::count_if(
-                    prototype->getExtParameterInfos(),
-                    [](const clang::FunctionProtoType::ExtParameterInfo &info) {
-                        return info.hasPassObjectSize();
-                    }
-                );
-            }
-
-            return required_args(prototype->getNumParams() + additional);
+            VAST_UNIMPLEMENTED_IF(prototype->isVariadic());
+            return { require_all_args };
         }
 
         static required_args for_prototype_plus(
@@ -463,6 +452,7 @@ namespace vast::cg
         bool is_variadic() const { return required.allows_optional_args(); }
         required_args get_required_args() const { return required; }
         unsigned get_num_required_args() const {
+            VAST_UNIMPLEMENTED_IF(is_variadic());
             return is_variadic() ? get_required_args().get_num_required_args() : arg_size();
         }
 

--- a/include/vast/CodeGen/FunctionInfo.hpp
+++ b/include/vast/CodeGen/FunctionInfo.hpp
@@ -235,10 +235,21 @@ namespace vast::cg
         // If function decl is not null, this will consider pass_object_size
         // params in function decl.
         static required_args for_prototype_plus(
-            const clang::FunctionProtoType *prototype, unsigned /* additional */
+            const clang::FunctionProtoType *prototype, unsigned additional
         ) {
-            VAST_UNIMPLEMENTED_IF(prototype->isVariadic());
-            return { require_all_args };
+            if (!prototype->isVariadic())
+                return require_all_args;
+
+            if (prototype->hasExtParameterInfos()) {
+                additional += llvm::count_if(
+                    prototype->getExtParameterInfos(),
+                    [](const clang::FunctionProtoType::ExtParameterInfo &info) {
+                        return info.hasPassObjectSize();
+                    }
+                );
+            }
+
+            return required_args(prototype->getNumParams() + additional);
         }
 
         static required_args for_prototype_plus(
@@ -452,7 +463,6 @@ namespace vast::cg
         bool is_variadic() const { return required.allows_optional_args(); }
         required_args get_required_args() const { return required; }
         unsigned get_num_required_args() const {
-            VAST_UNIMPLEMENTED_IF(is_variadic());
             return is_variadic() ? get_required_args().get_num_required_args() : arg_size();
         }
 

--- a/include/vast/Frontend/GenAction.hpp
+++ b/include/vast/Frontend/GenAction.hpp
@@ -27,8 +27,10 @@ namespace vast::cc {
 
     namespace opt {
         constexpr string_ref emit_high_level = "emit-high-level";
-        constexpr string_ref emit_cir = "emit-cir";
+        constexpr string_ref emit_cir  = "emit-cir";
         constexpr string_ref emit_llvm = "emit-llvm";
+        constexpr string_ref emit_obj  = "emit-obj";
+        constexpr string_ref emit_asm  = "emit-asm";
 
         constexpr string_ref emit_mlir = "emit-mlir";
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,18 +49,19 @@ config.vast_test_util = os.path.join(config.vast_src_root, 'test/utils')
 config.vast_tools_dir = os.path.join(config.vast_obj_root, 'tools')
 
 tools = [
-    ToolSubst('vast-opt', command = 'vast-opt'),
-    ToolSubst('vast-cc', command = 'vast-cc'),
-    ToolSubst('vast-query', command = 'vast-query'),
-    ToolSubst('vast-front', command = 'vast-front'),
-    ToolSubst('vast-repl', command = 'vast-repl'),
+    ToolSubst('%vast-opt', command = 'vast-opt'),
+    ToolSubst('%vast-cc', command = 'vast-cc'),
+    ToolSubst('%vast-query', command = 'vast-query'),
+    ToolSubst('%vast-front', command = 'vast-front'),
+    ToolSubst('%vast-repl', command = 'vast-repl'),
     ToolSubst('%vast-cc1', command = 'vast-front',
         extra_args=[
             "-cc1",
             "-internal-isystem",
             "-nostdsysteminc"
         ]
-    ) ]
+    )
+]
 
 
 
@@ -71,4 +72,5 @@ else:
 
 for tool in tools:
     path = [config.vast_tools_dir, tool.command, config.vast_build_type]
-    llvm_config.add_tool_substitutions([tool], os.path.join(*path))
+    tool.command = os.path.join(*path, tool.command)
+    llvm_config.add_tool_substitutions([tool])

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -48,7 +48,23 @@ config.test_exec_root = os.path.join(config.vast_obj_root, 'test')
 config.vast_test_util = os.path.join(config.vast_src_root, 'test/utils')
 config.vast_tools_dir = os.path.join(config.vast_obj_root, 'tools')
 
-tools = [ 'vast-opt', 'vast-cc', 'vast-query', 'vast-front', 'vast-repl' ]
+tools = [
+    'vast-opt',
+    'vast-cc',
+    'vast-query',
+    'vast-front',
+    'vast-repl',
+    ToolSubst(
+        '%vast-cc1',
+        command='vast-front',
+        extra_args=[
+            "-cc1",
+            "-internal-isystem",
+            "-nostdsysteminc"
+        ]
+    ) ]
+
+
 
 if 'BUILD_TYPE' in lit_config.params:
     config.vast_build_type = lit_config.params['BUILD_TYPE']

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,14 +49,12 @@ config.vast_test_util = os.path.join(config.vast_src_root, 'test/utils')
 config.vast_tools_dir = os.path.join(config.vast_obj_root, 'tools')
 
 tools = [
-    'vast-opt',
-    'vast-cc',
-    'vast-query',
-    'vast-front',
-    'vast-repl',
-    ToolSubst(
-        '%vast-cc1',
-        command='vast-front',
+    ToolSubst('vast-opt', command = 'vast-opt'),
+    ToolSubst('vast-cc', command = 'vast-cc'),
+    ToolSubst('vast-query', command = 'vast-query'),
+    ToolSubst('vast-front', command = 'vast-front'),
+    ToolSubst('vast-repl', command = 'vast-repl'),
+    ToolSubst('%vast-cc1', command = 'vast-front',
         extra_args=[
             "-cc1",
             "-internal-isystem",
@@ -72,5 +70,5 @@ else:
     config.vast_build_type = "Debug"
 
 for tool in tools:
-    path = [config.vast_tools_dir, tool, config.vast_build_type]
+    path = [config.vast_tools_dir, tool.command, config.vast_build_type]
     llvm_config.add_tool_substitutions([tool], os.path.join(*path))

--- a/test/query/simple.c
+++ b/test/query/simple.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-query --show-symbols=functions %t | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-query --show-symbols=functions %t | FileCheck %s
 
 // CHECK: func : main
 int main() {}

--- a/test/query/symbols.c
+++ b/test/query/symbols.c
@@ -1,21 +1,21 @@
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --show-symbols=all %t | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --show-symbols=all %t | \
 // RUN: FileCheck %s -check-prefix=FOO-VAR -check-prefix=MAIN-VAR -check-prefix=FUN
 
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --show-symbols=vars %t | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --show-symbols=vars %t | \
 // RUN: FileCheck %s -check-prefix=FOO-VAR -check-prefix=MAIN-VAR
 
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --show-symbols=vars %t --scope=foo | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --show-symbols=vars %t --scope=foo | \
 // RUN: FileCheck %s -check-prefix=FOO-VAR
 
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --show-symbols=vars %t --scope=main | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --show-symbols=vars %t --scope=main | \
 // RUN: FileCheck %s -check-prefix=MAIN-VAR
 
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --show-symbols=functions %t | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --show-symbols=functions %t | \
 // RUN: FileCheck %s -check-prefix=FUN
 
 // FOO-VAR-DAG: hl.var : a
@@ -29,7 +29,7 @@ int foo() {
 // MAIN-VAR-DAG: hl.var : b
 // MAIN-VAR-DAG: hl.var : c
 // FUN-DAG: func : main
-int main() 
+int main()
 {
     int a = 1, b = 1;
     {

--- a/test/query/users.c
+++ b/test/query/users.c
@@ -1,13 +1,13 @@
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --symbol-users=a %t | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --symbol-users=a %t | \
 // RUN: FileCheck %s -check-prefix=MAIN -check-prefix=FOO
 
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --symbol-users=a --scope=main %t | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --symbol-users=a --scope=main %t | \
 // RUN: FileCheck %s -check-prefix=MAIN
 
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && \
-// RUN: vast-query --symbol-users=a --scope=foo %t | \
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && \
+// RUN: %vast-query --symbol-users=a --scope=foo %t | \
 // RUN: FileCheck %s -check-prefix=FOO
 
 // FOO: hl.ref %0

--- a/test/repl/raise.c
+++ b/test/repl/raise.c
@@ -1,3 +1,3 @@
-// RUN: printf "load %s\n raise vast-hl-to-ll-cf\n show module\n exit" | vast-repl | FileCheck %s
+// RUN: printf "load %s\n raise vast-hl-to-ll-cf\n show module\n exit" | %vast-repl | FileCheck %s
 // CHECK: ll.return %0 : !hl.int
 int main(void) { return 0; }

--- a/test/vast/Compile/SingleSource/argc.c
+++ b/test/vast/Compile/SingleSource/argc.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -o %t %s && (%t 1 3 4; test $? -eq 4)
-// RUN: vast-front -o %t %s && (%t; test $? -eq 1)
+// RUN: %vast-front -o %t %s && (%t 1 3 4; test $? -eq 4)
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 1)
 
 int main(int argc, char **)
 {

--- a/test/vast/Compile/SingleSource/argv-a.c
+++ b/test/vast/Compile/SingleSource/argv-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -o %t %s && (%t; test $? -eq 121)
-// RUN: vast-front -o %t %s && (%t hello; test $? -eq 108)
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 121)
+// RUN: %vast-front -o %t %s && (%t hello; test $? -eq 108)
 
 int third( const char *arr )
 {

--- a/test/vast/Compile/SingleSource/cc1.c
+++ b/test/vast/Compile/SingleSource/cc1.c
@@ -1,0 +1,34 @@
+// RUN: %vast-cc1 -triple x86_64-unknown-linux-gnu -vast-emit-mlir=hl %s -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=HL
+// RUN: %vast-cc1 -triple x86_64-unknown-linux-gnu -vast-emit-mlir=llvm %s -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
+// RUN: %vast-cc1 -triple x86_64-unknown-linux-gnu -vast-emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+// RUN: %vast-cc1 -triple x86_64-unknown-linux-gnu -S %s -o %t.s
+// RUN: FileCheck --input-file=%t.s %s -check-prefix=ASM
+// RUN: %vast-cc1 -triple x86_64-unknown-linux-gnu -vast-emit-obj %s -o %t.o
+// RUN: objdump -d %t.o | FileCheck %s -check-prefix=OBJ
+
+void foo() {
+    return;
+}
+
+//      HL: hl.func external @foo () -> !hl.void {
+// HL-NEXT:   hl.return
+// HL-NEXT: }
+
+//      MLIR: llvm.func @foo() {
+// MLIR-NEXT:   llvm.return
+// MLIR-NEXT: }
+
+//      LLVM: define void @foo()
+// LLVM-NEXT:   ret void
+// LLVM-NEXT: }
+
+//      ASM: .globl  foo
+// ASM-NEXT: .p2align
+// ASM-NEXT: .type foo,@function
+// ASM-NEXT: foo:
+//      ASM: retq
+
+// OBJ: 0: c3 ret

--- a/test/vast/Compile/SingleSource/fib-a.c
+++ b/test/vast/Compile/SingleSource/fib-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -o %t %s && (%t; test $? -eq 42)
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 42)
 int fib( int x )
 {
     if ( x == 0 )

--- a/test/vast/Compile/SingleSource/global-a.c
+++ b/test/vast/Compile/SingleSource/global-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -o %t %s && (%t 1 2 3; test $? -eq 5)
+// RUN: %vast-front -o %t %s && (%t 1 2 3; test $? -eq 5)
 
 int x = 5;
 

--- a/test/vast/Compile/SingleSource/label-a.c
+++ b/test/vast/Compile/SingleSource/label-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -o %t %s && (%t; test $? -eq 2)
-// RUN: vast-front -o %t %s && (%t 1 2 3; test $? -eq 5)
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 2)
+// RUN: %vast-front -o %t %s && (%t 1 2 3; test $? -eq 5)
 
 int main(int argc, char **argv)
 {

--- a/test/vast/Compile/SingleSource/putchar-a.c
+++ b/test/vast/Compile/SingleSource/putchar-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -o %t %s && %t | FileCheck %s
+// RUN: %vast-front -o %t %s && %t | FileCheck %s
 
 int putchar(int);
 

--- a/test/vast/Compile/SingleSource/puts-a.c
+++ b/test/vast/Compile/SingleSource/puts-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -o %t %s && %t hello | FileCheck %s
+// RUN: %vast-front -o %t %s && %t hello | FileCheck %s
 
 int puts(const char *);
 

--- a/test/vast/Compile/SingleSource/strlit-a.c
+++ b/test/vast/Compile/SingleSource/strlit-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -o %t %s && (%t; test $? -eq 8)
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 8)
 int third( const char *arr )
 {
     return arr[ 2 ];

--- a/test/vast/Compile/SingleSource/var-a.c
+++ b/test/vast/Compile/SingleSource/var-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -o %t %s && (%t 1; test $? -eq 2)
+// RUN: %vast-front -o %t %s && (%t 1; test $? -eq 2)
 // REQUIRES: union_lowering
 
 #include <stdlib.h>

--- a/test/vast/Conversion/Common/CoreToLLVM/binland-a.c
+++ b/test/vast/Conversion/Common/CoreToLLVM/binland-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
 
 int fun(int arg1, int arg2) {
     int res = arg1 && arg2;

--- a/test/vast/Conversion/Common/CoreToLLVM/binlor-a.c
+++ b/test/vast/Conversion/Common/CoreToLLVM/binlor-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-hl-to-lazy-regions --vast-irs-to-llvm --vast-core-to-llvm | FileCheck %s
 
 int fun(int arg1, int arg2) {
     int res = arg1 || arg2;

--- a/test/vast/Conversion/Common/IRsToLLVM/add-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/add-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/addfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/addfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/array-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/array-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/array-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/array-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/bin_not.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/bin_not.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-splice-trailing-scopes --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     int a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/divfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/divsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/divunsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/divunsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 unsigned int fn(unsigned int arg0, unsigned int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/float-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/float-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/fn-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/fn-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn() {
 void fn()

--- a/test/vast/Conversion/Common/IRsToLLVM/fn-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/fn-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn() -> i32 {
 int fn()

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @count([[ARG:%arg[0-9]+]]: i32)
 void count(int arg)

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-b.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @count([[ARG:%arg[0-9]+]]: i32)
 void count(int arg)

--- a/test/vast/Conversion/Common/IRsToLLVM/hl-assign-c.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/hl-assign-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 void count()
 {

--- a/test/vast/Conversion/Common/IRsToLLVM/mul-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/mul-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/mulfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/mulfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/not-float.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/not-float.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     float a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/not.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/not.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 int main() {
     int a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/remsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/remsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/remunsigned-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/remunsigned-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 unsigned int fn(unsigned int arg0, unsigned int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/signs.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/signs.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -vast-emit-mlir=llvm -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=llvm -o - %s | FileCheck %s
 
 int main() {
     int a = 5;

--- a/test/vast/Conversion/Common/IRsToLLVM/sub-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/sub-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: i32, %arg1: i32) -> i32 {
 int fn(int arg0, int arg1)

--- a/test/vast/Conversion/Common/IRsToLLVM/subfloat-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/subfloat-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | FileCheck %s
 
 // CHECK: llvm.func @fn(%arg0: f32, %arg1: f32) -> f32 {
 float fn(float arg0, float arg1)

--- a/test/vast/Conversion/FromHL/ToFunc/fn-decl-a.c
+++ b/test/vast/Conversion/FromHL/ToFunc/fn-decl-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-func | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-to-func | FileCheck %s
 
 // CHECK: func.func private @foo()
 void foo();

--- a/test/vast/Conversion/FromHL/ToFunc/fn-decl-b.c
+++ b/test/vast/Conversion/FromHL/ToFunc/fn-decl-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-func | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-func | FileCheck %s
 
 // CHECK: func.func private @foo()
 void foo();

--- a/test/vast/Conversion/FromHL/ToLLCF/for-a.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Conversion/FromHL/ToLLCF/for-b.c
+++ b/test/vast/Conversion/FromHL/ToLLCF/for-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-cf | FileCheck %s
 
 int fn()
 {

--- a/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
+++ b/test/vast/Conversion/FromHL/ToLLVars/vars-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-to-ll-vars | FileCheck %s
 
 int main()
 {

--- a/test/vast/Dialect/Core/binlop-a.c
+++ b/test/vast/Dialect/Core/binlop-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-lazy-regions | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-to-lazy-regions | FileCheck %s
 
 void logic_assign_to_different_type() {
     // CHECK: [[L:%[0-9]+]] = core.lazy.op {

--- a/test/vast/Dialect/Core/binlop-b.c
+++ b/test/vast/Dialect/Core/binlop-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-to-lazy-regions | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-to-lazy-regions | FileCheck %s
 
 void logic_assign_to_different_type() {
     // CHECK: [[L:%[0-9]+]] = core.lazy.op {

--- a/test/vast/Dialect/HighLevel/add-a.c
+++ b/test/vast/Dialect/HighLevel/add-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void plus(int arg1, int arg2) {
 

--- a/test/vast/Dialect/HighLevel/addfloat-a.c
+++ b/test/vast/Dialect/HighLevel/addfloat-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void plus(float arg1, float arg2) {
 

--- a/test/vast/Dialect/HighLevel/alignof-a.c
+++ b/test/vast/Dialect/HighLevel/alignof-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: hl.alignof.type !hl.int -> !hl.long< unsigned >

--- a/test/vast/Dialect/HighLevel/alignof-b.c
+++ b/test/vast/Dialect/HighLevel/alignof-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -Wno-gnu-statement-expression --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -Wno-gnu-statement-expression --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -Wno-gnu-statement-expression --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -Wno-gnu-statement-expression --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: hl.alignof.type !hl.int -> !hl.long< unsigned >

--- a/test/vast/Dialect/HighLevel/array-a.c
+++ b/test/vast/Dialect/HighLevel/array-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "ai" : !hl.lvalue<!hl.array<10, !hl.int>>
 int ai[10];

--- a/test/vast/Dialect/HighLevel/array-b.c
+++ b/test/vast/Dialect/HighLevel/array-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "earr" sc_extern : !hl.lvalue<!hl.array<?, !hl.int>>
 extern int earr[];

--- a/test/vast/Dialect/HighLevel/array-c.c
+++ b/test/vast/Dialect/HighLevel/array-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "cai" : !hl.lvalue<!hl.array<3, !hl.int< const >>> = {
 // CHECK:   [[V1:%[0-9]+]] = hl.const #hl.integer<1> : !hl.int

--- a/test/vast/Dialect/HighLevel/array-d.c
+++ b/test/vast/Dialect/HighLevel/array-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // TODO decl.ref registers
 

--- a/test/vast/Dialect/HighLevel/array-e.c
+++ b/test/vast/Dialect/HighLevel/array-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void foo(int size) {
     // CHECK: hl.var "arr" : !hl.lvalue<!hl.array<?, !hl.int>> allocation_size {

--- a/test/vast/Dialect/HighLevel/assign-a.c
+++ b/test/vast/Dialect/HighLevel/assign-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int a, b;
 

--- a/test/vast/Dialect/HighLevel/assign-b.c
+++ b/test/vast/Dialect/HighLevel/assign-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 short a;
 

--- a/test/vast/Dialect/HighLevel/attr-a.c
+++ b/test/vast/Dialect/HighLevel/attr-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.typedef "u64" : !hl.longlong< unsigned >
 typedef unsigned long long u64;

--- a/test/vast/Dialect/HighLevel/bit-field-a.c
+++ b/test/vast/Dialect/HighLevel/bit-field-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 struct S1 {
     // CHECK: hl.field "a" : !hl.int< unsigned >

--- a/test/vast/Dialect/HighLevel/bits-a.c
+++ b/test/vast/Dialect/HighLevel/bits-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 #define CHAR_BIT 8
 

--- a/test/vast/Dialect/HighLevel/bits-b.c
+++ b/test/vast/Dialect/HighLevel/bits-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @oposite_signs ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>, [[A2:%arg[0-9]+]]: !hl.lvalue<!hl.int>) -> !hl.bool {
 _Bool oposite_signs(int x, int y) {

--- a/test/vast/Dialect/HighLevel/branch-a.cpp
+++ b/test/vast/Dialect/HighLevel/branch-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z10branch_retii
 int branch_ret(int a, int b)

--- a/test/vast/Dialect/HighLevel/calls-a.c
+++ b/test/vast/Dialect/HighLevel/calls-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int constant() { return 7; }
 

--- a/test/vast/Dialect/HighLevel/calls-b.c
+++ b/test/vast/Dialect/HighLevel/calls-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: @factorial ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>) -> !hl.int
 int factorial(int i) {

--- a/test/vast/Dialect/HighLevel/calls-c.c
+++ b/test/vast/Dialect/HighLevel/calls-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: typedef-pointer-like-inference
 
 // CHECK: hl.typedef "operation" : !hl.ptr<(!hl.int, !hl.int) -> !hl.int>

--- a/test/vast/Dialect/HighLevel/calls-d.c
+++ b/test/vast/Dialect/HighLevel/calls-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --ccopts -std=c89 --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --ccopts -std=c89 --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --ccopts -std=c89 --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --ccopts -std=c89 --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main()
 {

--- a/test/vast/Dialect/HighLevel/cast-a.cpp
+++ b/test/vast/Dialect/HighLevel/cast-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z11cast_cstylev
 void cast_cstyle()

--- a/test/vast/Dialect/HighLevel/cast-b.c
+++ b/test/vast/Dialect/HighLevel/cast-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.typedef "function_type" : (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.int>) -> !hl.int
 typedef int function_type(int a, int b);

--- a/test/vast/Dialect/HighLevel/class-a.cpp
+++ b/test/vast/Dialect/HighLevel/class-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.class "A" :
 class A {};

--- a/test/vast/Dialect/HighLevel/cmp-a.c
+++ b/test/vast/Dialect/HighLevel/cmp-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 typedef unsigned long int uintptr_t;
 

--- a/test/vast/Dialect/HighLevel/comma-a.c
+++ b/test/vast/Dialect/HighLevel/comma-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int comma1(int a, int b)
 {

--- a/test/vast/Dialect/HighLevel/comma-b.c
+++ b/test/vast/Dialect/HighLevel/comma-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 void f0(int* a) {(*a)++; }
 int f1(int* a) {(*a)++; return *a;}
 

--- a/test/vast/Dialect/HighLevel/constants-a.c
+++ b/test/vast/Dialect/HighLevel/constants-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "i" : !hl.lvalue<!hl.int>
 // CHECK:   hl.const #hl.integer<0> : !hl.int

--- a/test/vast/Dialect/HighLevel/decayed-type-a.c
+++ b/test/vast/Dialect/HighLevel/decayed-type-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @f ([[ARG:%arg[0-9]+]]: !hl.lvalue<!hl.decayed<!hl.ptr<!hl.int>>>)
 void f(int i[]) {

--- a/test/vast/Dialect/HighLevel/divfloat-a.c
+++ b/test/vast/Dialect/HighLevel/divfloat-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void div(float arg1, float arg2) {
 

--- a/test/vast/Dialect/HighLevel/divsigned-a.c
+++ b/test/vast/Dialect/HighLevel/divsigned-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void div(int arg1, int arg2) {
 

--- a/test/vast/Dialect/HighLevel/divunsigned-a.c
+++ b/test/vast/Dialect/HighLevel/divunsigned-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void div(unsigned int arg1, unsigned int arg2) {
 

--- a/test/vast/Dialect/HighLevel/dowhile-a.cpp
+++ b/test/vast/Dialect/HighLevel/dowhile-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z5basicv
 void basic() {

--- a/test/vast/Dialect/HighLevel/empty-decl-a.c
+++ b/test/vast/Dialect/HighLevel/empty-decl-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.empty.decl
 ;

--- a/test/vast/Dialect/HighLevel/enum-a.c
+++ b/test/vast/Dialect/HighLevel/enum-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.enum "color" : !hl.int< unsigned > {
 // CHECK:  hl.enum.const "RED" = #hl.integer<0> : !hl.int

--- a/test/vast/Dialect/HighLevel/enum-b.c
+++ b/test/vast/Dialect/HighLevel/enum-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int puts(const char *str);
 

--- a/test/vast/Dialect/HighLevel/enum-c.c
+++ b/test/vast/Dialect/HighLevel/enum-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.enum "Foo" : !hl.int< unsigned >
 // CHECK:  hl.enum.const "A" = #hl.integer<0> : !hl.int

--- a/test/vast/Dialect/HighLevel/enum-d.c
+++ b/test/vast/Dialect/HighLevel/enum-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.enum "color" : !hl.int< unsigned >
 enum color { RED, GREEN, BLUE };

--- a/test/vast/Dialect/HighLevel/enum-e.c
+++ b/test/vast/Dialect/HighLevel/enum-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "Element"
 // CHECK:  hl.field "z" : !hl.int

--- a/test/vast/Dialect/HighLevel/enum-f.c
+++ b/test/vast/Dialect/HighLevel/enum-f.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
 
 // CHECK: hl.enum "kobj_ns_type" : !hl.int< unsigned >
 // CHECK:   hl.enum.const "KOBJ_NS_TYPE_NONE"

--- a/test/vast/Dialect/HighLevel/expr-a.c
+++ b/test/vast/Dialect/HighLevel/expr-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: assign_to_lvalue_expr ([[A:%arg[0-9]+]]: !hl.lvalue<!hl.ptr<!hl.int>>)
 void assign_to_lvalue_expr(int *a) {

--- a/test/vast/Dialect/HighLevel/floats-a.c
+++ b/test/vast/Dialect/HighLevel/floats-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "fp16" : !hl.lvalue<!hl.half>
 __fp16 fp16 = 0.5;

--- a/test/vast/Dialect/HighLevel/fun-redecl-a.c
+++ b/test/vast/Dialect/HighLevel/fun-redecl-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
 
 // CHECK: hl.func external @abort
 // CHECK-NOT: hl.func external @abort

--- a/test/vast/Dialect/HighLevel/fun-redecl-b.c
+++ b/test/vast/Dialect/HighLevel/fun-redecl-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
 
 // CHECK: hl.func external @abort
 // CHECK-NOT: hl.func external @abort

--- a/test/vast/Dialect/HighLevel/fun-redecl-c.c
+++ b/test/vast/Dialect/HighLevel/fun-redecl-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
 
 // CHECK: hl.func external @abort
 // CHECK-NOT: hl.func external @abort

--- a/test/vast/Dialect/HighLevel/fun-ref-a.c
+++ b/test/vast/Dialect/HighLevel/fun-ref-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
 
 void fun(void);
 

--- a/test/vast/Dialect/HighLevel/fun-type-a.c
+++ b/test/vast/Dialect/HighLevel/fun-type-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -x c -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -x c -vast-emit-mlir=hl -o - %s | FileCheck %s
 
 // CHECK: hl.func external @fun (%arg0: !hl.lvalue<!hl.int>, %arg1: !hl.lvalue<!hl.int>) -> !hl.ptr<!hl.int> {
 int *(fun)(int a, int b){int c = a + b; return &c;}

--- a/test/vast/Dialect/HighLevel/function-void-a.c
+++ b/test/vast/Dialect/HighLevel/function-void-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -vast-emit-mlir=hl -x c -o - %s | FileCheck %s
-// RUN: vast-front -vast-emit-mlir=hl -x c++ -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -x c -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -x c++ -o - %s | FileCheck %s
 
 // CHECK: hl.func external {{.*}} () -> !hl.void
 void f1() {}

--- a/test/vast/Dialect/HighLevel/function-void-b.c
+++ b/test/vast/Dialect/HighLevel/function-void-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -vast-emit-mlir=hl -x c -o - %s | FileCheck %s
-// RUN: vast-front -vast-emit-mlir=hl -x c++ -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -x c -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -x c++ -o - %s | FileCheck %s
 
 // CHECK: hl.func external {{.*}} () -> !hl.void
 void f1() {}

--- a/test/vast/Dialect/HighLevel/glob-a.c
+++ b/test/vast/Dialect/HighLevel/glob-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "a" : !hl.lvalue<!hl.int>
 int a = 0;

--- a/test/vast/Dialect/HighLevel/glob-front-a.c
+++ b/test/vast/Dialect/HighLevel/glob-front-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-front %s -vast-emit-high-level -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-high-level -o - | FileCheck %s
 
 // CHECK: hl.var "NUM"
 // CHECK: hl.value.yield

--- a/test/vast/Dialect/HighLevel/glob-front-b.c
+++ b/test/vast/Dialect/HighLevel/glob-front-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-front %s -vast-emit-high-level -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-high-level -o - | FileCheck %s
 
 // CHECK: hl.var "NUM"
 short NUM;

--- a/test/vast/Dialect/HighLevel/glob-front-c.c
+++ b/test/vast/Dialect/HighLevel/glob-front-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-front %s -vast-emit-high-level -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-high-level -o - | FileCheck %s
 
 extern short GIB_SHORT(void);
 // CHECK: hl.var "NUM"

--- a/test/vast/Dialect/HighLevel/glob-front-d.c
+++ b/test/vast/Dialect/HighLevel/glob-front-d.c
@@ -1,4 +1,4 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
 
 // CHECK: hl.var "a" sc_static
 static int a = 2;

--- a/test/vast/Dialect/HighLevel/goto-a.c
+++ b/test/vast/Dialect/HighLevel/goto-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: [[L:%[0-9]+]] = hl.label.decl "end" : !hl.label

--- a/test/vast/Dialect/HighLevel/goto-b.c
+++ b/test/vast/Dialect/HighLevel/goto-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: indirect-goto
 
 void foo(int test) {

--- a/test/vast/Dialect/HighLevel/hello-world.c
+++ b/test/vast/Dialect/HighLevel/hello-world.c
@@ -1,4 +1,4 @@
-// RUN: vast-front %s -vast-emit-high-level -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-high-level -o - | FileCheck %s
 
 // CHECK: hl.func external @printf
 #include <stdio.h>

--- a/test/vast/Dialect/HighLevel/indirect-call-a.c
+++ b/test/vast/Dialect/HighLevel/indirect-call-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.typedef "ck_rv_t" : !hl.long< unsigned >
 typedef unsigned long ck_rv_t;

--- a/test/vast/Dialect/HighLevel/libc-a.c
+++ b/test/vast/Dialect/HighLevel/libc-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: libc
 
 #include <stdio.h>

--- a/test/vast/Dialect/HighLevel/linkage-a.c
+++ b/test/vast/Dialect/HighLevel/linkage-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func internal @foo
 static void foo(void) {}

--- a/test/vast/Dialect/HighLevel/literals-a.c
+++ b/test/vast/Dialect/HighLevel/literals-a.c
@@ -1,5 +1,5 @@
-// // RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// // RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// // RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// // RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "li" : !hl.lvalue<!hl.int< const >>
 // CHECK: hl.const #hl.integer<10> : !hl.int

--- a/test/vast/Dialect/HighLevel/loop-a.cpp
+++ b/test/vast/Dialect/HighLevel/loop-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z11loop_simplev
 void loop_simple()

--- a/test/vast/Dialect/HighLevel/main-a.c
+++ b/test/vast/Dialect/HighLevel/main-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @main () -> !hl.int
 int main() {}

--- a/test/vast/Dialect/HighLevel/mul-a.c
+++ b/test/vast/Dialect/HighLevel/mul-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void plus(int arg1, int arg2) {
 

--- a/test/vast/Dialect/HighLevel/mulfloat-a.c
+++ b/test/vast/Dialect/HighLevel/mulfloat-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void plus(float arg1, float arg2) {
 

--- a/test/vast/Dialect/HighLevel/ops-a.c
+++ b/test/vast/Dialect/HighLevel/ops-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @add1 ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>, [[A2:%arg[0-9]+]]: !hl.lvalue<!hl.int>) -> !hl.int
 int add1(int a, int b)

--- a/test/vast/Dialect/HighLevel/ops-b.c
+++ b/test/vast/Dialect/HighLevel/ops-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @arithemtic_signed ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>, [[A2:%arg[0-9]+]]: !hl.lvalue<!hl.int>)
 void arithemtic_signed(int a, int b)

--- a/test/vast/Dialect/HighLevel/ops-c.c
+++ b/test/vast/Dialect/HighLevel/ops-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void bit_ops(int a, int b) {
     // CHECK: [[V1:%[0-9]+]] = hl.ref %arg0

--- a/test/vast/Dialect/HighLevel/ops-d.c
+++ b/test/vast/Dialect/HighLevel/ops-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void unary_inplace(int a) {
     // CHECK: hl.var "pre" : !hl.lvalue<!hl.int>

--- a/test/vast/Dialect/HighLevel/ops-e.c
+++ b/test/vast/Dialect/HighLevel/ops-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void assign_assign() {
     int a, b, c;

--- a/test/vast/Dialect/HighLevel/ops-f.c
+++ b/test/vast/Dialect/HighLevel/ops-f.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int ptr_cmp(void *a, void *b) {
     // CHECK: hl.cmp eq [[A:%[0-9]+]], [[B:%[0-9]+]] : !hl.ptr<!hl.void>, !hl.ptr<!hl.void> -> !hl.int

--- a/test/vast/Dialect/HighLevel/ops-g.c
+++ b/test/vast/Dialect/HighLevel/ops-g.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void logic_assign_to_different_type() {
     // CHECK: hl.bin.lor {

--- a/test/vast/Dialect/HighLevel/ops-h.c
+++ b/test/vast/Dialect/HighLevel/ops-h.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @arithemtic_int_short ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>, [[A2:%arg[0-9]+]]: !hl.lvalue<!hl.short>)
 void arithemtic_int_short(int a, short b)

--- a/test/vast/Dialect/HighLevel/pointerops-a.c
+++ b/test/vast/Dialect/HighLevel/pointerops-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void add(int* a, int b) {
     // CHECK: [[A1:%[0-9]+]] = hl.add [[B1:%[0-9]+]], [[C1:%[0-9]+]] : (!hl.ptr<!hl.int>, !hl.int) -> !hl.ptr<!hl.int>

--- a/test/vast/Dialect/HighLevel/pointers-a.c
+++ b/test/vast/Dialect/HighLevel/pointers-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "vp" : !hl.lvalue<!hl.ptr<!hl.void>>
 void * vp = 0;

--- a/test/vast/Dialect/HighLevel/pointers-b.c
+++ b/test/vast/Dialect/HighLevel/pointers-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "p" : !hl.lvalue<!hl.ptr<!hl.float>>
 // CHECK: hl.var "pp" : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.float>>>

--- a/test/vast/Dialect/HighLevel/pointers-c.c
+++ b/test/vast/Dialect/HighLevel/pointers-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:   ArrayToPointerDecay : !hl.lvalue<!hl.array<2, !hl.int>> -> !hl.ptr<!hl.int>

--- a/test/vast/Dialect/HighLevel/pointers-d.c
+++ b/test/vast/Dialect/HighLevel/pointers-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void f(int);
 // CHECK: hl.var "pf1" : !hl.lvalue<!hl.ptr<!hl.paren<(!hl.lvalue<!hl.int>) -> !hl.void>>>

--- a/test/vast/Dialect/HighLevel/pointers-e.c
+++ b/test/vast/Dialect/HighLevel/pointers-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int f();
 

--- a/test/vast/Dialect/HighLevel/pointers-f.c
+++ b/test/vast/Dialect/HighLevel/pointers-f.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int f(int), fc(const int);
 

--- a/test/vast/Dialect/HighLevel/pointers-g.c
+++ b/test/vast/Dialect/HighLevel/pointers-g.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: [[N:%[0-9]+]] = hl.var "n" : !hl.lvalue<!hl.int>

--- a/test/vast/Dialect/HighLevel/prototypes-a.c
+++ b/test/vast/Dialect/HighLevel/prototypes-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 short b(void);
 // CHECK: func external @b () -> !hl.short

--- a/test/vast/Dialect/HighLevel/qualifiers-a.cpp
+++ b/test/vast/Dialect/HighLevel/qualifiers-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "i" : !hl.lvalue<!hl.int>
 int i;

--- a/test/vast/Dialect/HighLevel/qualifiers-b.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main()
 {

--- a/test/vast/Dialect/HighLevel/qualifiers-c.cpp
+++ b/test/vast/Dialect/HighLevel/qualifiers-c.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "p" : !hl.lvalue<!hl.ptr<!hl.void>>
 void *p;

--- a/test/vast/Dialect/HighLevel/qualifiers-d.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: @chptr (!hl.lvalue<!hl.ptr<!hl.char>>)
 void chptr(char *p);

--- a/test/vast/Dialect/HighLevel/qualifiers-e.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "ia" : !hl.lvalue<!hl.array<10, !hl.int>>
 int ia[10];

--- a/test/vast/Dialect/HighLevel/qualifiers-f.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-f.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: @f (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.int>, !hl.lvalue<!hl.decayed<!hl.ptr<!hl.array<?, !hl.float>,  restrict >>>, !hl.lvalue<!hl.decayed<!hl.ptr<!hl.array<?, !hl.float>,  restrict >>>)
 void f(int m, int n, float a[restrict m][n], float b[restrict m][n]);

--- a/test/vast/Dialect/HighLevel/qualifiers-g.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-g.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "a" : !hl.lvalue<!hl.ptr<!hl.float,  restrict >>
 // CHECK: hl.var "b" : !hl.lvalue<!hl.ptr<!hl.float,  restrict >>

--- a/test/vast/Dialect/HighLevel/qualifiers-h.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-h.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.enum "e" : !hl.int< unsigned >
 enum e { a, b, c };

--- a/test/vast/Dialect/HighLevel/qualifiers-i.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-i.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.union "u"
 union u { int i; double d; };

--- a/test/vast/Dialect/HighLevel/qualifiers-j.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-j.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "fp" : !hl.lvalue<!hl.ptr<!hl.paren<(!hl.lvalue<!hl.int>) -> !hl.int>>>
 int (*fp) (int);

--- a/test/vast/Dialect/HighLevel/quirks-a.c
+++ b/test/vast/Dialect/HighLevel/quirks-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-b.c
+++ b/test/vast/Dialect/HighLevel/quirks-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: compund-literal
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01

--- a/test/vast/Dialect/HighLevel/quirks-c.c
+++ b/test/vast/Dialect/HighLevel/quirks-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-d.c
+++ b/test/vast/Dialect/HighLevel/quirks-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: static_assert
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01

--- a/test/vast/Dialect/HighLevel/quirks-e.c
+++ b/test/vast/Dialect/HighLevel/quirks-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: qualified-type
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01

--- a/test/vast/Dialect/HighLevel/quirks-f.c
+++ b/test/vast/Dialect/HighLevel/quirks-f.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-g.c
+++ b/test/vast/Dialect/HighLevel/quirks-g.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-h.c
+++ b/test/vast/Dialect/HighLevel/quirks-h.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-i.c
+++ b/test/vast/Dialect/HighLevel/quirks-i.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-j.c
+++ b/test/vast/Dialect/HighLevel/quirks-j.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-k.c
+++ b/test/vast/Dialect/HighLevel/quirks-k.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-l.c
+++ b/test/vast/Dialect/HighLevel/quirks-l.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: offsetof
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01

--- a/test/vast/Dialect/HighLevel/quirks-m.cpp
+++ b/test/vast/Dialect/HighLevel/quirks-m.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-n.c
+++ b/test/vast/Dialect/HighLevel/quirks-n.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/quirks-o.c
+++ b/test/vast/Dialect/HighLevel/quirks-o.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // adapted from https://gist.github.com/fay59/5ccbe684e6e56a7df8815c3486568f01
 

--- a/test/vast/Dialect/HighLevel/ref-a.c
+++ b/test/vast/Dialect/HighLevel/ref-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main()
 {

--- a/test/vast/Dialect/HighLevel/ref-b.c
+++ b/test/vast/Dialect/HighLevel/ref-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main()
 {

--- a/test/vast/Dialect/HighLevel/remsigned-a.c
+++ b/test/vast/Dialect/HighLevel/remsigned-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void div(int arg1, int arg2) {
 

--- a/test/vast/Dialect/HighLevel/remunsigned-a.c
+++ b/test/vast/Dialect/HighLevel/remunsigned-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void div(unsigned int arg1, unsigned int arg2) {
 

--- a/test/vast/Dialect/HighLevel/return-a.c
+++ b/test/vast/Dialect/HighLevel/return-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @a () -> !hl.int
 // CHECK: [[V1:%[0-9]+]] = hl.const #hl.integer<7> : !hl.int

--- a/test/vast/Dialect/HighLevel/scope-a.c
+++ b/test/vast/Dialect/HighLevel/scope-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @test1 () -> !hl.int
 int test1()

--- a/test/vast/Dialect/HighLevel/sizeof-a.c
+++ b/test/vast/Dialect/HighLevel/sizeof-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: hl.sizeof.type !hl.int -> !hl.long< unsigned >

--- a/test/vast/Dialect/HighLevel/stmt-expr.c
+++ b/test/vast/Dialect/HighLevel/stmt-expr.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: hl.stmt.expr : !hl.int

--- a/test/vast/Dialect/HighLevel/storage-a.c
+++ b/test/vast/Dialect/HighLevel/storage-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "i" : !hl.lvalue<!hl.int>
 int i;

--- a/test/vast/Dialect/HighLevel/string-a.c
+++ b/test/vast/Dialect/HighLevel/string-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "gstr" : !hl.lvalue<!hl.ptr<!hl.char< const >>>
 // CHECK: hl.const #hl.strlit<"global"> : !hl.lvalue<!hl.array<7, !hl.char>>

--- a/test/vast/Dialect/HighLevel/string-b.c
+++ b/test/vast/Dialect/HighLevel/string-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.var "gstr" : !hl.lvalue<!hl.ptr<!hl.char< const >>>
 // CHECK:   hl.const #hl.strlit<"global\n"> : !hl.lvalue<!hl.array<8, !hl.char>>

--- a/test/vast/Dialect/HighLevel/struct-a.c
+++ b/test/vast/Dialect/HighLevel/struct-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "empty"
 struct empty {};

--- a/test/vast/Dialect/HighLevel/struct-b.c
+++ b/test/vast/Dialect/HighLevel/struct-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "node" : {
 // CHECK:  hl.field "data" : !hl.int

--- a/test/vast/Dialect/HighLevel/struct-c.c
+++ b/test/vast/Dialect/HighLevel/struct-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "[[N:anonymous\[[0-9]+\]]]" : {
 // CHECK:  hl.field "data" : !hl.int

--- a/test/vast/Dialect/HighLevel/struct-d.c
+++ b/test/vast/Dialect/HighLevel/struct-d.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.type "s"
 

--- a/test/vast/Dialect/HighLevel/struct-e.c
+++ b/test/vast/Dialect/HighLevel/struct-e.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "s" : {
 // CHECK:  hl.field "a" : !hl.int

--- a/test/vast/Dialect/HighLevel/struct-f.c
+++ b/test/vast/Dialect/HighLevel/struct-f.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "X"
 struct X {};

--- a/test/vast/Dialect/HighLevel/sub-a.c
+++ b/test/vast/Dialect/HighLevel/sub-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void minus(int arg1, int arg2) {
 

--- a/test/vast/Dialect/HighLevel/subfloat-a.c
+++ b/test/vast/Dialect/HighLevel/subfloat-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 void minus(float arg1, float arg2) {
 

--- a/test/vast/Dialect/HighLevel/switch-a.c
+++ b/test/vast/Dialect/HighLevel/switch-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @switch_simple ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>) -> !hl.int
 int switch_simple(int num)

--- a/test/vast/Dialect/HighLevel/switch-b.c
+++ b/test/vast/Dialect/HighLevel/switch-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -std=c++17 --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -std=c++17 --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -std=c++17 --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -std=c++17 --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.func external @_Z11switch_initi ([[A1:%arg[0-9]+]]: !hl.lvalue<!hl.int>) -> !hl.int
 int switch_init(int num)

--- a/test/vast/Dialect/HighLevel/ternary-a.c
+++ b/test/vast/Dialect/HighLevel/ternary-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 typedef int INT;
 typedef INT INT2;
 

--- a/test/vast/Dialect/HighLevel/typedef-a.c
+++ b/test/vast/Dialect/HighLevel/typedef-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.typedef "INT" : !hl.int
 // CHECK: hl.typedef "SHORT" : !hl.short

--- a/test/vast/Dialect/HighLevel/typedef-b.c
+++ b/test/vast/Dialect/HighLevel/typedef-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.typedef "INT" : !hl.int
 // CHECK: hl.typedef "INT2" : !hl.long

--- a/test/vast/Dialect/HighLevel/typedef-c.c
+++ b/test/vast/Dialect/HighLevel/typedef-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.typedef "INT" : !hl.int
 typedef int INT;

--- a/test/vast/Dialect/HighLevel/typeof-a.c
+++ b/test/vast/Dialect/HighLevel/typeof-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
-// RUN: vast-front -vast-emit-mlir=hl -o - %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
 // CHECK: hl.var "i" : !hl.lvalue<!hl.int>

--- a/test/vast/Dialect/HighLevel/typeof-b.c
+++ b/test/vast/Dialect/HighLevel/typeof-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
-// RUN: vast-front -vast-emit-mlir=hl -o - %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
 // CHECK: hl.var "i" : !hl.lvalue<!hl.int< const >>

--- a/test/vast/Dialect/HighLevel/typeof-c.c
+++ b/test/vast/Dialect/HighLevel/typeof-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
-// RUN: vast-front -vast-emit-mlir=hl -o - %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
 // CHECK: hl.var "i" : !hl.lvalue<!hl.int>

--- a/test/vast/Dialect/HighLevel/unary-a.cpp
+++ b/test/vast/Dialect/HighLevel/unary-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z10arithmetici
 void arithmetic(int a)

--- a/test/vast/Dialect/HighLevel/unary-b.c
+++ b/test/vast/Dialect/HighLevel/unary-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
     // CHECK: [[A:%[0-9]+]] = hl.var "a" : !hl.lvalue<!hl.int>

--- a/test/vast/Dialect/HighLevel/unary-c.c
+++ b/test/vast/Dialect/HighLevel/unary-c.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @logical
 void logical(unsigned long a)

--- a/test/vast/Dialect/HighLevel/unary-d.cpp
+++ b/test/vast/Dialect/HighLevel/unary-d.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z7logicalm
 void logical(unsigned long a)

--- a/test/vast/Dialect/HighLevel/union-a.c
+++ b/test/vast/Dialect/HighLevel/union-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.union "u" : {
 // CHECK:   hl.field "u32" : !hl.int< unsigned >

--- a/test/vast/Dialect/HighLevel/union-b.c
+++ b/test/vast/Dialect/HighLevel/union-b.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --ccopts -std=c11 --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --ccopts -std=c11 --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --ccopts -std=c11 --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --ccopts -std=c11 --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.struct "v"
 struct v {

--- a/test/vast/Dialect/HighLevel/vararg-a.c
+++ b/test/vast/Dialect/HighLevel/vararg-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: libc
 
 #include <stdarg.h>

--- a/test/vast/Dialect/HighLevel/vars-a.c
+++ b/test/vast/Dialect/HighLevel/vars-a.c
@@ -1,5 +1,5 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | FileCheck %s
-// RUN: vast-cc --ccopts -xc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --ccopts -xc --from-source %s | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @main () -> !hl.int
 int main()

--- a/test/vast/Dialect/HighLevel/vars-b.c
+++ b/test/vast/Dialect/HighLevel/vars-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
 
 #include <stdlib.h>
 

--- a/test/vast/Dialect/HighLevel/vars-c.c
+++ b/test/vast/Dialect/HighLevel/vars-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | FileCheck %s
 
 #include <stdlib.h>
 

--- a/test/vast/Dialect/HighLevel/while-a.cpp
+++ b/test/vast/Dialect/HighLevel/while-a.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z11while_emptyv
 void while_empty()

--- a/test/vast/Dialect/HighLevel/while-b.cpp
+++ b/test/vast/Dialect/HighLevel/while-b.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-cc --from-source %s | FileCheck %s
-// RUN: vast-cc --from-source %s > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-cc --from-source %s | FileCheck %s
+// RUN: %vast-cc --from-source %s > %t && %vast-opt %t | diff -B %t -
 
 // CHECK-LABEL: hl.func external @_Z11while_breakv
 void while_break()

--- a/test/vast/Dialect/Unsupported/atomicexpr.cpp
+++ b/test/vast/Dialect/Unsupported/atomicexpr.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 int load(int* p) {
     // CHECK: unsup.stmt "AtomicExpr"

--- a/test/vast/Dialect/Unsupported/extern-in-namespace.cpp
+++ b/test/vast/Dialect/Unsupported/extern-in-namespace.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 // REQUIRES: extern-in-namespace
 
 // CHECK: unsup.decl "Namespace::N"

--- a/test/vast/Dialect/Unsupported/linkage-spec.cpp
+++ b/test/vast/Dialect/Unsupported/linkage-spec.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 #define __BEGIN_DECLS   extern "C" {
 #define __END_DECLS     }

--- a/test/vast/Dialect/Unsupported/namespace.cpp
+++ b/test/vast/Dialect/Unsupported/namespace.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: unsup.decl "Namespace::test" :
 namespace test {

--- a/test/vast/Dialect/Unsupported/staticassert.cpp
+++ b/test/vast/Dialect/Unsupported/staticassert.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: unsup.decl "StaticAssert"
 static_assert(1, "Test static assert 1");

--- a/test/vast/Dialect/Unsupported/stdio.cpp
+++ b/test/vast/Dialect/Unsupported/stdio.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: unsup.decl "LinkageSpec"
 #include <stdio.h>

--- a/test/vast/Dialect/Unsupported/struct-type.cpp
+++ b/test/vast/Dialect/Unsupported/struct-type.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: hl.cxxstruct
 struct  Student {

--- a/test/vast/Dialect/Unsupported/using.cpp
+++ b/test/vast/Dialect/Unsupported/using.cpp
@@ -1,5 +1,5 @@
-// RUN: vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
-// RUN: vast-front %s -vast-emit-mlir=hl -o - > %t && vast-opt %t | diff -B %t -
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | FileCheck %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - > %t && %vast-opt %t | diff -B %t -
 
 // CHECK: unsup.decl "TypeAlias::Int"
 using Int = int;

--- a/test/vast/Transform/FromHL/LowerTypes/array-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/array-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK: hl.var "ai" : !hl.lvalue<memref<10xsi32>>
 int ai[10];

--- a/test/vast/Transform/FromHL/LowerTypes/array-b.c
+++ b/test/vast/Transform/FromHL/LowerTypes/array-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK: hl.var "a" sc_extern : !hl.lvalue<memref<?xsi32>>
 extern int a[];

--- a/test/vast/Transform/FromHL/LowerTypes/calls-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/calls-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 int constant() { return 7; }
 

--- a/test/vast/Transform/FromHL/LowerTypes/loop.c
+++ b/test/vast/Transform/FromHL/LowerTypes/loop.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 void loop_simple()
 {

--- a/test/vast/Transform/FromHL/LowerTypes/scope-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/scope-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @test1 () -> si32 attributes {sym_visibility = "private"} {
 int test1()

--- a/test/vast/Transform/FromHL/LowerTypes/strlit-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/strlit-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/struct-access-a.c
+++ b/test/vast/Transform/FromHL/LowerTypes/struct-access-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK:  hl.struct "X" : {
 // CHECK:    hl.field "member_x" : si32

--- a/test/vast/Transform/FromHL/LowerTypes/vars-a.cpp
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-a.cpp
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/vars-b.cpp
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-b.cpp
@@ -1,4 +1,4 @@
-// RUN: vast-cc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/LowerTypes/vars-c.c
+++ b/test/vast/Transform/FromHL/LowerTypes/vars-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types | FileCheck %s
 
 // CHECK-LABEL: hl.func external @main () -> si32
 int main()

--- a/test/vast/Transform/FromHL/StructsToLLVM/empty-a.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/empty-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", ()>
 struct X {};

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-a.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", (i32)>
 struct X { int x; };

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-b.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.type "Y"
 struct Y;

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-c.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-c.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 struct Y;
 

--- a/test/vast/Transform/FromHL/StructsToLLVM/struct-d.c
+++ b/test/vast/Transform/FromHL/StructsToLLVM/struct-d.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-structs-to-llvm | FileCheck %s
 
 // CHECK: hl.typedef "X" : !llvm.struct<"X", (i32, ptr<struct<"X">>)>
 struct X { int a; struct X *x; };

--- a/test/vast/Transform/FromHL/ToLLGEPs/member-access-a.c
+++ b/test/vast/Transform/FromHL/ToLLGEPs/member-access-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-lower-types --vast-hl-to-ll-geps | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-geps | FileCheck %s
 
 struct X { int a; };
 

--- a/test/vast/Transform/HL/DCE/for-a.c
+++ b/test/vast/Transform/HL/DCE/for-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Transform/HL/DCE/for-b.c
+++ b/test/vast/Transform/HL/DCE/for-b.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce | FileCheck %s
 
 void fn()
 {

--- a/test/vast/Transform/HL/DCE/if-a.c
+++ b/test/vast/Transform/HL/DCE/if-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce | FileCheck %s
 // REQUIRES: return
 
 void fn()

--- a/test/vast/Transform/HL/ResolveTypedefs/func-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/func-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/test/vast/Transform/HL/ResolveTypedefs/struct-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/struct-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/test/vast/Transform/HL/ResolveTypedefs/var-a.c
+++ b/test/vast/Transform/HL/ResolveTypedefs/var-a.c
@@ -1,4 +1,4 @@
-// RUN: vast-cc --ccopts -xc --from-source %s | vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-dce --vast-hl-lower-types --vast-hl-resolve-typedefs | FileCheck %s
 
 typedef int INT;
 

--- a/tools/vast-front/compiler_invocation.cpp
+++ b/tools/vast-front/compiler_invocation.cpp
@@ -37,6 +37,18 @@ namespace vast::cc
             return std::make_unique< vast::cc::emit_mlir_action >(vargs);
         }
 
+        if (vargs.has_option(opt::emit_llvm)) {
+            return std::make_unique< vast::cc::emit_llvm_action >(vargs);
+        }
+
+        if (vargs.has_option(opt::emit_asm)) {
+            return std::make_unique< vast::cc::emit_assembly_action >(vargs);
+        }
+
+        if (vargs.has_option(opt::emit_obj)) {
+            return std::make_unique< vast::cc::emit_obj_action >(vargs);
+        }
+
         switch (act) {
             case ASTDump:  return std::make_unique< clang::ASTDumpAction >();
             case EmitAssembly: return std::make_unique< vast::cc::emit_assembly_action >(vargs);


### PR DESCRIPTION
Allows to specify: `-vast-emit-{obj/asm/llvm}`.

Tests `cc1` compilation outputs.