### PR TITLE
Unify various copy & paste utilities of `FuncOp`s.

### DIFF
--- a/include/vast/Dialect/ABI/ABI.td
+++ b/include/vast/Dialect/ABI/ABI.td
@@ -24,6 +24,8 @@ def ABI_Dialect : Dialect {
         void registerTypes();
         void registerAttributes();
     }];
+
+    let dependentDialects = ["vast::core::CoreDialect"];
 }
 
 class ABI_Op< string mnemonic, list< Trait > traits = [] >

--- a/include/vast/Dialect/ABI/ABIOps.hpp
+++ b/include/vast/Dialect/ABI/ABIOps.hpp
@@ -20,6 +20,7 @@ VAST_RELAX_WARNINGS
 #include "vast/Dialect/Core/CoreDialect.hpp"
 #include "vast/Dialect/Core/CoreTypes.hpp"
 #include "vast/Dialect/Core/CoreAttributes.hpp"
+#include "vast/Dialect/Core/Func.hpp"
 
 #define GET_OP_CLASSES
 #include "vast/Dialect/ABI/ABI.h.inc"

--- a/include/vast/Dialect/Core/Func.hpp
+++ b/include/vast/Dialect/Core/Func.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2021-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Util/Warnings.hpp"
+#include "vast/Util/Common.hpp"
+
+VAST_RELAX_WARNINGS
+#include <mlir/IR/FunctionImplementation.h>
+VAST_UNRELAX_WARNINGS
+
+#include "vast/Dialect/Core/CoreDialect.hpp"
+
+namespace vast::core {
+
+    llvm::StringRef getLinkageAttrNameString();
+
+    // This function is adapted from CIR:
+    //
+    // Verifies linkage types, similar to LLVM:
+    // - functions don't have 'common' linkage
+    // - external functions have 'external' or 'extern_weak' linkage
+    logical_result verifyFuncOp(auto op) {
+        using core::GlobalLinkageKind;
+
+        auto linkage = op.getLinkage();
+        constexpr auto common = GlobalLinkageKind::CommonLinkage;
+        if (linkage == common) {
+            return op.emitOpError() << "functions cannot have '"
+                << stringifyGlobalLinkageKind(common)
+                << "' linkage";
+        }
+
+        // isExternal(FunctionOpInterface) only checks for empty
+        // bodyonly checks for empty body...
+        // We need to be able to handle functions with internal linkage without body.
+        if (linkage != GlobalLinkageKind::InternalLinkage && op.isExternal()) {
+            constexpr auto external = GlobalLinkageKind::ExternalLinkage;
+            constexpr auto weak_external = GlobalLinkageKind::ExternalWeakLinkage;
+            if (linkage != external && linkage != weak_external) {
+                return op.emitOpError() << "external functions must have '"
+                    << stringifyGlobalLinkageKind(external)
+                    << "' or '"
+                    << stringifyGlobalLinkageKind(weak_external)
+                    << "' linkage";
+            }
+            return mlir::success();
+        }
+        return mlir::success();
+    }
+
+    ParseResult parseFunctionSignatureAndBody(
+        Parser &parser, Attribute &funcion_type,
+        mlir::NamedAttrList &attr_dict, Region &body
+    );
+
+
+    void printFunctionSignatureAndBody(
+        Printer &printer, auto op,
+        Attribute /* funcion_type */, mlir::DictionaryAttr, Region &body
+    ) {
+        if (op.getLinkage() != core::GlobalLinkageKind::ExternalLinkage) {
+            printer << stringifyGlobalLinkageKind(op.getLinkage()) << ' ';
+        }
+
+        auto fty = op.getFunctionType();
+        mlir::function_interface_impl::printFunctionSignature(
+            printer, op, fty.getInputs(), fty.isVarArg(), fty.getResults()
+        );
+
+        mlir::function_interface_impl::printFunctionAttributes(
+            printer, op, { getLinkageAttrNameString(), op.getFunctionTypeAttrName() }
+        );
+
+        if (!body.empty()) {
+            printer.getStream() << " ";
+            printer.printRegion( body,
+                /* printEntryBlockArgs */false,
+                /* printBlockTerminators */true
+            );
+        }
+    }
+} // namespace vast::core

--- a/include/vast/Dialect/Core/Func.hpp
+++ b/include/vast/Dialect/Core/Func.hpp
@@ -31,8 +31,7 @@ namespace vast::core {
                 << "' linkage";
         }
 
-        // isExternal(FunctionOpInterface) only checks for empty
-        // bodyonly checks for empty body...
+        // isExternal(FunctionOpInterface) only checks for empty body...
         // We need to be able to handle functions with internal linkage without body.
         if (linkage != GlobalLinkageKind::InternalLinkage && op.isExternal()) {
             constexpr auto external = GlobalLinkageKind::ExternalLinkage;

--- a/include/vast/Dialect/Core/Func.td
+++ b/include/vast/Dialect/Core/Func.td
@@ -67,6 +67,10 @@ class Core_FuncBaseOp< Dialect dialect, string mnemonic, list< Trait > traits = 
 
   let regions = (region AnyRegion:$body);
 
+  let assemblyFormat = [{
+    $sym_name custom< FunctionSignatureAndBody >($function_type, attr-dict, $body)
+  }];
+
   let extraClassDeclaration = [{
     bool isVarArg() { return getFunctionType().isVarArg(); }
 

--- a/include/vast/Dialect/HighLevel/HighLevel.td
+++ b/include/vast/Dialect/HighLevel/HighLevel.td
@@ -35,6 +35,8 @@ def HighLevel_Dialect : Dialect {
     let useDefaultAttributePrinterParser = 1;
 
     let hasConstantMaterializer = 1;
+
+    let dependentDialects = ["vast::core::CoreDialect"];
 }
 
 class HighLevel_Op< string mnemonic, list< Trait > traits = [] >

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -59,10 +59,6 @@ def HighLevel_FuncOp
     }] >
   ];
 
-  let assemblyFormat = [{
-    $sym_name custom< FunctionSignatureAndBody >($function_type, attr-dict, $body)
-  }];
-
   let hasVerifier = 1;
 }
 

--- a/include/vast/Dialect/LowLevel/LowLevel.td
+++ b/include/vast/Dialect/LowLevel/LowLevel.td
@@ -27,6 +27,8 @@ def LowLevel_Dialect : Dialect {
         void registerTypes();
         void registerAttributes();
     }];
+
+    let dependentDialects = ["vast::core::CoreDialect"];
 }
 
 class LowLevel_Op< string mnemonic, list< Trait > traits = [] >

--- a/lib/vast/Dialect/ABI/ABIOps.cpp
+++ b/lib/vast/Dialect/ABI/ABIOps.cpp
@@ -11,11 +11,25 @@ VAST_UNRELAX_WARNINGS
 
 #include "vast/Util/Dialect.hpp"
 
-#define GET_OP_CLASSES
-#include "vast/Dialect/ABI/ABI.cpp.inc"
+#include "vast/Dialect/Core/Func.hpp"
 
 namespace vast::abi
 {
+    ParseResult parseFunctionSignatureAndBody(
+        Parser &parser, Attribute &funcion_type,
+        mlir::NamedAttrList &attr_dict, Region &body
+    ) {
+        return core::parseFunctionSignatureAndBody( parser, funcion_type, attr_dict, body );
+    }
+
+
+    void printFunctionSignatureAndBody(
+        Printer &printer, auto op,
+        Attribute attr, mlir::DictionaryAttr dict, Region &body
+    ) {
+        return core::printFunctionSignatureAndBody( printer, op, attr, dict, body );
+    }
+
     mlir::CallInterfaceCallable CallOp::getCallableForCallee()
     {
         return (*this)->getAttrOfType< mlir::SymbolRefAttr >("callee");
@@ -99,3 +113,6 @@ namespace vast::abi
     SSACFG_REGION_OP( WrapFuncOp );
 
 } // namespace vast::abi
+
+#define GET_OP_CLASSES
+#include "vast/Dialect/ABI/ABI.cpp.inc"

--- a/lib/vast/Dialect/Core/CMakeLists.txt
+++ b/lib/vast/Dialect/Core/CMakeLists.txt
@@ -5,6 +5,7 @@ add_vast_dialect_library(Core
     CoreTypes.cpp
     CoreTraits.cpp
     CoreAttributes.cpp
+    Func.cpp
     Linkage.cpp
 )
 

--- a/lib/vast/Dialect/Core/Func.cpp
+++ b/lib/vast/Dialect/Core/Func.cpp
@@ -60,9 +60,6 @@ namespace vast::core
             arg_types.push_back(arg.type);
         }
 
-        // TODO: no idea why CoreDialect is not loaded before
-        parser.getContext()->loadDialect< core::CoreDialect >();
-
         // create parsed function type
         funcion_type = mlir::TypeAttr::get(
             core::FunctionType::get(

--- a/lib/vast/Dialect/Core/Func.cpp
+++ b/lib/vast/Dialect/Core/Func.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2021-present, Trail of Bits, Inc.
+
+#include "vast/Util/Warnings.hpp"
+
+VAST_RELAX_WARNINGS
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/IR/OperationSupport.h>
+#include <mlir/IR/FunctionImplementation.h>
+
+#include <llvm/Support/ErrorHandling.h>
+VAST_UNRELAX_WARNINGS
+
+#include "vast/Dialect/Core/Func.hpp"
+
+#include "vast/Dialect/Core/CoreAttributes.hpp"
+#include "vast/Dialect/Core/CoreDialect.hpp"
+#include "vast/Dialect/Core/Linkage.hpp"
+
+#include "vast/Util/Common.hpp"
+#include "vast/Util/Dialect.hpp"
+#include "vast/Util/Region.hpp"
+
+namespace vast::core
+{
+    //===----------------------------------------------------------------------===//
+    // FuncOp
+    //===----------------------------------------------------------------------===//
+
+    llvm::StringRef getLinkageAttrNameString() { return "linkage"; }
+
+    ParseResult parseFunctionSignatureAndBody(
+        Parser &parser, Attribute &funcion_type, mlir::NamedAttrList &attr_dict, Region &body
+    ) {
+        using core::GlobalLinkageKind;
+
+        // Default to external linkage if no keyword is provided.
+        attr_dict.append(
+            getLinkageAttrNameString(),
+            core::GlobalLinkageKindAttr::get(
+                parser.getContext(),
+                parse_optional_vast_keyword< GlobalLinkageKind >(
+                    parser, GlobalLinkageKind::ExternalLinkage
+                )
+            )
+        );
+
+        llvm::SmallVector< Parser::Argument, 8 > arguments;
+        llvm::SmallVector< mlir::DictionaryAttr, 1 > result_attrs;
+        llvm::SmallVector< Type, 8 > arg_types;
+        llvm::SmallVector< Type, 4 > result_types;
+
+        bool is_variadic = false;
+        if (mlir::failed(mlir::function_interface_impl::parseFunctionSignature(
+            parser, /*allowVariadic=*/true, arguments, is_variadic, result_types, result_attrs
+        ))) {
+            return mlir::failure();
+        }
+
+        for (auto &arg : arguments) {
+            arg_types.push_back(arg.type);
+        }
+
+        // TODO: no idea why CoreDialect is not loaded before
+        parser.getContext()->loadDialect< core::CoreDialect >();
+
+        // create parsed function type
+        funcion_type = mlir::TypeAttr::get(
+            core::FunctionType::get(
+                arg_types, result_types, is_variadic
+            )
+        );
+
+        // If additional attributes are present, parse them.
+        if (parser.parseOptionalAttrDictWithKeyword(attr_dict)) {
+            return mlir::failure();
+        }
+
+        // TODO: Add the attributes to the function arguments.
+        // VAST_ASSERT(result_attrs.size() == result_types.size());
+        // return mlir::function_interface_impl::addArgAndResultAttrs(
+        //     builder, state, arguments, result_attrs
+        // );
+
+        auto loc = parser.getCurrentLocation();
+        auto parse_result = parser.parseOptionalRegion(
+            body, arguments, /* enableNameShadowing */false
+        );
+
+        if (parse_result.has_value()) {
+            if (failed(*parse_result))
+                return mlir::failure();
+            // Function body was parsed, make sure its not empty.
+            if (body.empty())
+                return parser.emitError(loc, "expected non-empty function body");
+        }
+
+        return mlir::success();
+    }
+
+} // namespace vast::core

--- a/lib/vast/Dialect/LowLevel/LowLevelOps.cpp
+++ b/lib/vast/Dialect/LowLevel/LowLevelOps.cpp
@@ -5,6 +5,8 @@
 #include "vast/Dialect/LowLevel/LowLevelDialect.hpp"
 #include "vast/Dialect/LowLevel/LowLevelOps.hpp"
 
+#include "vast/Dialect/Core/Func.hpp"
+
 VAST_RELAX_WARNINGS
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/FunctionInterfaces.h>
@@ -29,112 +31,22 @@ namespace vast::ll
     // FuncOp
     //===----------------------------------------------------------------------===//
 
-    // This function is adapted from CIR:
-    //
-    // Verifies linkage types, similar to LLVM:
-    // - functions don't have 'common' linkage
-    // - external functions have 'external' or 'extern_weak' linkage
     logical_result FuncOp::verify() {
-        using core::GlobalLinkageKind;
-
-        auto linkage = getLinkage();
-        constexpr auto common = GlobalLinkageKind::CommonLinkage;
-        if (linkage == common) {
-            return emitOpError() << "functions cannot have '"
-                << stringifyGlobalLinkageKind(common)
-                << "' linkage";
-        }
-
-        // isExternal(FunctionOpInterface) only checks for empty bodyonly checks for empty body...
-        // We need to be able to handle functions with internal linkage without body.
-        if (linkage != GlobalLinkageKind::InternalLinkage && isExternal()) {
-            constexpr auto external = GlobalLinkageKind::ExternalLinkage;
-            constexpr auto weak_external = GlobalLinkageKind::ExternalWeakLinkage;
-            if (linkage != external && linkage != weak_external) {
-                return emitOpError() << "external functions must have '"
-                    << stringifyGlobalLinkageKind(external)
-                    << "' or '"
-                    << stringifyGlobalLinkageKind(weak_external)
-                    << "' linkage";
-            }
-            return mlir::success();
-        }
-        return mlir::success();
+        return core::verifyFuncOp(*this);
     }
 
     ParseResult parseFunctionSignatureAndBody(
-        Parser &parser, Attribute &funcion_type, mlir::NamedAttrList &attr_dict, Region &body
+        Parser &parser, Attribute &function_type,
+        mlir::NamedAttrList &attr_dict, Region &body
     ) {
-        llvm::SmallVector< Parser::Argument, 8 > arguments;
-        llvm::SmallVector< mlir::DictionaryAttr, 1 > result_attrs;
-        llvm::SmallVector< Type, 8 > arg_types;
-        llvm::SmallVector< Type, 4 > result_types;
-
-        auto &builder = parser.getBuilder();
-
-        bool is_variadic = false;
-        if (mlir::failed(mlir::function_interface_impl::parseFunctionSignature(
-            parser, /*allowVariadic=*/false, arguments, is_variadic, result_types, result_attrs
-        ))) {
-            return mlir::failure();
-        }
-
-
-        for (auto &arg : arguments) {
-            arg_types.push_back(arg.type);
-        }
-
-        // create parsed function type
-        funcion_type = mlir::TypeAttr::get(
-            builder.getFunctionType(arg_types, result_types)
-        );
-
-        // If additional attributes are present, parse them.
-        if (parser.parseOptionalAttrDictWithKeyword(attr_dict)) {
-            return mlir::failure();
-        }
-
-        // TODO: Add the attributes to the function arguments.
-        // VAST_ASSERT(result_attrs.size() == result_types.size());
-        // return mlir::function_interface_impl::addArgAndResultAttrs(
-        //     builder, state, arguments, result_attrs
-        // );
-
-        auto loc = parser.getCurrentLocation();
-        auto parse_result = parser.parseOptionalRegion(
-            body, arguments, /* enableNameShadowing */false
-        );
-
-        if (parse_result.has_value()) {
-            if (failed(*parse_result))
-                return mlir::failure();
-            // Function body was parsed, make sure its not empty.
-            if (body.empty())
-                return parser.emitError(loc, "expected non-empty function body");
-        }
-
-        return mlir::success();
+        return core::parseFunctionSignatureAndBody(parser, function_type, attr_dict, body);
     }
 
     void printFunctionSignatureAndBody(
-        Printer &printer, FuncOp op, Attribute /* funcion_type */, mlir::DictionaryAttr, Region &body
+        Printer &printer, FuncOp op, Attribute function_type,
+        mlir::DictionaryAttr dict_attr, Region &body
     ) {
-        auto fty = op.getFunctionType();
-        mlir::function_interface_impl::printFunctionSignature(
-            printer, op, fty.getInputs(), /* variadic */false, fty.getResults()
-        );
-
-        mlir::function_interface_impl::printFunctionAttributes(
-            printer, op, {"linkage", op.getFunctionTypeAttrName() }
-        );
-
-        if (!body.empty()) {
-            printer.getStream() << " ";
-            printer.printRegion( body,
-                /* printEntryBlockArgs */false,
-                /* printBlockTerminators */true
-            );
-        }
+        return core::printFunctionSignatureAndBody(printer, op, function_type, dict_attr, body);
     }
 
     SSACFG_REGION_OP( FuncOp );


### PR DESCRIPTION
Not sure how to avoid the stubs that forward to their `core::` counterparts as I was not able to specify `custom< core::XXX >` in the `assemblyFormat`. One option would be to import `Core/Func.hpp` and then just `using namespace vast::core` but it sounds like more pain than gain.