### PR TITLE
Generalize emit mlir options and remove duplicits.

### DIFF
--- a/include/vast/Frontend/FrontendAction.hpp
+++ b/include/vast/Frontend/FrontendAction.hpp
@@ -15,8 +15,6 @@ namespace vast::cc {
 
     enum class output_type {
         emit_assembly,
-        emit_high_level,
-        emit_cir,
         emit_mlir,
         emit_llvm,
         emit_obj,

--- a/include/vast/Frontend/GenAction.hpp
+++ b/include/vast/Frontend/GenAction.hpp
@@ -26,13 +26,11 @@ namespace mlir {
 namespace vast::cc {
 
     namespace opt {
-        constexpr string_ref emit_high_level = "emit-high-level";
-        constexpr string_ref emit_cir  = "emit-cir";
         constexpr string_ref emit_llvm = "emit-llvm";
         constexpr string_ref emit_obj  = "emit-obj";
         constexpr string_ref emit_asm  = "emit-asm";
 
-        constexpr string_ref emit_mlir = "emit-mlir";
+        constexpr string_ref emit_mlir  = "emit-mlir";
 
         constexpr string_ref disable_vast_verifier = "disable-vast-verifier";
         constexpr string_ref vast_verify_diags = "verify-diags";
@@ -106,24 +104,6 @@ namespace vast::cc {
     //
     struct emit_obj_action : vast_gen_action {
         emit_obj_action(const vast_args &vargs, mcontext_t *mcontext = nullptr);
-    private:
-        virtual void anchor();
-    };
-
-    //
-    // Emit high level mlir dialect
-    //
-    struct emit_high_level_action : vast_gen_action {
-        emit_high_level_action(const vast_args &vargs, mcontext_t *mcontext = nullptr);
-    private:
-        virtual void anchor();
-    };
-
-    //
-    // Emit cir mlir dialect
-    //
-    struct emit_cir_action : vast_gen_action {
-        emit_cir_action(const vast_args &vargs, mcontext_t *mcontext = nullptr);
     private:
         virtual void anchor();
     };

--- a/lib/vast/Frontend/GenAction.cpp
+++ b/lib/vast/Frontend/GenAction.cpp
@@ -32,7 +32,7 @@ namespace vast::cc {
     namespace opt {
 
         bool emit_only_mlir(const vast_args &vargs) {
-            for (auto arg : {emit_high_level, emit_cir, emit_mlir}) {
+            for (auto arg : {emit_mlir}) {
                 if (vargs.has_option(arg))
                     return true;
             }
@@ -51,8 +51,6 @@ namespace vast::cc {
     static std::string get_output_stream_suffix(output_type act) {
         switch (act) {
             case output_type::emit_assembly: return "s";
-            case output_type::emit_high_level: return "hl";
-            case output_type::emit_cir: return "cir";
             case output_type::emit_mlir: return "mlir";
             case output_type::emit_llvm: return "ll";
             case output_type::emit_obj: return "o";
@@ -285,10 +283,6 @@ namespace vast::cc {
                 case output_type::emit_assembly:
                     return emit_backend_output(clang::BackendAction::Backend_EmitAssembly,
                                                std::move(mod), mctx.get());
-                case output_type::emit_high_level:
-                    return emit_mlir_output(target_dialect::high_level, std::move(mod), mctx.get());
-                case output_type::emit_cir:
-                    VAST_UNIMPLEMENTED_MSG("HandleTranslationUnit for emit CIR not implemented");
                 case output_type::emit_mlir:
                 {
                     auto trg = parse_target_dialect(vargs.get_options_list(opt::emit_mlir));
@@ -439,20 +433,6 @@ namespace vast::cc {
 
     emit_obj_action::emit_obj_action(const vast_args &vargs, mcontext_t *mcontex)
         : vast_gen_action(output_type::emit_obj, vargs, mcontex)
-    {}
-
-    // emit high level
-    void emit_high_level_action::anchor() {}
-
-    emit_high_level_action::emit_high_level_action(const vast_args &vargs, mcontext_t *mcontex)
-        : vast_gen_action(output_type::emit_high_level, vargs, mcontex)
-    {}
-
-    // emit cir
-    void emit_cir_action::anchor() {}
-
-    emit_cir_action::emit_cir_action(const vast_args &vargs, mcontext_t *mcontex)
-        : vast_gen_action(output_type::emit_cir, vargs, mcontex)
     {}
 
 } // namespace vast::cc

--- a/test/vast/Dialect/HighLevel/glob-front-a.c
+++ b/test/vast/Dialect/HighLevel/glob-front-a.c
@@ -1,4 +1,4 @@
-// RUN: %vast-front %s -vast-emit-high-level -o - | %file-check %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | %file-check %s
 
 // CHECK: hl.var "NUM"
 // CHECK: hl.value.yield

--- a/test/vast/Dialect/HighLevel/glob-front-b.c
+++ b/test/vast/Dialect/HighLevel/glob-front-b.c
@@ -1,4 +1,4 @@
-// RUN: %vast-front %s -vast-emit-high-level -o - | %file-check %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | %file-check %s
 
 // CHECK: hl.var "NUM"
 short NUM;

--- a/test/vast/Dialect/HighLevel/glob-front-c.c
+++ b/test/vast/Dialect/HighLevel/glob-front-c.c
@@ -1,4 +1,4 @@
-// RUN: %vast-front %s -vast-emit-high-level -o - | %file-check %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | %file-check %s
 
 extern short GIB_SHORT(void);
 // CHECK: hl.var "NUM"

--- a/test/vast/Dialect/HighLevel/hello-world.c
+++ b/test/vast/Dialect/HighLevel/hello-world.c
@@ -1,4 +1,4 @@
-// RUN: %vast-front %s -vast-emit-high-level -o - | %file-check %s
+// RUN: %vast-front %s -vast-emit-mlir=hl -o - | %file-check %s
 
 // CHECK: hl.func @printf
 #include <stdio.h>

--- a/tools/vast-front/compiler_invocation.cpp
+++ b/tools/vast-front/compiler_invocation.cpp
@@ -25,14 +25,6 @@ namespace vast::cc
         auto act   = opts.ProgramAction;
         using namespace clang::frontend;
 
-        if (vargs.has_option(opt::emit_high_level)) {
-            return std::make_unique< vast::cc::emit_high_level_action >(vargs);
-        }
-
-        if (vargs.has_option(opt::emit_cir)) {
-            return std::make_unique< vast::cc::emit_cir_action >(vargs);
-        }
-
         if (vargs.has_option(opt::emit_mlir)) {
             return std::make_unique< vast::cc::emit_mlir_action >(vargs);
         }


### PR DESCRIPTION
Replaces specific options `-vast-emit-high-level` and `-vast-emit-cir` with generic `-vast-emit-mlir=...`.