### PR TITLE
Fix lowering of global variables to llvm

### DIFF
--- a/lib/vast/Conversion/Common/Common.hpp
+++ b/lib/vast/Conversion/Common/Common.hpp
@@ -53,6 +53,10 @@ namespace vast::conv::irstollvm {
                 loc, index_type, rewriter.getIntegerAttr(index_type, idx)
             );
         }
+
+        auto undef(auto &rewriter, auto loc, auto type) const {
+            return rewriter.template create< mlir::LLVM::UndefOp >(loc, type);
+        }
     };
 
     template< typename src_t, typename trg_t >

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -426,10 +426,10 @@ namespace vast::conv::irstollvm
             auto create_dummy_value = [&] () -> mlir::Attribute {
                 if (auto trg_arr = mlir::dyn_cast< mlir::LLVM::LLVMArrayType >(target_type)) {
                     attrs_t arr(trg_arr.getNumElements(),
-                                rewriter.getIntegerAttr(trg_arr.getElementType(), 0));
+                                rewriter.getIntegerAttr(rewriter.getIndexType(), 0));
                     return rewriter.getArrayAttr(arr);
                 }
-                return rewriter.getIntegerAttr(target_type, 0);
+                return rewriter.getIntegerAttr(rewriter.getIndexType(), 0);
             };
 
             // So we know this is a global, otherwise it would be in `ll:`.

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -327,8 +327,9 @@ namespace vast::conv::irstollvm
         static bool points_to_scalar(mlir_type t)
         {
             auto ptr = mlir::dyn_cast< mlir::LLVM::LLVMPointerType >(t);
-            VAST_ASSERT(ptr);
-            return !mlir::isa< mlir::LLVM::LLVMStructType >(ptr.getElementType());
+            VAST_CHECK(ptr, "Expected pointer type, {0}", ptr);
+            return !mlir::isa< mlir::LLVM::LLVMStructType, mlir::LLVM::LLVMArrayType >(
+                ptr.getElementType());
         }
 
         void handle_root(typename op_t::Adaptor ops,

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -257,6 +257,11 @@ namespace vast::conv::irstollvm
 
             return base::handle_multiblock(op, ops, rewriter);
         }
+
+        static void legalize(conversion_target &trg)
+        {
+            trg.addIllegalOp< op_t >();
+        }
     };
 
     using label_stmt = hl_scopelike< hl::LabelStmt >;

--- a/lib/vast/Conversion/Common/LLCFToLLVM.hpp
+++ b/lib/vast/Conversion/Common/LLCFToLLVM.hpp
@@ -136,8 +136,8 @@ namespace vast::conv::irstollvm::ll_cf
             conversion_rewriter &rewriter) const
         {
             auto parent = op->getParentRegion();
-            inline_region_blocks(rewriter, op.getBody(),
-                                 mlir::Region::iterator(parent->end()));
+
+            rewriter.inlineRegionBefore(op.getBody(), *parent, parent->end());
 
             // splice newly created translation unit block in the module
             auto &unit_block = parent->back();

--- a/test/vast/Compile/SingleSource/array-a.c
+++ b/test/vast/Compile/SingleSource/array-a.c
@@ -1,0 +1,8 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 12) \
+// RUN:                      && (%t 0 0 0; test $? -eq 11)
+
+int main(int argc, char **argv)
+{
+    int array[] = { 10, 12, 13, 14, 11 };
+    return array[argc];
+}

--- a/test/vast/Compile/SingleSource/array-b.c
+++ b/test/vast/Compile/SingleSource/array-b.c
@@ -1,0 +1,9 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 2) \
+// RUN:                      && (%t 0 0 0; test $? -eq 5)
+
+int g[] = { 1, 2, 3, 4, 5 };
+
+int main(int argc, char **argv)
+{
+    return g[argc];
+}

--- a/test/vast/Compile/SingleSource/array-c.c
+++ b/test/vast/Compile/SingleSource/array-c.c
@@ -1,0 +1,9 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 14) \
+// RUN:                      && (%t 0 0; test $? -eq 18)
+
+
+int main(int argc, char **argv)
+{
+    int array[][2] = { { 1, 11 }, { 2, 12 }, { 3, 13 }, { 4, 14 } };
+    return array[argc][0] + array[argc][1];
+}

--- a/test/vast/Compile/SingleSource/array-d.c
+++ b/test/vast/Compile/SingleSource/array-d.c
@@ -1,0 +1,14 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 1) \
+// RUN:                      && (%t 0 0 0; test $? -eq 4)
+
+struct wrapped
+{
+    int v;
+};
+
+
+int main(int argc, char **argv)
+{
+    struct wrapped array[] = { { 0 }, { 1 }, { 2 }, { 3 }, { 4 } };
+    return array[argc].v;
+}

--- a/test/vast/Compile/SingleSource/array-e.c
+++ b/test/vast/Compile/SingleSource/array-e.c
@@ -1,0 +1,21 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 3) \
+// RUN:                      && (%t 0 0 0; test $? -eq 12)
+
+struct point
+{
+    int vs[3];
+};
+
+int main(int argc, char **argv)
+{
+    struct point points[10];
+
+    for (int i = 0; i < 10; ++i)
+    {
+        struct point t = { i, i + 1, i - 1};
+        points[i] = t;
+    }
+
+    struct point v = points[argc];
+    return v.vs[0] + v.vs[1] + v.vs[2];
+}

--- a/test/vast/Compile/SingleSource/struct-a.c
+++ b/test/vast/Compile/SingleSource/struct-a.c
@@ -1,0 +1,16 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 10)
+
+struct data
+{
+    int a;
+    int b;
+    int c;
+    int d;
+    int e;
+};
+
+int main(int argc, char **argv)
+{
+    struct data d = { 0, 1, 2, 3, 4 };
+    return d.a + d.b + d.c + d.d + d.e;
+}

--- a/test/vast/Compile/SingleSource/struct-b.c
+++ b/test/vast/Compile/SingleSource/struct-b.c
@@ -1,0 +1,23 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 14)
+
+struct wrap
+{
+    int v;
+};
+
+struct data
+{
+    int a;
+    struct wrap b;
+    struct wrap c;
+    struct wrap d;
+    int e;
+};
+
+int main(int argc, char **argv)
+{
+    struct data d = { 0, { 1 }, { 2 }, { 3 }, 4 };
+    struct wrap w = { 5 };
+    d.b = w;
+    return d.a + d.b.v + d.c.v + d.d.v + d.e;
+}

--- a/test/vast/Conversion/Common/IRsToLLVM/cmake-platform-test.c
+++ b/test/vast/Conversion/Common/IRsToLLVM/cmake-platform-test.c
@@ -1,0 +1,52 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -o - %s | %file-check %s
+
+#include <stdint.h>
+#undef KEY
+#if defined(__i386)
+# define KEY '_','_','i','3','8','6'
+#elif defined(__x86_64)
+# define KEY '_','_','x','8','6','_','6','4'
+#elif defined(__PPC64__)
+# define KEY '_','_','P','P','C','6','4','_','_'
+#elif defined(__ppc64__)
+# define KEY '_','_','p','p','c','6','4','_','_'
+#elif defined(__PPC__)
+# define KEY '_','_','P','P','C','_','_'
+#elif defined(__ppc__)
+# define KEY '_','_','p','p','c','_','_'
+#elif defined(__aarch64__)
+# define KEY '_','_','a','a','r','c','h','6','4','_','_'
+#elif defined(__ARM_ARCH_7A__)
+# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','A','_','_'
+#elif defined(__ARM_ARCH_7S__)
+# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','S','_','_'
+#endif
+
+#define SIZE (sizeof(unsigned short))
+
+// CHECK: constant @info_size() {{.*}} !llvm.array
+static char info_size[] =  {'I', 'N', 'F', 'O', ':', 's','i','z','e','[',
+  ('0' + ((SIZE / 10000)%10)),
+  ('0' + ((SIZE / 1000)%10)),
+  ('0' + ((SIZE / 100)%10)),
+  ('0' + ((SIZE / 10)%10)),
+  ('0' +  (SIZE    % 10)),
+  ']',
+#ifdef KEY
+  ' ','k','e','y','[', KEY, ']',
+#endif
+  '\0'};
+
+// CHECK: llvm.func @main
+#ifdef __CLASSIC_C__
+int main(argc, argv) int argc; char *argv[];
+#else
+int main(int argc, char *argv[])
+#endif
+{
+  int require = 0;
+  require += info_size[argc];
+  (void)argv;
+  return require;
+}
+


### PR DESCRIPTION
- [ ] Add conversion for global variables to llvm
- [ ] Check that the example program compiles
```
#include <stdint.h>
#undef KEY
#if defined(__i386)
# define KEY '_','_','i','3','8','6'
#elif defined(__x86_64)
# define KEY '_','_','x','8','6','_','6','4'
#elif defined(__PPC64__)
# define KEY '_','_','P','P','C','6','4','_','_'
#elif defined(__ppc64__)
# define KEY '_','_','p','p','c','6','4','_','_'
#elif defined(__PPC__)
# define KEY '_','_','P','P','C','_','_'
#elif defined(__ppc__)
# define KEY '_','_','p','p','c','_','_'
#elif defined(__aarch64__)
# define KEY '_','_','a','a','r','c','h','6','4','_','_'
#elif defined(__ARM_ARCH_7A__)
# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','A','_','_'
#elif defined(__ARM_ARCH_7S__)
# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','S','_','_'
#endif

#define SIZE (sizeof(unsigned short))
static char info_size[] =  {'I', 'N', 'F', 'O', ':', 's','i','z','e','[',
  ('0' + ((SIZE / 10000)%10)),
  ('0' + ((SIZE / 1000)%10)),
  ('0' + ((SIZE / 100)%10)),
  ('0' + ((SIZE / 10)%10)),
  ('0' +  (SIZE    % 10)),
  ']',
#ifdef KEY
  ' ','k','e','y','[', KEY, ']',
#endif
  '\0'};

#ifdef __CLASSIC_C__
int main(argc, argv) int argc; char *argv[];
#else
int main(int argc, char *argv[])
#endif
{
  int require = 0;
  require += info_size[argc];
  (void)argv;
  return require;
}
```