### PR TITLE
Allow to disable pipelines by name.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,6 +11,7 @@
             "displayName": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/builds/${presetName}",
             "generator": "Ninja Multi-Config",
+            "toolchainFile": "${sourceDir}/cmake/lld.toolchain.cmake",
             "cacheVariables": {
                 "CMAKE_CONFIGURATION_TYPES": "Release;RelWithDebInfo;Debug",
                 "VAST_ENABLE_TESTING": "ON",

--- a/include/vast/Frontend/Options.hpp
+++ b/include/vast/Frontend/Options.hpp
@@ -81,6 +81,8 @@ namespace vast::cc
 
         constexpr string_ref simplify = "simplify";
 
+        llvm::Twine disable(string_ref pipeline_name);
+
         constexpr string_ref show_locs = "show-locs";
         constexpr string_ref locs_as_meta_ids = "locs-as-meta-ids";
 

--- a/include/vast/Frontend/Options.hpp
+++ b/include/vast/Frontend/Options.hpp
@@ -12,6 +12,7 @@ VAST_RELAX_WARNINGS
 #include <clang/Frontend/FrontendOptions.h>
 VAST_UNRELAX_WARNINGS
 
+#include "vast/Dialect/Core/CoreAttributes.hpp"
 #include "vast/Util/Common.hpp"
 
 namespace vast::cc
@@ -90,5 +91,9 @@ namespace vast::cc
         bool emit_only_mlir(const vast_args &vargs);
         bool emit_only_llvm(const vast_args &vargs);
     } // namespace opt
+
+    using source_language = core::SourceLanguage;
+
+    source_language get_source_language(const language_options &opts);
 
 } // namespace vast::cc

--- a/include/vast/Frontend/Pipelines.hpp
+++ b/include/vast/Frontend/Pipelines.hpp
@@ -14,12 +14,6 @@ VAST_UNRELAX_WARNINGS
 
 namespace vast::cc {
 
-    struct pipelines_config {
-        llvm::StringMap< pipeline_step_builder > pipelines;
-    };
-
-    pipelines_config default_pipelines_config();
-
     enum class pipeline_source { ast };
 
     //
@@ -33,14 +27,10 @@ namespace vast::cc {
     // If the target is LLVM IR or other downstream target, the pipeline will
     // proceed into LLVM dialect.
     //
-    // Pipeline configuration describe named pipelines that are used in the
-    // scheduled pipeline.
-    //
     std::unique_ptr< pipeline_t > setup_pipeline(
         pipeline_source src, target_dialect trg,
         mcontext_t &mctx,
-        const vast_args &vargs,
-        const pipelines_config &config
+        const vast_args &vargs
     );
 
 } // namespace vast::cc

--- a/include/vast/Util/Pipeline.hpp
+++ b/include/vast/Util/Pipeline.hpp
@@ -147,17 +147,6 @@ namespace vast {
         std::vector< pipeline_step_builder > steps;
     };
 
-    struct optional_pipeline : pipeline_step {
-        explicit optional_pipeline(pipeline_step_builder step)
-            : step(std::move(step))
-        {}
-
-        void schedule_on(pipeline_t &ppl) const override;
-
-        bool enabled = true;
-        pipeline_step_builder step;
-    };
-
     template< typename... args_t >
     decltype(auto) pass(args_t &&... args) {
         return pipeline_step_init< pass_pipeline_step >(
@@ -170,11 +159,6 @@ namespace vast {
         return pipeline_step_init< nested_pass_pipeline_step< parent > >(
             std::forward< args_t >(args)...
         );
-    }
-
-    template< auto step >
-    decltype(auto) optional() {
-        return pipeline_step_init< optional_pipeline >(step);
     }
 
     template< typename... steps_t >

--- a/include/vast/Util/Pipeline.hpp
+++ b/include/vast/Util/Pipeline.hpp
@@ -120,18 +120,16 @@ namespace vast {
     };
 
     template< typename parent_t >
-    struct nested_pass_pipeline_step : pipeline_step
+    struct nested_pass_pipeline_step : pass_pipeline_step
     {
         explicit nested_pass_pipeline_step(pass_builder_t builder)
-            : pass_builder(builder)
+            : pass_pipeline_step(builder)
         {}
 
         void schedule_on(pipeline_t &ppl) const override {
             schedule_dependencies(ppl);
             ppl.addNestedPass< parent_t >(pass_builder());
         }
-
-        pass_builder_t pass_builder;
     };
 
     // compound step represents subpipeline to be run

--- a/lib/vast/Conversion/ABI/Passes.cpp
+++ b/lib/vast/Conversion/ABI/Passes.cpp
@@ -21,7 +21,7 @@ namespace vast::conv::pipeline {
     }
 
     pipeline_step_ptr abi() {
-        return lower_abi();
+        return compose("abi", lower_abi);
     }
 
 } // namespace vast::conv::pipeline

--- a/lib/vast/Conversion/Core/Passes.cpp
+++ b/lib/vast/Conversion/Core/Passes.cpp
@@ -28,7 +28,7 @@ namespace vast::conv::pipeline {
     }
 
     pipeline_step_ptr to_llvm() {
-        return compose(irs_to_llvm, core_to_llvm, llvm_debug_scope);
+        return compose("to-llvm", irs_to_llvm, core_to_llvm, llvm_debug_scope);
     }
 
 } // namespace vast::conv::pipeline

--- a/lib/vast/Conversion/FromHL/Passes.cpp
+++ b/lib/vast/Conversion/FromHL/Passes.cpp
@@ -37,7 +37,7 @@ namespace vast::conv::pipeline {
     }
 
     pipeline_step_ptr to_ll() {
-        return compose(
+        return compose( "to-ll",
             hl_to_ll_func,
             hl_to_ll_vars,
             hl_to_ll_cf,

--- a/lib/vast/Dialect/HighLevel/Passes.cpp
+++ b/lib/vast/Dialect/HighLevel/Passes.cpp
@@ -32,7 +32,6 @@ namespace vast::hl::pipeline {
     }
 
     // TODO: add more passes here (remove elaborations, decayed types, lvalue types etc.)
-
     pipeline_step_ptr desugar() {
         return lower_types();
     }

--- a/lib/vast/Dialect/HighLevel/Passes.cpp
+++ b/lib/vast/Dialect/HighLevel/Passes.cpp
@@ -45,7 +45,7 @@ namespace vast::hl::pipeline {
     }
 
     pipeline_step_ptr simplify() {
-        return compose(optional< dce >, optional< desugar >);
+        return compose(dce, desugar);
     }
 
     //

--- a/lib/vast/Dialect/HighLevel/Passes.cpp
+++ b/lib/vast/Dialect/HighLevel/Passes.cpp
@@ -45,7 +45,7 @@ namespace vast::hl::pipeline {
     }
 
     pipeline_step_ptr simplify() {
-        return compose(dce, desugar);
+        return compose("simplify", dce, desugar);
     }
 
     //

--- a/lib/vast/Frontend/Consumer.cpp
+++ b/lib/vast/Frontend/Consumer.cpp
@@ -32,10 +32,6 @@ namespace vast::cc {
 
     void emit_mlir_output(target_dialect target, owning_module_ref mod, mcontext_t *mctx);
 
-    using source_language = core::SourceLanguage;
-
-    source_language get_source_language(const cc::language_options &opts);
-
     void vast_consumer::Initialize(acontext_t &actx) {
         VAST_CHECK(!mctx, "initialized multiple times");
         mctx = std::make_unique< mcontext_t >();
@@ -242,21 +238,6 @@ namespace vast::cc {
         flags.enableDebugInfo(vargs.has_option(opt::show_locs), /* prettyForm */ true);
 
         mod->print(*output_stream, flags);
-    }
-
-    source_language get_source_language(const cc::language_options &opts) {
-        using ClangStd = clang::LangStandard;
-
-        if (opts.CPlusPlus || opts.CPlusPlus11 || opts.CPlusPlus14 ||
-            opts.CPlusPlus17 || opts.CPlusPlus20 || opts.CPlusPlus23 ||
-            opts.CPlusPlus26)
-            return source_language::CXX;
-        if (opts.C99 || opts.C11 || opts.C17 || opts.C2x ||
-            opts.LangStd == ClangStd::lang_c89)
-            return source_language::C;
-
-        // TODO: support remaining source languages.
-        VAST_UNIMPLEMENTED_MSG("VAST does not yet support the given source language");
     }
 
 } // namespace vast::cc

--- a/lib/vast/Frontend/Consumer.cpp
+++ b/lib/vast/Frontend/Consumer.cpp
@@ -209,10 +209,7 @@ namespace vast::cc {
         }
 
         // Setup and execute vast pipeline
-        auto pipeline = setup_pipeline(
-            pipeline_source::ast, target, *mctx, vargs,
-            default_pipelines_config()
-        );
+        auto pipeline = setup_pipeline(pipeline_source::ast, target, *mctx, vargs);
         VAST_CHECK(pipeline, "failed to setup pipeline");
 
         auto result = pipeline->run(mod);

--- a/lib/vast/Frontend/Options.cpp
+++ b/lib/vast/Frontend/Options.cpp
@@ -31,6 +31,13 @@ namespace vast::cc {
         }
     } // detail
 
+    namespace opt
+    {
+        llvm::Twine disable(string_ref name) {
+            return "disable-" + name;
+        }
+    } // namespace opt
+
     bool vast_args::has_option(string_ref name) const {
         return detail::get_option_impl(args, name).has_value();
     }

--- a/lib/vast/Frontend/Options.cpp
+++ b/lib/vast/Frontend/Options.cpp
@@ -86,4 +86,20 @@ namespace vast::cc {
         return { vargs, rest };
     }
 
+    source_language get_source_language(const language_options &opts) {
+        using ClangStd = clang::LangStandard;
+
+        if (opts.CPlusPlus || opts.CPlusPlus11 || opts.CPlusPlus14 ||
+            opts.CPlusPlus17 || opts.CPlusPlus20 || opts.CPlusPlus23 ||
+            opts.CPlusPlus26)
+            return source_language::CXX;
+        if (opts.C99 || opts.C11 || opts.C17 || opts.C2x ||
+            opts.LangStd == ClangStd::lang_c89)
+            return source_language::C;
+
+        // TODO: support remaining source languages.
+        VAST_UNIMPLEMENTED_MSG("VAST does not yet support the given source language");
+    }
+
+
 } // namespace vast::cc

--- a/lib/vast/Frontend/Pipelines.cpp
+++ b/lib/vast/Frontend/Pipelines.cpp
@@ -11,12 +11,14 @@ namespace vast::cc {
 
         // Generates almost AST like MLIR, without any conversions applied
         pipeline_step_ptr high_level() {
-            return hl::pipeline::canonicalize();
+            return compose("canonicalize",
+                hl::pipeline::canonicalize
+            );
         }
 
         // Simplifies high level MLIR
         pipeline_step_ptr reduce_high_level() {
-            return compose( "reduce-hl",
+            return compose("reduce-hl",
                 hl::pipeline::desugar,
                 hl::pipeline::simplify
             );
@@ -24,7 +26,9 @@ namespace vast::cc {
 
         // Generates MLIR with standard types
         pipeline_step_ptr standard_types() {
-            return hl::pipeline::stdtypes();
+            return compose("standard-types",
+                hl::pipeline::stdtypes
+            );
         }
 
         pipeline_step_ptr abi() {

--- a/lib/vast/Frontend/Pipelines.cpp
+++ b/lib/vast/Frontend/Pipelines.cpp
@@ -7,15 +7,6 @@
 
 namespace vast::cc {
 
-    pipelines_config default_pipelines_config() {
-        return pipelines_config{{
-            { "canonicalize", hl::pipeline::canonicalize },
-            { "desugar", hl::pipeline::desugar },
-            { "simplify", hl::pipeline::simplify },
-            { "stdtypes", hl::pipeline::stdtypes }
-        }};
-    }
-
     namespace pipeline {
 
         // Generates almost AST like MLIR, without any conversions applied
@@ -37,7 +28,7 @@ namespace vast::cc {
         }
 
         pipeline_step_ptr abi() {
-            return optional< conv::pipeline::abi >();
+            return conv::pipeline::abi();
         }
 
         // Conversion to LLVM dialects
@@ -67,8 +58,7 @@ namespace vast::cc {
         gap::generator< pipeline_step_ptr > conversion(
             pipeline_source src,
             target_dialect trg,
-            const vast_args &vargs,
-            const pipelines_config &config
+            const vast_args &vargs
         ) {
             // TODO: add support for custom conversion paths
             // deduced from source, target and vargs
@@ -97,8 +87,7 @@ namespace vast::cc {
         pipeline_source src,
         target_dialect trg,
         mcontext_t &mctx,
-        const vast_args &vargs,
-        const pipelines_config &config
+        const vast_args &vargs
     ) {
         auto passes = std::make_unique< pipeline_t >(&mctx);
 
@@ -120,7 +109,7 @@ namespace vast::cc {
         // binary/assembly. We perform entire conversion to llvm dialect. Vargs
         // can specify how we want to convert to llvm dialect and allows to turn
         // off optional pipelines.
-        for (auto &&step : pipeline::conversion(src, trg, vargs, config)) {
+        for (auto &&step : pipeline::conversion(src, trg, vargs)) {
             *passes << std::move(step);
         }
 

--- a/lib/vast/Frontend/Pipelines.cpp
+++ b/lib/vast/Frontend/Pipelines.cpp
@@ -16,7 +16,7 @@ namespace vast::cc {
 
         // Simplifies high level MLIR
         pipeline_step_ptr reduce_high_level() {
-            return compose(
+            return compose( "reduce-hl",
                 hl::pipeline::desugar,
                 hl::pipeline::simplify
             );

--- a/lib/vast/Util/Pipeline.cpp
+++ b/lib/vast/Util/Pipeline.cpp
@@ -33,11 +33,19 @@ namespace vast {
         ppl.addPass(pass_builder());
     }
 
+    string_ref pass_pipeline_step::name() const {
+        return pass_builder()->getName();
+    }
+
     void compound_pipeline_step::schedule_on(pipeline_t &ppl) const {
         schedule_dependencies(ppl);
         for (const auto &step : steps) {
             step()->schedule_on(ppl);
         }
+    }
+
+    string_ref compound_pipeline_step::name() const {
+        return pipeline_name;
     }
 
 } // namespace vast

--- a/lib/vast/Util/Pipeline.cpp
+++ b/lib/vast/Util/Pipeline.cpp
@@ -40,11 +40,4 @@ namespace vast {
         }
     }
 
-    void optional_pipeline::schedule_on(pipeline_t &ppl) const {
-        if (enabled) {
-            schedule_dependencies(ppl);
-            step()->schedule_on(ppl);
-        }
-    }
-
 } // namespace vast


### PR DESCRIPTION
Introduces set of options  `-vast-disable-<pipeline-name>` which allow the user to turn off specific steps of pipeline.

Adds capability to name pipelines and rename passes.