### PR TITLE
Sizeof lowering

### DIFF
--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -1059,6 +1059,8 @@ namespace vast::conv::irstollvm
         logical_result matchAndRewrite(
             op_t op, adaptor_t ops, conversion_rewriter &rewriter
         ) const override {
+            // TODO mimic: clang/lib/CodeGen/CGExprScalar.cpp:VisitUnaryExprOrTypeTraitExpr
+            // This does not consider type alignment and VLA types
             auto target_type = this->convert(op.getType());
             const auto &dl = this->type_converter().getDataLayoutAnalysis()->getAtOrAbove(op);
             auto attr = rewriter.getIntegerAttr(

--- a/test/vast/Conversion/Common/IRsToLLVM/sizeof-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/sizeof-a.c
@@ -1,0 +1,6 @@
+// RUN: %vast-cc --ccopts -xc --from-source %s | %vast-opt --vast-hl-lower-types --vast-hl-to-ll-cf --vast-hl-to-ll-vars --vast-irs-to-llvm | %file-check %s
+
+unsigned long sizeof_int() {
+    // CHECK: llvm.mlir.constant(4 : i64) : i64
+    return sizeof(int);
+}


### PR DESCRIPTION
Implement `sizeof(type)` conversion for primitive types.