### PR TITLE
Fix minor issues in ABI conversions.

### DIFF
--- a/include/vast/Conversion/ABI/Common.hpp
+++ b/include/vast/Conversion/ABI/Common.hpp
@@ -1,0 +1,8 @@
+// Copyright (c) 2024-present, Trail of Bits, Inc.
+
+#pragma once
+
+namespace vast::conv::abi
+{
+    static inline const std::string abi_func_name_prefix = "vast.abi.";
+} // namespace vast::conv::abi

--- a/lib/vast/Conversion/ABI/EmitABI.cpp
+++ b/lib/vast/Conversion/ABI/EmitABI.cpp
@@ -830,7 +830,7 @@ namespace vast
             auto is_return_legal = [&](hl::ReturnOp op)
             {
                 auto func = op->getParentOfType< abi::FuncOp >();
-                if (!func || func.getName() == "main")
+                if (!func)
                     return true;
 
                 for (auto val : op.getResult())

--- a/lib/vast/Conversion/ABI/EmitABI.cpp
+++ b/lib/vast/Conversion/ABI/EmitABI.cpp
@@ -227,7 +227,7 @@ namespace vast
                         op.getLoc(),
                         // Temporal, to avoid verification issues, will be changed once
                         // original func is removed.
-                        "vast.abi" + op.getName().str(),
+                        "vast.abi." + op.getName().str(),
                         this->abified_type(),
                         core::GlobalLinkageKind::InternalLinkage,
                         other_attrs,
@@ -757,7 +757,7 @@ namespace vast
                     return mlir::failure();
 
                 auto name = func.getName();
-                if (!name.consume_front("vast.abi"))
+                if (!name.consume_front("vast.abi."))
                     return mlir::failure();
 
                 auto abi_map_it = abi_info_map.find(name.str());

--- a/lib/vast/Conversion/ABI/EmitABI.cpp
+++ b/lib/vast/Conversion/ABI/EmitABI.cpp
@@ -18,6 +18,8 @@ VAST_UNRELAX_WARNINGS
 
 #include "../PassesDetails.hpp"
 
+#include "vast/Conversion/ABI/Common.hpp"
+
 #include "vast/Conversion/Common/Patterns.hpp"
 #include "vast/Conversion/TypeConverters/TypeConverter.hpp"
 
@@ -227,7 +229,7 @@ namespace vast
                         op.getLoc(),
                         // Temporal, to avoid verification issues, will be changed once
                         // original func is removed.
-                        "vast.abi." + op.getName().str(),
+                        conv::abi::abi_func_name_prefix + op.getName().str(),
                         this->abified_type(),
                         core::GlobalLinkageKind::InternalLinkage,
                         other_attrs,
@@ -758,7 +760,7 @@ namespace vast
                     return mlir::failure();
 
                 auto name = func.getName();
-                if (!name.consume_front("vast.abi."))
+                if (!name.consume_front(conv::abi::abi_func_name_prefix))
                     return mlir::failure();
 
                 auto abi_map_it = abi_info_map.find(name.str());

--- a/lib/vast/Conversion/ABI/EmitABI.cpp
+++ b/lib/vast/Conversion/ABI/EmitABI.cpp
@@ -237,7 +237,8 @@ namespace vast
                 // Copying visibility from the original function results in error?
                 wrapper.setVisibility(mlir::SymbolTable::Visibility::Private);
 
-                mk_prologue(wrapper);
+                if (!op.getBody().empty())
+                    mk_prologue(wrapper);
 
                 return wrapper;
             }
@@ -805,9 +806,8 @@ namespace vast
 
             auto should_transform = [&](hl::FuncOp op)
             {
-                // TODO(abi): Due to some issues with location info of arguments
-                //            declaration are not yet supported.
-                return op.getName() == "main" && !op.isDeclaration();
+                // TODO(conv:abi): We should always emit main with a fixed type.
+                return op.getName() == "main";
             };
 
             target.addDynamicallyLegalOp< hl::FuncOp >(should_transform);

--- a/lib/vast/Conversion/ABI/LowerABI.cpp
+++ b/lib/vast/Conversion/ABI/LowerABI.cpp
@@ -18,6 +18,7 @@ VAST_UNRELAX_WARNINGS
 #include "../PassesDetails.hpp"
 
 #include "vast/Conversion/Common/Patterns.hpp"
+#include "vast/Conversion/ABI/Common.hpp"
 
 #include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
@@ -604,7 +605,7 @@ namespace vast
                 op.getAllArgAttrs(arg_attrs);
 
                 auto name = op.getName();
-                if (!name.consume_front("vast.abi."))
+                if (!name.consume_front(conv::abi::abi_func_name_prefix))
                     return mlir::failure();
 
                 auto fn = rewriter.create< hl::FuncOp >(

--- a/lib/vast/Conversion/ABI/LowerABI.cpp
+++ b/lib/vast/Conversion/ABI/LowerABI.cpp
@@ -604,7 +604,7 @@ namespace vast
                 op.getAllArgAttrs(arg_attrs);
 
                 auto name = op.getName();
-                if (!name.consume_front("vast.abi"))
+                if (!name.consume_front("vast.abi."))
                     return mlir::failure();
 
                 auto fn = rewriter.create< hl::FuncOp >(

--- a/lib/vast/Conversion/FromHL/ToLLCF.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLCF.cpp
@@ -25,6 +25,7 @@ VAST_UNRELAX_WARNINGS
 
 
 #include "vast/Dialect/Core/CoreTraits.hpp"
+#include "vast/Dialect/Core/CoreOps.hpp"
 #include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
 #include "vast/Dialect/LowLevel/LowLevelOps.hpp"
 
@@ -457,6 +458,7 @@ namespace vast::conv
             , while_op
             , for_op
             , replace< hl::ReturnOp, ll::ReturnOp >
+            , replace< core::ImplicitReturnOp, ll::ReturnOp >
         >;
 
     } // namespace pattern
@@ -474,7 +476,9 @@ namespace vast::conv
 
             trg.addIllegalOp< hl::ContinueOp >();
             trg.addIllegalOp< hl::BreakOp >();
+
             trg.addIllegalOp< hl::ReturnOp >();
+            trg.addIllegalOp< core::ImplicitReturnOp >();
 
             trg.addLegalOp< mlir::cf::BranchOp >();
             trg.markUnknownOpDynamicallyLegal([](auto){ return true; });

--- a/test/vast/Compile/SingleSource/putchar-a.c
+++ b/test/vast/Compile/SingleSource/putchar-a.c
@@ -1,5 +1,4 @@
 // RUN: %vast-front -o %t %s && %t | %file-check %s
-// REQUIRES: abi
 
 int putchar(int);
 

--- a/test/vast/Compile/SingleSource/puts-a.c
+++ b/test/vast/Compile/SingleSource/puts-a.c
@@ -1,5 +1,4 @@
 // RUN: %vast-front -o %t %s && %t hello | %file-check %s
-// REQUIRES: abi
 
 int puts(const char *);
 


### PR DESCRIPTION
closes #376 and fixes incorrect name prefix during abi conversions.