### PR TITLE
Attribute visitor improvements

### DIFF
--- a/include/vast/CodeGen/CodeGenAttrVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenAttrVisitor.hpp
@@ -81,12 +81,8 @@ namespace vast::cg {
         }
 
         mlir_attr VisitAllocSizeAttr(const clang::AllocSizeAttr *attr) {
-            auto size = attr->getElemSizeParam();
-            auto num = attr->getNumElemsParam();
-            if (num.isValid()) {
-                return make< hl::AllocSizeAttr >(size.getSourceIndex(), num.getSourceIndex());
-            }
-            return make< hl::AllocSizeAttr >(size.getSourceIndex(), int());
+            auto num = attr->getNumElemsParam().isValid() ? attr->getNumElemsParam().getSourceIndex() : int();
+            return make< hl::AllocSizeAttr >(attr->getElemSizeParam().getSourceIndex(), num);
         }
     };
 } // namespace vast::cg

--- a/include/vast/CodeGen/CodeGenAttrVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenAttrVisitor.hpp
@@ -13,6 +13,8 @@ VAST_UNRELAX_WARNINGS
 
 #include <mlir/IR/Attributes.h>
 #include <vast/CodeGen/Types.hpp>
+#include <vast/CodeGen/CodeGenVisitorLens.hpp>
+#include <vast/CodeGen/CodeGenBuilder.hpp>
 
 namespace vast::cg {
 

--- a/include/vast/CodeGen/CodeGenAttrVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenAttrVisitor.hpp
@@ -66,6 +66,18 @@ namespace vast::cg {
             return make< hl::WarnUnusedResultAttr >();
         }
 
+        mlir_attr VisitRestrictAttr(const clang::RestrictAttr *attr) {
+            return make< hl::MallocAttr >();
+        }
+
+        mlir_attr VisitNoThrowAttr(const clang::NoThrowAttr *attr) {
+            return make< hl::NoThrowAttr >();
+        }
+
+        mlir_attr VisitBuiltinAttr(const clang::BuiltinAttr *attr) {
+            return make< hl::BuiltinAttr >(attr->getID());
+        }
+
         mlir_attr VisitAllocSizeAttr(const clang::AllocSizeAttr *attr) {
             auto size = attr->getElemSizeParam();
             auto num = attr->getNumElemsParam();

--- a/include/vast/CodeGen/CodeGenAttrVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenAttrVisitor.hpp
@@ -65,5 +65,14 @@ namespace vast::cg {
         mlir_attr VisitWarnUnusedResultAttr(const clang::WarnUnusedResultAttr *attr) {
             return make< hl::WarnUnusedResultAttr >();
         }
+
+        mlir_attr VisitAllocSizeAttr(const clang::AllocSizeAttr *attr) {
+            auto size = attr->getElemSizeParam();
+            auto num = attr->getNumElemsParam();
+            if (num.isValid()) {
+                return make< hl::AllocSizeAttr >(size.getSourceIndex(), num.getSourceIndex());
+            }
+            return make< hl::AllocSizeAttr >(size.getSourceIndex(), int());
+        }
     };
 } // namespace vast::cg

--- a/include/vast/CodeGen/CodeGenAttrVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenAttrVisitor.hpp
@@ -69,7 +69,7 @@ namespace vast::cg {
         }
 
         mlir_attr VisitRestrictAttr(const clang::RestrictAttr *attr) {
-            return make< hl::MallocAttr >();
+            return make< hl::RestrictAttr >();
         }
 
         mlir_attr VisitNoThrowAttr(const clang::NoThrowAttr *attr) {

--- a/include/vast/CodeGen/CodeGenDeclVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenDeclVisitor.hpp
@@ -71,7 +71,12 @@ namespace vast::cg {
             // getAttrs on decl without attrs triggers an assertion in clang
             if (decl->hasAttrs()) {
                 mlir::NamedAttrList attrs = op->getAttrs();
-                for (auto attr : decl->getAttrs()) {
+                using excluded_attr_list = util::type_list<
+                     clang::WeakAttr
+                    ,clang::SelectAnyAttr
+                    ,clang::CUDAGlobalAttr
+                >;
+                for (auto attr : exclude_attrs< excluded_attr_list >(decl->getAttrs())) {
                     auto visited = visit(attr);
 
                     auto spelling = attr->getSpelling();

--- a/include/vast/CodeGen/CodeGenDeclVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenDeclVisitor.hpp
@@ -804,10 +804,12 @@ namespace vast::cg {
                 if (decl->hasAttrs()) {
                     mlir::NamedAttrList attrs = op->getAttrs();
                     for (auto attr : decl->getAttrs()) {
+                        auto visited = visit(attr);
                         auto spelling = attr->getSpelling();
-                        if (!attrs.getNamed(spelling)) {
-                            attrs.append(spelling, visit(attr));
+                        if (auto prev = attrs.getNamed(spelling)) {
+                            VAST_CHECK(visited == prev.value().getValue(), "Conflicting redefinition of attribute {0}", spelling);
                         }
+                        attrs.set(spelling, visited);
                     }
                     op->setAttrs(attrs);
                 }

--- a/include/vast/CodeGen/CodeGenDeclVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenDeclVisitor.hpp
@@ -805,10 +805,17 @@ namespace vast::cg {
                     mlir::NamedAttrList attrs = op->getAttrs();
                     for (auto attr : decl->getAttrs()) {
                         auto visited = visit(attr);
+
                         auto spelling = attr->getSpelling();
+                        // Bultin attr doesn't have spelling because it can not be written in code
+                        if (auto builtin = clang::dyn_cast< clang::BuiltinAttr >(attr)) {
+                            spelling = "builtin";
+                        }
+
                         if (auto prev = attrs.getNamed(spelling)) {
                             VAST_CHECK(visited == prev.value().getValue(), "Conflicting redefinition of attribute {0}", spelling);
                         }
+
                         attrs.set(spelling, visited);
                     }
                     op->setAttrs(attrs);

--- a/include/vast/CodeGen/UnreachableVisitor.hpp
+++ b/include/vast/CodeGen/UnreachableVisitor.hpp
@@ -4,6 +4,7 @@
 
 #include "vast/Util/Warnings.hpp"
 #include "vast/Util/TypeList.hpp"
+#include "vast/CodeGen/Types.hpp"
 
 namespace vast::cg
 {

--- a/include/vast/CodeGen/Util.hpp
+++ b/include/vast/CodeGen/Util.hpp
@@ -8,9 +8,12 @@ VAST_RELAX_WARNINGS
 #include <mlir/IR/IRMapping.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Region.h>
+#include <clang/AST/Attr.h>
 VAST_UNRELAX_WARNINGS
 
 #include <gap/core/generator.hpp>
+
+#include <vast/Util/TypeList.hpp>
 
 namespace vast::cg
 {
@@ -19,6 +22,15 @@ namespace vast::cg
         for (auto x : from) {
             if (auto s = dyn_cast< T >(x))
                 co_yield s;
+        }
+    }
+
+    template< typename list >
+    gap::generator< clang::Attr * > exclude_attrs(auto from) {
+        for (auto attr : from) {
+            if (!util::is_one_of< list >(attr)) {
+                co_yield attr;
+            }
         }
     }
 } // namespace vast::cg

--- a/include/vast/CodeGen/Util.hpp
+++ b/include/vast/CodeGen/Util.hpp
@@ -17,7 +17,7 @@ namespace vast::cg
     template< typename T >
     gap::generator< T * > filter(auto from) {
         for (auto x : from) {
-            if (auto s = clang::dyn_cast< T >(x))
+            if (auto s = dyn_cast< T >(x))
                 co_yield s;
         }
     }

--- a/include/vast/Dialect/Core/Linkage.td
+++ b/include/vast/Dialect/Core/Linkage.td
@@ -51,7 +51,8 @@ def GlobalLinkageKind : I32EnumAttr<
         Global_ExternalLinkage, Global_AvailableExternallyLinkage,
         Global_LinkOnceAnyLinkage, Global_LinkOnceODRLinkage,
         Global_WeakAnyLinkage, Global_WeakODRLinkage, Global_InternalLinkage,
-        Global_PrivateLinkage, Global_ExternalWeakLinkage, Global_CommonLinkage
+        Global_PrivateLinkage, Global_ExternalWeakLinkage, Global_CommonLinkage,
+        Global_AppendingLinkage
     ]>
 {
   let cppNamespace = "::vast::core";

--- a/include/vast/Dialect/HighLevel/HighLevelAttributes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelAttributes.td
@@ -37,4 +37,10 @@ def NoInstrumentAttr  : HighLevel_Attr< "NoInstrumentFunction", "no_instrument_f
 def PackedAttr        : HighLevel_Attr< "Packed", "packed" >;
 def WarnUnusedResAttr : HighLevel_Attr< "WarnUnusedResult", "warn_unused_result" >;
 
+def AllocSizeAttr : HighLevel_Attr< "AllocSize", "alloc_size" >{
+  let parameters = (ins "int":$size_arg_pos, OptionalParameter< "int" >:$num_arg_pos);
+
+  let assemblyFormat = "`<` `size_pos` `:` $size_arg_pos (`,` `num_pos` `:` $num_arg_pos^)? `>`";
+}
+
 #endif // VAST_DIALECT_HIGHLEVEL_IR_HIGHLEVELATTRIBUTES

--- a/include/vast/Dialect/HighLevel/HighLevelAttributes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelAttributes.td
@@ -36,6 +36,13 @@ def LoaderUninitAttr  : HighLevel_Attr< "LoaderUninitialized", "loader_uninitial
 def NoInstrumentAttr  : HighLevel_Attr< "NoInstrumentFunction", "no_instrument_function" >;
 def PackedAttr        : HighLevel_Attr< "Packed", "packed" >;
 def WarnUnusedResAttr : HighLevel_Attr< "WarnUnusedResult", "warn_unused_result" >;
+def MallocAttr : HighLevel_Attr< "Malloc", "malloc" >;
+def NoThrowAttr : HighLevel_Attr< "NoThrow", "nothrow" >;
+
+def BuiltinAttr : HighLevel_Attr< "Builtin", "builtin" > {
+  let parameters = (ins "unsigned":$ID);
+  let assemblyFormat = "`<` $ID `>`";
+}
 
 def AllocSizeAttr : HighLevel_Attr< "AllocSize", "alloc_size" >{
   let parameters = (ins "int":$size_arg_pos, OptionalParameter< "int" >:$num_arg_pos);

--- a/include/vast/Dialect/HighLevel/HighLevelAttributes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelAttributes.td
@@ -36,7 +36,7 @@ def LoaderUninitAttr  : HighLevel_Attr< "LoaderUninitialized", "loader_uninitial
 def NoInstrumentAttr  : HighLevel_Attr< "NoInstrumentFunction", "no_instrument_function" >;
 def PackedAttr        : HighLevel_Attr< "Packed", "packed" >;
 def WarnUnusedResAttr : HighLevel_Attr< "WarnUnusedResult", "warn_unused_result" >;
-def MallocAttr : HighLevel_Attr< "Malloc", "malloc" >;
+def RestrictAttr : HighLevel_Attr< "Restrict", "restrict" >;
 def NoThrowAttr : HighLevel_Attr< "NoThrow", "nothrow" >;
 
 def BuiltinAttr : HighLevel_Attr< "Builtin", "builtin" > {

--- a/include/vast/Util/TypeList.hpp
+++ b/include/vast/Util/TypeList.hpp
@@ -142,7 +142,7 @@ namespace vast::util {
         template< typename list, typename elem, std::size_t ...idxs >
         constexpr bool is_one_of(elem e, std::index_sequence< idxs... >)
         {
-            return (e.template isa< std::tuple_element_t< idxs, list > >() || ...);
+            return (isa< std::tuple_element_t< idxs, list > >(e) || ...);
         }
 
         template< typename list, typename elem >

--- a/lib/vast/Dialect/Core/Linkage.cpp
+++ b/lib/vast/Dialect/Core/Linkage.cpp
@@ -136,14 +136,18 @@ namespace vast::core {
     // adapted from getMLIRVisibilityFromCIRLinkage
     Visibility get_visibility_from_linkage(GlobalLinkageKind linkage) {
         switch (linkage) {
+            case GlobalLinkageKind::ExternalLinkage:
+            case GlobalLinkageKind::AvailableExternallyLinkage:
+            case GlobalLinkageKind::LinkOnceAnyLinkage:
+            case GlobalLinkageKind::LinkOnceODRLinkage:
+            case GlobalLinkageKind::WeakAnyLinkage:
+            case GlobalLinkageKind::WeakODRLinkage:
+            case GlobalLinkageKind::AppendingLinkage:
+            case GlobalLinkageKind::ExternalWeakLinkage:
+                return Visibility::Public;
             case GlobalLinkageKind::InternalLinkage:
             case GlobalLinkageKind::PrivateLinkage:
                 return Visibility::Private;
-            case GlobalLinkageKind::ExternalLinkage:
-            case GlobalLinkageKind::AvailableExternallyLinkage:
-            case GlobalLinkageKind::ExternalWeakLinkage:
-            case GlobalLinkageKind::LinkOnceODRLinkage:
-                return Visibility::Public;
             default:
                 VAST_UNREACHABLE("unsupported linkage kind {0}", stringifyGlobalLinkageKind(linkage));
         }

--- a/test/vast/Dialect/HighLevel/attr-c.c
+++ b/test/vast/Dialect/HighLevel/attr-c.c
@@ -1,0 +1,10 @@
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
+
+// CHECK: hl.func @malloc {{.*}} attributes {alloc_size = #hl.alloc_size<size_pos : 1>, builtin = #hl.builtin<836>, malloc = #hl.restrict, nothrow = #hl.nothrow, sym_visibility = "private"}
+#include <stdlib.h>
+
+int main() {
+    int *x = malloc(sizeof(*x));
+    return 0;
+}

--- a/test/vast/Dialect/HighLevel/attr-c.c
+++ b/test/vast/Dialect/HighLevel/attr-c.c
@@ -1,7 +1,7 @@
 // RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s
 // RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
 
-// CHECK: hl.func @malloc {{.*}} attributes {alloc_size = #hl.alloc_size<size_pos : 1>, builtin = #hl.builtin<836>, malloc = #hl.restrict, nothrow = #hl.nothrow, sym_visibility = "private"}
+// CHECK: hl.func @malloc {{.*}} attributes {alloc_size = #hl.alloc_size<size_pos : 1>, builtin = #hl.builtin<{{[0-9]+}}>, malloc = #hl.restrict, nothrow = #hl.nothrow, sym_visibility = "private"}
 #include <stdlib.h>
 
 int main() {

--- a/test/vast/Dialect/HighLevel/attr-d.c
+++ b/test/vast/Dialect/HighLevel/attr-d.c
@@ -1,0 +1,9 @@
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
+
+// CHECK: hl.func @fun weak () -> !hl.void {
+void __attribute__((__weak__)) fun (void) {}
+int mian() {
+    fun();
+    return 0;
+}


### PR DESCRIPTION
- support for additional attributes (I covered all attributes that are used for `malloc` in `stdlib`)
- deduplication of attributes - I believe this shouldn't be necessary, but it might be a bug in the AST…