### PR TITLE
Enables VAST codegen to be used directly on a TranslatioUnitDecl independent of an ASTConsumer. 

### DIFF
--- a/include/vast/CodeGen/CodeGenTypeVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenTypeVisitor.hpp
@@ -117,7 +117,7 @@ namespace vast::cg {
 
         auto with_qualifiers(const clang::EnumType *ty, qualifiers quals) -> mlir_type {
             auto name = make_name_attr( context().decl_name(ty->getDecl()) );
-            return with_cv_qualifiers( type_builder< hl::RecordType >().bind(name), quals ).freeze();
+            return with_cv_qualifiers( type_builder< hl::EnumType >().bind(name), quals ).freeze();
         }
 
         auto with_qualifiers(const clang::TypedefType *ty, qualifiers quals) -> mlir_type {

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.td
@@ -170,6 +170,11 @@ class IsMaybeWrappedTypedef< string arg > : PredOpTrait<
     CPred< "::vast::hl::strip_elaborated($" # arg # ").hasTrait< mlir::TypeTrait::TypedefTrait >()" >
 >;
 
+class IsMaybeWrappedEnum< string arg > : PredOpTrait<
+    "type is an enum, maybe wrapped in the elaborated type",
+    CPred< "::vast::hl::strip_elaborated($" # arg # ").isa< ::vast::hl::EnumType >()" >
+>;
+
 class ContainsTypedef< list< string > tl > : PredOpTrait< "contains typedef type",
     Or< !foreach(type, tl, IsMaybeWrappedTypedef< type >.predicate) >
 >;
@@ -264,12 +269,13 @@ def LongLongType : IntegerType< "LongLong", "longlong", [LongLongTypeTrait] >;
 def Int128Type   : IntegerType< "Int128", "int128", [Int128TypeTrait] >;
 
 def HLIntegerType : AnyTypeOf<[
-  CharType, ShortType, IntType, LongType, LongLongType, Int128Type, TypedefType
+  CharType, ShortType, IntType, LongType, LongLongType, Int128Type, TypedefType, EnumType
 ]>;
 
 def IntegerLikeType : TypeConstraint<
   Or< [HLIntegerType.predicate, AnyInteger.predicate,
-       IsMaybeWrappedTypedef< "_self" >.predicate] >,
+       IsMaybeWrappedTypedef< "_self" >.predicate,
+       IsMaybeWrappedEnum< "_self" >.predicate] >,
   "integer like type"
 >;
 


### PR DESCRIPTION
The thrust of the changes focuses on codegening function bodies only when the recursive decl visitor actually visits those bodies.

I don't actually expect this PR to be accepted, but it has some bug fixes and changes that perhaps will help explain the needs of mx codegen.