### PR TITLE
Union lowering

### DIFF
--- a/include/vast/Conversion/TypeConverters/LLVMTypeConverter.hpp
+++ b/include/vast/Conversion/TypeConverters/LLVMTypeConverter.hpp
@@ -237,7 +237,7 @@ namespace vast::conv::tc {
             if (!def) {
                 return {};
             }
-            return { hl::field_types(*def) };
+            return { def.getFieldTypes() };
         }
 
         maybe_type_t convert_elaborated_type(hl::ElaboratedType t) {

--- a/include/vast/Conversion/TypeConverters/TypeConverter.hpp
+++ b/include/vast/Conversion/TypeConverters/TypeConverter.hpp
@@ -39,6 +39,16 @@ namespace vast::conv::tc {
         }
     };
 
+    struct type_converter_with_dl : base_type_converter
+    {
+        using base = base_type_converter;
+        using dl_t = mlir::DataLayout;
+
+        const dl_t &dl;
+
+        type_converter_with_dl(const dl_t &dl, mcontext_t &mctx) : dl(dl) {}
+    };
+
     template< typename R, typename UnaryPred >
     bool all_of_subtypes(R &&types, UnaryPred &&pred) {
         mlir::AttrTypeWalker walker;

--- a/include/vast/Dialect/HighLevel/HighLevelOps.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.hpp
@@ -10,10 +10,15 @@ VAST_RELAX_WARNINGS
 #include <mlir/Interfaces/InferTypeOpInterface.h>
 VAST_UNRELAX_WARNINGS
 
+#include <gap/core/generator.hpp>
+
 #include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
 #include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
+
 #include "vast/Interfaces/SymbolInterface.hpp"
+#include "vast/Interfaces/AggregateTypeDefinitionInterface.hpp"
+
 
 namespace vast::hl
 {

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -6,6 +6,7 @@
 include "mlir/IR/OpBase.td"
 include "mlir/IR/BuiltinAttributes.td"
 
+include "vast/Interfaces/AggregateTypeDefinitionInterface.td"
 include "mlir/Interfaces/CastInterfaces.td"
 include "vast/Interfaces/SymbolInterface.td"
 
@@ -196,8 +197,11 @@ def EnumDeclOp
   let assemblyFormat = [{ $name attr-dict `:` ($type^ $constants)? }];
 }
 
-class RecordLikeDeclOp< string mnemonic, list< Trait > traits = [] >
-    : HighLevel_Op< mnemonic, !listconcat(traits, [NoTerminator, VastSymbol]) >
+class RecordLikeDeclOp< string mnemonic, string concrete_name, list< Trait > traits = [] >
+    : HighLevel_Op<
+        mnemonic,
+        !listconcat(traits, [NoTerminator, VastSymbol,
+                            DeclareOpInterfaceMethods< AggregateTypeDefinition >]) >
     , Arguments<(ins StrAttr:$name)>
 {
   // TODO(Heno): Add region constraints.
@@ -211,15 +215,34 @@ class RecordLikeDeclOp< string mnemonic, list< Trait > traits = [] >
     )>
   ];
 
+  let extraClassDefinition = [{
+    // AggregateTypeDefinitionInterface
+
+    gap::generator<mlir::Type> }] # concrete_name # [{ ::getFieldTypes() {
+        return hl::get_field_types(*this);
+    }
+
+    gap::generator<std::tuple<std::string, mlir::Type>>}] # concrete_name # [{ ::getFieldsInfo() {
+        return hl::get_fields_info(*this);
+    }
+
+    gap::generator< vast::AggregateTypeDefinitionInterface > }] # concrete_name # [{ ::getNestedDeclarations() {
+        return hl::get_nested_declarations(*this);
+    }
+
+    std::string }] # concrete_name # [{ ::getDefinedName() { return this->getName().str(); }
+
+  }];
+
   let assemblyFormat = [{ $name attr-dict `:` $fields }];
 }
 
-def StructDeclOp : RecordLikeDeclOp< "struct" > {
+def StructDeclOp : RecordLikeDeclOp< "struct", "StructDeclOp" > {
   let summary = "VAST struct declaration";
   let description = [{ VAST struct declaration }];
 }
 
-def UnionDeclOp : RecordLikeDeclOp< "union" > {
+def UnionDeclOp : RecordLikeDeclOp< "union", "UnionDeclOp" > {
   let summary = "VAST record declaration";
   let description = [{ VAST record declaration }];
 }

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -16,84 +16,69 @@
 
 namespace vast::hl
 {
-    template< typename T >
-    gap::generator< T > top_level_ops(vast_module module_op)
-    {
-        auto body = module_op.getBody();
-        if (!body)
-            co_return;
-
-        for (auto &op : *body)
-            if (auto casted = mlir::dyn_cast< T >(op))
-                co_yield casted;
+    static inline gap::generator< mlir_type > get_field_types(auto op) {
+        for (auto [_, type] : get_fields_info(op))
+            co_yield type;
     }
 
-    using type_generator = gap::generator< mlir::Type >;
-    using value_generator = gap::generator< mlir::Value >;
-
-    template< typename op_t >
-    concept defines_field_types = std::is_same_v< hl::StructDeclOp, op_t > ||
-                                  std::is_same_v< hl::UnionDeclOp, op_t >;
-
-    template< defines_field_types op_t >
-    static inline gap::generator< hl::FieldDeclOp > field_defs(op_t op)
-    {
+    static inline gap::generator< std::tuple< std::string, mlir_type > > get_fields_info(
+        auto op
+    ) {
         for (auto &maybe_field : op.getOps())
         {
-            // TODO(hl): So normally only `hl.field` should be present here,
-            //           but currently also re-declarations of nested structures
-            //           are here - add hard fail if the conversion fails in the future.
-            if (mlir::isa< hl::StructDeclOp >(maybe_field))
+            // Definition of nested structure, we ignore not a field.
+            if (mlir::isa< AggregateTypeDefinitionInterface >(maybe_field))
                 continue;
 
             auto field_decl = mlir::dyn_cast< hl::FieldDeclOp >(maybe_field);
             VAST_ASSERT(field_decl);
-            co_yield field_decl;
+            co_yield std::make_tuple(field_decl.getName().str(), field_decl.getType());
         }
     }
 
-    template< defines_field_types op_t >
-    static inline type_generator field_types(op_t op)
-    {
-        for (auto def : field_defs(op))
-            co_yield def.getType();
+    static inline gap::generator< AggregateTypeDefinitionInterface > get_nested_declarations(
+        auto op
+    ) {
+        for (auto &maybe_field : op.getOps())
+            if (auto casted = mlir::dyn_cast< AggregateTypeDefinitionInterface >(maybe_field))
+                co_yield casted;
     }
 
     // TODO(hl): This is a placeholder that works in our test cases so far.
     //           In general, we will need generic resolution for scoping that
     //           will be used instead of this function.
-    template< defines_field_types op_t = hl::StructDeclOp >
     static inline auto definition_of(mlir::Type t, vast_module module_op)
-        -> std::optional< op_t >
+        -> AggregateTypeDefinitionInterface
     {
         auto type_name = hl::name_of_record(t);
         VAST_CHECK(type_name, "hl::name_of_record failed with {0}", t);
-        for (auto op : top_level_ops< op_t >(module_op))
-            if (op.getName() == *type_name)
-                return { op };
-        return {};
+
+        AggregateTypeDefinitionInterface out;;
+        auto walker = [&](AggregateTypeDefinitionInterface op) {
+            if (op.getDefinedName() == type_name)
+            {
+                out = op;
+                return mlir::WalkResult::interrupt();
+            }
+            return mlir::WalkResult::advance();
+
+        };
+        module_op->walk(walker);
+        return out;
     }
 
-    static inline auto type_decls(hl::StructDeclOp struct_decl)
-        -> gap::generator< hl::TypeDeclOp >
-    {
-        auto module_op = struct_decl->getParentOfType< vast_module >();
-        VAST_ASSERT(module_op);
 
-        for (auto decl : top_level_ops< hl::TypeDeclOp >(module_op))
-            if (decl.getName() == struct_decl.getName())
-                co_yield decl;
-    }
-
-    static inline type_generator field_types(mlir::Type t, vast_module module_op)
+    static inline auto field_types(mlir::Type t, vast_module module_op)
+        -> gap::generator< mlir_type >
     {
-        auto def = definition_of< hl::StructDeclOp >(t, module_op);
+        auto def = definition_of(t, module_op);
         VAST_CHECK(def, "Was not able to fetch definition of type: {0}", t);
-        return field_types(*def);
+        return def.getFieldTypes();
     }
 
-    hl::ImplicitCastOp implicit_cast_lvalue_to_rvalue(auto &rewriter, auto loc, auto lvalue_op)
-    {
+    static inline hl::ImplicitCastOp implicit_cast_lvalue_to_rvalue(
+        auto &rewriter, auto loc, auto lvalue_op
+    ){
         auto lvalue_type = mlir::dyn_cast< hl::LValueType >(lvalue_op.getType());
         VAST_ASSERT(lvalue_type);
         return rewriter.template create< hl::ImplicitCastOp >(
@@ -102,30 +87,27 @@ namespace vast::hl
     }
 
     // Given record `root` emit `hl::RecordMemberOp` for each its member.
-    auto generate_ptrs_to_record_members(operation root, auto loc, auto &bld)
+    static inline auto generate_ptrs_to_record_members(operation root, auto loc, auto &bld)
         -> gap::generator< hl::RecordMemberOp >
     {
         auto module_op = root->getParentOfType< vast_module >();
         VAST_ASSERT(module_op);
-        auto def = definition_of< hl::StructDeclOp >(root->getResultTypes()[0], module_op);
+        auto def = definition_of(root->getResultTypes()[0], module_op);
         VAST_CHECK(def, "Was not able to fetch definition of type from: {0}", *root);
 
-        for (auto field_def : field_defs(*def))
+        for (const auto &[name, type] : def.getFieldsInfo())
         {
             VAST_ASSERT(root->getNumResults() == 1);
             auto as_val = root->getResult(0);
             // `hl.member` requires type to be an lvalue.
-            auto wrap_type = hl::LValueType::get(module_op.getContext(), field_def.getType());
-            co_yield bld.template create< hl::RecordMemberOp >(loc,
-                                                               wrap_type,
-                                                               as_val,
-                                                               field_def.getName());
+            auto wrap_type = hl::LValueType::get(module_op.getContext(), type);
+            co_yield bld.template create< hl::RecordMemberOp >(loc, wrap_type, as_val, name);
         }
     }
 
     // Given record `root` emit `hl::RecordMemberOp` casted as rvalue for each
     // its member.
-    auto generate_values_of_record_members(operation root, auto &bld)
+    static inline auto generate_values_of_record_members(operation root, auto &bld)
         -> gap::generator< hl::ImplicitCastOp >
     {
         for (auto member_ptr : generate_ptrs_to_members(root, bld)) {
@@ -133,16 +115,16 @@ namespace vast::hl
         }
     }
 
-
-
-    std::optional< std::size_t > field_idx(llvm::StringRef name, auto struct_decl)
-    {
-        std::size_t out = 0;
-        for (auto field_def : field_defs(struct_decl))
+    static inline std::optional< std::size_t > field_idx(
+        llvm::StringRef name, AggregateTypeDefinitionInterface decl
+    ) {
+        std::size_t idx = 0;
+        // `llvm::enumerate` is unhappy when coroutine is passed in.
+        for (const auto &[field_name, _] : decl.getFieldsInfo())
         {
-            if (field_def.getName() == name)
-                return { out };
-            ++out;
+            if (field_name == name)
+                return { idx };
+            ++idx;
         }
         return {};
     }

--- a/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
+++ b/include/vast/Dialect/HighLevel/HighLevelUtils.hpp
@@ -4,8 +4,8 @@
 
 #include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
-#include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelOps.hpp"
+#include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
 #include "vast/Interfaces/SymbolInterface.hpp"
 
 #include "vast/Util/Common.hpp"
@@ -14,21 +14,20 @@
 
 /* Contains common utilities often needed to work with hl dialect. */
 
-namespace vast::hl
-{
+namespace vast::hl {
     static inline gap::generator< mlir_type > get_field_types(auto op) {
-        for (auto [_, type] : get_fields_info(op))
+        for (auto [_, type] : get_fields_info(op)) {
             co_yield type;
+        }
     }
 
-    static inline gap::generator< std::tuple< std::string, mlir_type > > get_fields_info(
-        auto op
+    static inline gap::generator< std::tuple< std::string, mlir_type > > get_fields_info(auto op
     ) {
-        for (auto &maybe_field : op.getOps())
-        {
+        for (auto &maybe_field : op.getOps()) {
             // Definition of nested structure, we ignore not a field.
-            if (mlir::isa< AggregateTypeDefinitionInterface >(maybe_field))
+            if (mlir::isa< AggregateTypeDefinitionInterface >(maybe_field)) {
                 continue;
+            }
 
             auto field_decl = mlir::dyn_cast< hl::FieldDeclOp >(maybe_field);
             VAST_ASSERT(field_decl);
@@ -36,69 +35,63 @@ namespace vast::hl
         }
     }
 
-    static inline gap::generator< AggregateTypeDefinitionInterface > get_nested_declarations(
-        auto op
-    ) {
-        for (auto &maybe_field : op.getOps())
-            if (auto casted = mlir::dyn_cast< AggregateTypeDefinitionInterface >(maybe_field))
+    static inline gap::generator< AggregateTypeDefinitionInterface >
+    get_nested_declarations(auto op) {
+        for (auto &maybe_field : op.getOps()) {
+            if (auto casted = mlir::dyn_cast< AggregateTypeDefinitionInterface >(maybe_field)) {
                 co_yield casted;
+            }
+        }
     }
 
     // TODO(hl): This is a placeholder that works in our test cases so far.
     //           In general, we will need generic resolution for scoping that
     //           will be used instead of this function.
     static inline auto definition_of(mlir::Type t, vast_module module_op)
-        -> AggregateTypeDefinitionInterface
-    {
+        -> AggregateTypeDefinitionInterface {
         auto type_name = hl::name_of_record(t);
         VAST_CHECK(type_name, "hl::name_of_record failed with {0}", t);
 
-        AggregateTypeDefinitionInterface out;;
+        AggregateTypeDefinitionInterface out;
+        ;
         auto walker = [&](AggregateTypeDefinitionInterface op) {
-            if (op.getDefinedName() == type_name)
-            {
+            if (op.getDefinedName() == type_name) {
                 out = op;
                 return mlir::WalkResult::interrupt();
             }
             return mlir::WalkResult::advance();
-
         };
         module_op->walk(walker);
         return out;
     }
 
-
     static inline auto field_types(mlir::Type t, vast_module module_op)
-        -> gap::generator< mlir_type >
-    {
+        -> gap::generator< mlir_type > {
         auto def = definition_of(t, module_op);
         VAST_CHECK(def, "Was not able to fetch definition of type: {0}", t);
         return def.getFieldTypes();
     }
 
-    static inline hl::ImplicitCastOp implicit_cast_lvalue_to_rvalue(
-        auto &rewriter, auto loc, auto lvalue_op
-    ){
+    static inline hl::ImplicitCastOp
+    implicit_cast_lvalue_to_rvalue(auto &rewriter, auto loc, auto lvalue_op) {
         auto lvalue_type = mlir::dyn_cast< hl::LValueType >(lvalue_op.getType());
         VAST_ASSERT(lvalue_type);
         return rewriter.template create< hl::ImplicitCastOp >(
-            loc, lvalue_type.getElementType(),
-            lvalue_op, hl::CastKind::LValueToRValue);
+            loc, lvalue_type.getElementType(), lvalue_op, hl::CastKind::LValueToRValue
+        );
     }
 
     // Given record `root` emit `hl::RecordMemberOp` for each its member.
     static inline auto generate_ptrs_to_record_members(operation root, auto loc, auto &bld)
-        -> gap::generator< hl::RecordMemberOp >
-    {
+        -> gap::generator< hl::RecordMemberOp > {
         auto module_op = root->getParentOfType< vast_module >();
         VAST_ASSERT(module_op);
         auto def = definition_of(root->getResultTypes()[0], module_op);
         VAST_CHECK(def, "Was not able to fetch definition of type from: {0}", *root);
 
-        for (const auto &[name, type] : def.getFieldsInfo())
-        {
+        for (const auto &[name, type] : def.getFieldsInfo()) {
             VAST_ASSERT(root->getNumResults() == 1);
-            auto as_val = root->getResult(0);
+            auto as_val    = root->getResult(0);
             // `hl.member` requires type to be an lvalue.
             auto wrap_type = hl::LValueType::get(module_op.getContext(), type);
             co_yield bld.template create< hl::RecordMemberOp >(loc, wrap_type, as_val, name);
@@ -108,24 +101,22 @@ namespace vast::hl
     // Given record `root` emit `hl::RecordMemberOp` casted as rvalue for each
     // its member.
     static inline auto generate_values_of_record_members(operation root, auto &bld)
-        -> gap::generator< hl::ImplicitCastOp >
-    {
+        -> gap::generator< hl::ImplicitCastOp > {
         for (auto member_ptr : generate_ptrs_to_members(root, bld)) {
             co_yield implicit_cast_lvalue_to_rvalue(bld, member_ptr->getLoc(), member_ptr);
         }
     }
 
-    static inline std::optional< std::size_t > field_idx(
-        llvm::StringRef name, AggregateTypeDefinitionInterface decl
-    ) {
+    static inline std::optional< std::size_t >
+    field_idx(llvm::StringRef name, AggregateTypeDefinitionInterface decl) {
         std::size_t idx = 0;
         // `llvm::enumerate` is unhappy when coroutine is passed in.
-        for (const auto &[field_name, _] : decl.getFieldsInfo())
-        {
-            if (field_name == name)
+        for (const auto &[field_name, _] : decl.getFieldsInfo()) {
+            if (field_name == name) {
                 return { idx };
+            }
             ++idx;
         }
         return {};
     }
-}
+} // namespace vast::hl

--- a/include/vast/Interfaces/AggregateTypeDefinitionInterface.hpp
+++ b/include/vast/Interfaces/AggregateTypeDefinitionInterface.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2024-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Util/Warnings.hpp"
+
+VAST_RELAX_WARNINGS
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Dialect.h>
+#include <mlir/IR/OperationSupport.h>
+VAST_RELAX_WARNINGS
+
+#include <gap/core/generator.hpp>
+
+/// Include the generated interface declarations.
+#include "vast/Interfaces/AggregateTypeDefinitionInterface.h.inc"

--- a/include/vast/Interfaces/AggregateTypeDefinitionInterface.td
+++ b/include/vast/Interfaces/AggregateTypeDefinitionInterface.td
@@ -1,0 +1,33 @@
+// Copyright (c) 2024-present, Trail of Bits, Inc.
+
+#ifndef VAST_IR_AGGREGATETYPEDEFINITIONINTERFACE
+#define VAST_IR_AGGREGATETYPEDEFINITIONINTERFACE
+
+include "mlir/IR/OpBase.td"
+
+def AggregateTypeDefinition
+    : OpInterface< "AggregateTypeDefinitionInterface" > {
+        let description = [{
+            This operation is encoding of a type.
+        }];
+
+        let cppNamespace = "::vast";
+
+        let methods = [
+            InterfaceMethod< "Returns element in order of their declaration.",
+                "gap::generator< mlir::Type >", "getFieldTypes", (ins), [{}] >,
+
+            InterfaceMethod< "Return all elements in order of their declaration.",
+                "gap::generator< std::tuple< std::string, mlir::Type > >",
+                "getFieldsInfo", (ins), [{}] >,
+
+            InterfaceMethod< "Return all nested definitions",
+                "gap::generator< vast::AggregateTypeDefinitionInterface >",
+                "getNestedDeclarations", (ins), [{}] >,
+
+            InterfaceMethod< "Get name of the defined type",
+                "std::string", "getDefinedName", (ins), [{}] >
+        ];
+    }
+
+#endif // VAST_IR_AGGREGATETYPEDEFINITIONINTERFACE

--- a/include/vast/Interfaces/CMakeLists.txt
+++ b/include/vast/Interfaces/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_vast_op_interface(SymbolInterface)
+add_vast_op_interface(AggregateTypeDefinitionInterface)
 add_vast_attr_interface(TypeQualifiersInterfaces)
 add_vast_type_interface(AliasTypeInterface)
 add_vast_type_interface(DefaultDataLayoutTypeInterface)

--- a/include/vast/Interfaces/SymbolInterface.td
+++ b/include/vast/Interfaces/SymbolInterface.td
@@ -14,7 +14,7 @@ def VastSymbol : OpInterface< "VastSymbolOpInterface" > {
 
     let methods = [
         InterfaceMethod<"Returns the name of this symbol.",
-            "llvm::StringRef", "getSymbolName", (ins), [{}], 
+            "llvm::StringRef", "getSymbolName", (ins), [{}],
             /*defaultImplementation=*/ [{
                 auto op = this->getOperation();
                 if (op->hasAttr(mlir::SymbolTable::getSymbolAttrName())) {

--- a/lib/vast/Conversion/Common/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/Common/IRsToLLVM.cpp
@@ -46,6 +46,7 @@ namespace vast::conv::irstollvm
         ignore_pattern< hl::PredefinedExpr >,
         ignore_pattern< hl::AddressOf >,
         erase_pattern< hl::StructDeclOp >,
+        erase_pattern< hl::UnionDeclOp >,
         erase_pattern< hl::TypeDeclOp >
     >;
 

--- a/lib/vast/Conversion/FromHL/ToLLGEPs.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLGEPs.cpp
@@ -38,10 +38,12 @@ namespace vast
                 if (!mod)
                     return mlir::failure();
 
-                if (auto struct_decl = hl::definition_of< hl::StructDeclOp >(parent_type, mod))
-                    return lower(op, ops, rewriter, *struct_decl);
-                if (auto union_decl = hl::definition_of< hl::UnionDeclOp >(parent_type, mod))
-                    return lower(op, ops, rewriter, *union_decl);
+                auto def = hl::definition_of(parent_type, mod);
+                if (auto struct_decl = mlir::dyn_cast_or_null< hl::StructDeclOp >(*def))
+                    return lower(op, ops, rewriter, struct_decl);
+                if (auto union_decl = mlir::dyn_cast_or_null< hl::UnionDeclOp >(*def))
+                    return lower(op, ops, rewriter, union_decl);
+
                 return mlir::failure();
             }
 

--- a/lib/vast/Conversion/FromHL/ToLLGEPs.cpp
+++ b/lib/vast/Conversion/FromHL/ToLLGEPs.cpp
@@ -5,8 +5,8 @@
 VAST_RELAX_WARNINGS
 #include <mlir/Analysis/DataLayoutAnalysis.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/DialectConversion.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 VAST_UNRELAX_WARNINGS
 
 #include "PassesDetails.hpp"
@@ -15,13 +15,11 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Dialect/HighLevel/HighLevelUtils.hpp"
 #include "vast/Dialect/LowLevel/LowLevelOps.hpp"
 
-#include "vast/Util/Symbols.hpp"
 #include "vast/Util/DialectConversion.hpp"
+#include "vast/Util/Symbols.hpp"
 
-namespace vast
-{
-    namespace
-    {
+namespace vast {
+    namespace {
         struct record_member_op : mlir::OpConversionPattern< hl::RecordMemberOp >
         {
             using op_t = hl::RecordMemberOp;
@@ -29,53 +27,53 @@ namespace vast
             using base::base;
 
             logical_result matchAndRewrite(
-                op_t op, typename op_t::Adaptor ops,
-                conversion_rewriter &rewriter
+                op_t op, typename op_t::Adaptor ops, conversion_rewriter &rewriter
             ) const override {
                 auto parent_type = ops.getRecord().getType();
 
                 auto mod = op->getParentOfType< vast_module >();
-                if (!mod)
+                if (!mod) {
                     return mlir::failure();
+                }
 
                 auto def = hl::definition_of(parent_type, mod);
-                if (auto struct_decl = mlir::dyn_cast_or_null< hl::StructDeclOp >(*def))
+                if (auto struct_decl = mlir::dyn_cast_or_null< hl::StructDeclOp >(*def)) {
                     return lower(op, ops, rewriter, struct_decl);
-                if (auto union_decl = mlir::dyn_cast_or_null< hl::UnionDeclOp >(*def))
+                }
+                if (auto union_decl = mlir::dyn_cast_or_null< hl::UnionDeclOp >(*def)) {
                     return lower(op, ops, rewriter, union_decl);
+                }
 
                 return mlir::failure();
             }
 
             logical_result lower(
-                op_t op, typename op_t::Adaptor ops,
-                conversion_rewriter &rewriter, hl::StructDeclOp struct_decl) const
-            {
+                op_t op, typename op_t::Adaptor ops, conversion_rewriter &rewriter,
+                hl::StructDeclOp struct_decl
+            ) const {
                 auto idx = hl::field_idx(op.getName(), struct_decl);
-                if (!idx)
+                if (!idx) {
                     return mlir::failure();
+                }
 
                 return replace(op, ops, rewriter, *idx);
             }
 
             logical_result lower(
-                op_t op, typename op_t::Adaptor ops,
-                conversion_rewriter &rewriter, hl::UnionDeclOp union_decl
+                op_t op, typename op_t::Adaptor ops, conversion_rewriter &rewriter,
+                hl::UnionDeclOp union_decl
             ) const {
                 // After lowered, union will only have one member.
                 return replace(op, ops, rewriter, 0);
             }
 
             logical_result replace(
-                op_t op, typename op_t::Adaptor ops,
-                conversion_rewriter &rewriter, auto idx
+                op_t op, typename op_t::Adaptor ops, conversion_rewriter &rewriter, auto idx
             ) const {
                 auto gep = rewriter.create< ll::StructGEPOp >(
-                        op.getLoc(),
-                        op.getType(),
-                        ops.getRecord(),
-                        rewriter.getI32IntegerAttr(idx),
-                        op.getNameAttr());
+                    op.getLoc(), op.getType(), ops.getRecord(), rewriter.getI32IntegerAttr(idx),
+                    op.getNameAttr()
+                );
                 rewriter.replaceOp(op, gep);
                 return mlir::success();
             }
@@ -85,29 +83,25 @@ namespace vast
 
     struct HLToLLGEPsPass : HLToLLGEPsBase< HLToLLGEPsPass >
     {
-        void runOnOperation() override
-        {
-            auto op = this->getOperation();
+        void runOnOperation() override {
+            auto op    = this->getOperation();
             auto &mctx = this->getContext();
 
-            {
-                mlir::ConversionTarget trg(mctx);
-                trg.markUnknownOpDynamicallyLegal( [](auto) { return true; } );
-                trg.addIllegalOp< hl::RecordMemberOp >();
+            mlir::ConversionTarget trg(mctx);
+            trg.markUnknownOpDynamicallyLegal([](auto) { return true; });
+            trg.addIllegalOp< hl::RecordMemberOp >();
 
-                mlir::RewritePatternSet patterns(&mctx);
+            mlir::RewritePatternSet patterns(&mctx);
 
-                patterns.add< record_member_op >(&mctx);
+            patterns.add< record_member_op >(&mctx);
 
-                if (mlir::failed(mlir::applyPartialConversion(op, trg, std::move(patterns))))
-                    return signalPassFailure();
+            if (mlir::failed(mlir::applyPartialConversion(op, trg, std::move(patterns)))) {
+                return signalPassFailure();
             }
         }
     };
 } // namespace vast
 
-
-std::unique_ptr< mlir::Pass > vast::createHLToLLGEPsPass()
-{
+std::unique_ptr< mlir::Pass > vast::createHLToLLGEPsPass() {
     return std::make_unique< vast::HLToLLGEPsPass >();
 }

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -19,6 +19,7 @@ VAST_UNRELAX_WARNINGS
 #include "vast/Dialect/HighLevel/HighLevelAttributes.hpp"
 #include "vast/Dialect/HighLevel/HighLevelDialect.hpp"
 #include "vast/Dialect/HighLevel/HighLevelTypes.hpp"
+#include "vast/Dialect/HighLevel/HighLevelUtils.hpp"
 #include "vast/Dialect/HighLevel/HighLevelOps.hpp"
 
 #include "vast/Dialect/Core/CoreAttributes.hpp"

--- a/lib/vast/Interfaces/AggregateTypeDefinitionInterface.cpp
+++ b/lib/vast/Interfaces/AggregateTypeDefinitionInterface.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#include "vast/Interfaces/AggregateTypeDefinitionInterface.hpp"
+
+//===----------------------------------------------------------------------===//
+// Aggregate Type Definition Interface
+//===----------------------------------------------------------------------===//
+
+/// Include the generated interface.
+#include "vast/Interfaces/AggregateTypeDefinitionInterface.cpp.inc"

--- a/lib/vast/Interfaces/CMakeLists.txt
+++ b/lib/vast/Interfaces/CMakeLists.txt
@@ -4,6 +4,11 @@ set(VAST_OPTIONAL_SOURCES
   AliasTypeInterface.cpp
   DefaultDataLayoutTypeInterface.cpp
   ElementTypeInterface.cpp
+  AggregateTypeDefinitionInterface.cpp
+)
+
+add_vast_interface_library(AggregateTypeDefinitionInterface
+  AggregateTypeDefinitionInterface.cpp
 )
 
 add_vast_interface_library(SymbolInterface

--- a/test/vast/Compile/SingleSource/nested-struct-a.c
+++ b/test/vast/Compile/SingleSource/nested-struct-a.c
@@ -1,0 +1,15 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 5)
+
+struct data
+{
+    struct nested
+    {
+        int a;
+    } n;
+};
+
+int main(int argc, char **argv)
+{
+    struct data d = { { 5 } };
+    return d.n.a;
+}

--- a/test/vast/Compile/SingleSource/nested-union-a.c
+++ b/test/vast/Compile/SingleSource/nested-union-a.c
@@ -1,0 +1,19 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 5)
+
+union data
+{
+    unsigned long long l;
+    struct P
+    {
+        int a;
+        int b;
+    } n;
+};
+
+int main(int argc, char **argv)
+{
+    union data d = { 5 };
+    if (d.n.b != 0)
+        return 0;
+    return d.n.a;
+}

--- a/test/vast/Compile/SingleSource/nested-union-b.c
+++ b/test/vast/Compile/SingleSource/nested-union-b.c
@@ -1,0 +1,21 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 5)
+
+union data
+{
+    unsigned long long l;
+    struct P
+    {
+        int a;
+        int b;
+    } n;
+};
+
+int main(int argc, char **argv)
+{
+    union data d;
+    struct P p = { 1, 2 };
+    d.n = p;
+    if (d.l != 0x0000000200000001)
+        return 128;
+    return 5;
+}

--- a/test/vast/Compile/SingleSource/union-a.c
+++ b/test/vast/Compile/SingleSource/union-a.c
@@ -1,0 +1,15 @@
+// RUN: %vast-front -o %t %s && (%t; test $? -eq 18)
+
+union data
+{
+    int a;
+    unsigned long long b;
+    char c;
+};
+
+int main(int argc, char **argv)
+{
+    union data d;
+    d.b = 0xffffffff00000012;
+    return d.a;
+}

--- a/test/vast/Compile/SingleSource/union-b.c
+++ b/test/vast/Compile/SingleSource/union-b.c
@@ -1,0 +1,16 @@
+// RUN: %vast-front -o %t %s && (%t 1 1 1 1; test $? -eq 5)
+
+union data
+{
+    int a;
+    unsigned long long b;
+    char c;
+};
+
+int main(int argc, char **argv)
+{
+    union data d;
+    d.b = 0xffffffff00000012;
+    d.a = argc;
+    return d.c;
+}

--- a/test/vast/Compile/SingleSource/union-c.c
+++ b/test/vast/Compile/SingleSource/union-c.c
@@ -1,0 +1,20 @@
+// RUN: %vast-front -o %t %s && (%t 1 1 1 1; test $? -eq 5)
+
+struct access
+{
+    int l;
+    int h;
+};
+
+union data
+{
+    unsigned long long b;
+    struct access s;
+};
+
+int main(int argc, char **argv)
+{
+    union data d;
+    d.b = 0xffffffff00000000 + argc;
+    return d.s.l;
+}

--- a/test/vast/Compile/SingleSource/union-d.c
+++ b/test/vast/Compile/SingleSource/union-d.c
@@ -1,0 +1,21 @@
+// RUN: %vast-front -o %t %s && (%t 1 1 1 1; test $? -eq 5)
+
+struct access
+{
+    int l;
+    int h;
+};
+
+union data
+{
+    unsigned long long b;
+    struct access s;
+};
+
+int main(int argc, char **argv)
+{
+    union data d;
+    d.b = 0xffffffff00000000 + argc;
+    d.s.h = 0x12;
+    return d.s.l;
+}


### PR DESCRIPTION
Add basic lowering of unions - this required some improvements to api that facilitates walking of aggregate types.
 * handle lowering unions
 * handle lowering of nested structures
 * `StructDeclOp` and `UnionDecl` op now implement `AggregateTypeDefinitionInterface`

closes #500 