### PR TITLE
Change getFunctionType() to return an optional

### DIFF
--- a/include/vast/CodeGen/CodeGenStmtVisitor.hpp
+++ b/include/vast/CodeGen/CodeGenStmtVisitor.hpp
@@ -978,8 +978,14 @@ namespace vast::cg {
         operation VisitIndirectCall(const clang::CallExpr *expr) {
             auto callee = VisitIndirectCallee(expr->getCallee())->getResult(0);
             auto args   = VisitArguments(expr);
-            auto type   = hl::getFunctionType(callee.getType(), context().mod.get()).getResults();
-            return make< hl::IndirectCallOp >(meta_location(expr), type, callee, args);
+            auto type   = hl::getFunctionType(callee.getType(), context().mod.get());
+            if (type) {
+                return make< hl::IndirectCallOp >(
+                    meta_location(expr), type.getResults(), callee, args
+                );
+            }
+
+            return {};
         }
 
         operation VisitCallExpr(const clang::CallExpr *expr) {

--- a/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
@@ -92,6 +92,10 @@ namespace vast::hl
     }
 
     core::FunctionType getFunctionType(mlir::CallInterfaceCallable callee, vast_module mod) {
+        if (!callee) {
+            return {};
+        }
+
         if (auto sym = callee.dyn_cast< mlir::SymbolRefAttr >()) {
             return mlir::dyn_cast_or_null< FuncOp >(
                 mlir::SymbolTable::lookupSymbolIn(mod, sym)

--- a/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
@@ -77,7 +77,7 @@ namespace vast::hl
         if (auto ty = type.dyn_cast< TypedefType >())
             return getFunctionType(getTypedefType(ty, mod), mod);
 
-        VAST_UNIMPLEMENTED_MSG("unknown type to extract function type");
+        return {};
     }
 
     core::FunctionType getFunctionType(Value callee) {
@@ -102,7 +102,7 @@ namespace vast::hl
             return getFunctionType(value.getType(), mod);
         }
 
-        VAST_UNIMPLEMENTED_MSG("unknown callee type");
+        return {};
     }
 
 

--- a/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelTypes.cpp
@@ -57,7 +57,7 @@ namespace vast::hl
             }
         }
 
-        VAST_FATAL("unknown typedef name");
+        return {};
     }
 
     auto name_of_record(mlir_type t) -> std::optional< std::string >


### PR DESCRIPTION
- Change each `getFunctionType()` overload to return an optional `FunctionType` so that they can return an empty option if they fail instead of crashing VAST.
- Check the return value of `getFunctionType()` in `VisitIndirectCall()` and return an `IndirectCallOp` only if the return value is not an empty option. Otherwise, return an empty op for a fallback visitor (e.g., the unsupported visitor) to handle.