### PR TITLE
Fix conversion of chained logical operators

### DIFF
--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -1029,7 +1029,11 @@ namespace vast::conv::irstollvm
             auto res_type = this->convert(op.getResult().getType());
             if (!res_type)
                 return logical_result::failure();
-            rewriter.replaceOpWithNewOp< LLVM::ZExtOp >(op, res_type, xor_val);
+            if (res_type != xor_val.getType()) {
+                rewriter.replaceOpWithNewOp< LLVM::ZExtOp >(op, res_type, xor_val);
+            } else {
+                rewriter.replaceOp(op, xor_val);
+            }
             return logical_result::success();
         }
 

--- a/lib/vast/Conversion/Core/ToLLVM.cpp
+++ b/lib/vast/Conversion/Core/ToLLVM.cpp
@@ -108,8 +108,10 @@ namespace vast
 
                 cond_br_lhs(rewriter, op.getLoc(), cmp_lhs, rhs_block, end_block);
 
-                // In the case that `rhs` consists of multiple blocks we need to
-                // insert to the last block…
+                // In the case that the `rhs` region consists of multiple blocks (i.e.
+                // it has already been lowered, since hl doesn't have blocks)
+                // we need to insert the break to the last block of this region - which
+                // is the region that is created by splitting the `end_block`.
                 // e.g.: in a && (b || c) mlir first matches the `||` which creates
                 // it's own cf blocks and then matches the `&&`
                 auto rhs_end_it = std::prev(end_block->getIterator(), 1);

--- a/lib/vast/Conversion/Core/ToLLVM.cpp
+++ b/lib/vast/Conversion/Core/ToLLVM.cpp
@@ -47,8 +47,7 @@ namespace vast
 
                 auto &first_block = lazy_region.front();
                 // The rewriter API doesn't provide a call to insert into a selected block
-                auto target_it = target->getIterator();
-                std::advance(target_it, 1);
+                auto target_it = std::next(target->getIterator());
                 rewriter.inlineRegionBefore(
                     lazy_region, *target->getParent(), target_it
                 );
@@ -114,7 +113,7 @@ namespace vast
                 // is the region that is created by splitting the `end_block`.
                 // e.g.: in a && (b || c) mlir first matches the `||` which creates
                 // it's own cf blocks and then matches the `&&`
-                auto rhs_end_it = std::prev(end_block->getIterator(), 1);
+                auto rhs_end_it = std::prev(end_block->getIterator());
                 rewriter.setInsertionPointToEnd(&*rhs_end_it);
                 auto cmp_rhs = rewriter.create< LLVM::ICmpOp >(
                     op.getLoc(), LLVM::ICmpPredicate::ne, rhs_res, zero

--- a/test/vast/Conversion/Common/IRsToLLVM/bin_chain-a.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/bin_chain-a.c
@@ -1,0 +1,12 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -o - %s | %file-check %s
+
+int main() {
+    int a = 5;
+    int b = 5;
+    int c = 5;
+    // CHECK: ^bb1{{.*}}// pred: ^bb0
+    // CHECK: ^bb2{{.*}}// pred: ^bb1
+    // CHECK: ^bb3{{.*}}// 2 preds: ^bb1, ^bb2
+    // CHECK: ^bb4{{.*}}// 2 preds: ^bb0, ^bb3
+    return a && (!b && !c);
+}


### PR DESCRIPTION
`a && (!b || !c)`