### PR TITLE
Extend readme and vast-front docs

### DIFF
--- a/.github/workflows/llvm-ts-run.yml
+++ b/.github/workflows/llvm-ts-run.yml
@@ -150,8 +150,6 @@ jobs:
           pattern: results-*
           merge-mutliple: true
 
-      - name: Display structure of downloaded files
-        run: ls -R
       - name: Install evaluator dependencies
         run: |
             pip3 install pandas scipy tabulate
@@ -167,12 +165,15 @@ jobs:
 
       - name: Generate the results
         run: |
-          python3 llvm-test-suite/utils/vast_compare.py --columns vast-hl,vast-llvm,vast-bin --files results-hl.json,results-llvm.json,results-bin.json
+          python3 llvm-test-suite/utils/vast_compare.py \
+            --columns vast-hl,vast-llvm,vast-bin \
+            --files results-hl.json,results-llvm.json,results-bin.json \
+            --output single-source-results
 
       - name: Post results as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: final-result
+          name: llvm-test-suite-results
           path: |
-            ./results.csv
-            ./results.md
+            ./single-source-results.csv
+            ./single-source-results.md

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: llvm-test-suite-results
+          path: llvm-test-suite-results
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Fetch LLVM test suite results
         uses: actions/download-artifact@v4
         with:
-          name: final-result
+          name: llvm-test-suite-results
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ to transform the representation to the best-fit program abstraction.
 
 For further information check [trailofbits.github.io/vast/](https://trailofbits.github.io/vast/).
 
+## Try VAST
+
+You can experiment with VAST on [compiler explorer](https://godbolt.org/z/3se3q9Tja). Feel free to use VAST and produce MLIR dialects. To specify the desired MLIR output, utilize the `-vast-emit-mlir=<dialect>` option. Currently, the supported options are:
+
+- `-vast-emit-mlir=hl` to generate [high-level](https://trailofbits.github.io/vast/dialects/HighLevel/HighLevel/) dialect.
+- `-vast-emit-mlir=llvm` to generate LLVM MLIR dialect.
+
 ## License
 
 VAST is licensed according to the [Apache 2.0](LICENSE) license. VAST links against and uses Clang and LLVM APIs. Clang is also licensed under Apache 2.0, with [LLVM exceptions](https://github.com/llvm/llvm-project/blob/main/clang/LICENSE.TXT).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can experiment with VAST on [compiler explorer](https://godbolt.org/z/3se3q9
 - `-vast-emit-mlir=hl` to generate [high-level](https://trailofbits.github.io/vast/dialects/HighLevel/HighLevel/) dialect.
 - `-vast-emit-mlir=llvm` to generate LLVM MLIR dialect.
 
+Refer to the [vast-front documentation](https://trailofbits.github.io/vast/Tools/vast-front/) for additional details.
+
 ## License
 
 VAST is licensed according to the [Apache 2.0](LICENSE) license. VAST links against and uses Clang and LLVM APIs. Clang is also licensed under Apache 2.0, with [LLVM exceptions](https://github.com/llvm/llvm-project/blob/main/clang/LICENSE.TXT).

--- a/docs/GettingStarted/extend.md
+++ b/docs/GettingStarted/extend.md
@@ -1,6 +1,6 @@
 ## How to Start Extending VAST?
 
-VAST offers a handy script to generate a variety of MLIR primitives. You can find the script at scripts/templater.py. This tool is designed to help you create dialects, passes, operations, types, and attributes interactively.
+VAST offers a handy script to generate a variety of MLIR primitives. You can find the script at `scripts/templater.py`. This tool is designed to help you create dialects, passes, operations, types, and attributes interactively.
 
 ### Usage
 

--- a/docs/Projects/related.md
+++ b/docs/Projects/related.md
@@ -1,5 +1,3 @@
-## Related Projects
-
 ### [LLVM Test Suite](https://github.com/trailofbits/vast-llvm-test-suite)
 
 Test suite extended to generate reports for VAST MLIR dialects.

--- a/docs/Projects/related.md
+++ b/docs/Projects/related.md
@@ -4,7 +4,7 @@
 
 Test suite extended to generate reports for VAST MLIR dialects.
 
-### [Benchamrks](https://github.com/trailofbits/vast-benchmarks)
+### [Benchmarks](https://github.com/trailofbits/vast-benchmarks)
 
 C/C++ benchmarks for VAST.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,21 @@ down to LLVM IR. This progression enables VAST to represent the code as a tower
 of IRs in multiple MLIR dialects. The MLIR allows us to capture high-level
 features from AST and interleave them with low-level dialects.
 
+## Try VAST
+
+You can experiment with VAST on [compiler
+explorer](https://godbolt.org/z/3se3q9Tja). Feel free to use VAST and produce
+MLIR dialects. To specify the desired MLIR output, utilize the
+`-vast-emit-mlir=<dialect>` option. Currently, the supported options are:
+
+- `-vast-emit-mlir=hl` to generate
+[high-level](https://trailofbits.github.io/vast/dialects/HighLevel/HighLevel/)
+dialect.  - `-vast-emit-mlir=llvm` to generate LLVM MLIR dialect.
+
+Refer to the [vast-front
+documentation](https://trailofbits.github.io/vast/Tools/vast-front/) for
+additional details.
+
 ## A Tower of IRs
 
 The feature that differentiates our approach is that the program representation

--- a/docs/Tools/vast-front.md
+++ b/docs/Tools/vast-front.md
@@ -1,3 +1,49 @@
 # VAST: Compiler Driver
 
-WIP `vast-front`
+`vast-front` serves as the primary `vast` compiler driver for compiling C/C++. It functions as an extension to the Clang compiler and generally supports all Clang's options. Moreover, `vast-front` offers several custom options, primarily designed as points of customization for MLIR generation. All these options are prefixed with `-vast`.
+
+## VAST output targets
+
+- `-vast-emit-mlir=<dialect>`
+  - Possible dialects: hl, std, llvm, cir
+  -This will execute the translation pipeline up to the specified dialect.
+
+Other available outputs:
+
+- `-vast-emit-llvm`
+- `-vast-emit-obj`
+- `-vast-emit-asm`
+
+Additional customization options include:
+
+- `-vast-print-pipeline`
+- `-vast-disable-<pipeline-step>`
+  - Options for `pipeline-step`: "canonicalize", "reduce-hl", "standard-types", etc. (see pipelines section below)
+
+- `-vast-simplify`
+  - Simplifies high-level output.
+
+- `-vast-show-locs`
+  - Displays locations in MLIR module print.
+
+- `-vast-locs-as-meta-ids`
+  - Uses metadata identifiers instead of file locations for locations.
+
+## Debuging and diagnostics
+
+- `-vast-emit-crash-reproducer="reproducer.mlir"`
+  - Emits an MLIR transformation crash reproducer; refer to [debugging docs](https://trailofbits.github.io/vast/GettingStarted/debug/).
+
+- `-vast-disable-multithreading`
+  - Disables multithreading in pipeline transformations for deterministic debugging.
+
+- `-vast-debug`
+  - Prints operations in diagnostics.
+  - Prints MLIR stack trace in diagnostics.
+
+- `-vast-disable-vast-verifier`
+  - Skips verification of the produced VAST MLIR module.
+
+## Pipelines
+
+WIP pipelines documentation

--- a/docs/Tools/vast-front.md
+++ b/docs/Tools/vast-front.md
@@ -6,7 +6,7 @@
 
 - `-vast-emit-mlir=<dialect>`
   - Possible dialects: hl, std, llvm, cir
-  -This will execute the translation pipeline up to the specified dialect.
+  - This will execute the translation pipeline up to the specified dialect.
 
 Other available outputs:
 

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -23,9 +23,9 @@ nav:
     - Optimizer: Tools/vast-opt.md
     - Query: Tools/vast-query.md
     - REPL: Tools/vast-repl.md
-  - Related Projects: projects/related.md
+  - Related Projects: Projects/related.md
   - Benchmarks:
-    - LLVM Test Suite SingleSource: benchmarks/results.md
+    - LLVM Single Source: Benchmarks/results.md
   - About:
     - 'License': 'statement.md'
 

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
     - REPL: Tools/vast-repl.md
   - Related Projects: Projects/related.md
   - Benchmarks:
-    - LLVM Single Source: Benchmarks/results.md
+    - LLVM Single Source: Benchmarks/single-source-results.md
   - About:
     - 'License': 'statement.md'
 

--- a/www/setup.sh
+++ b/www/setup.sh
@@ -32,6 +32,7 @@ if [ ! -d "$dst" ]; then
     mkdir -p "$dst"
 fi
 
+
 # Setup hand-written docs
 cp -rv $(pwd)/docs $dst
 cp -rv $(pwd)/LICENSE $dst/docs
@@ -41,7 +42,12 @@ cp -rv $(pwd)/CONTRIBUTING.md $dst/docs
 cp -rv $build/docs $dst/docs/dialects
 
 # Setup benchmark results
-cp -rv $(pwd)/results.md $dst/docs/benchmarks
+if [ ! -d "$dst/docs/Benchmarks" ]; then
+    echo "Creating benchmarks directory: $dst/docs/Benchmarks"
+    mkdir -p "$dst/docs/Benchmarks"
+fi
+
+cp -rv $(pwd)/llvm-test-suite-results/single-source-results.md $dst/docs/Benchmarks/
 
 # Setup site assets
 cp -rv $(pwd)/www/assets $dst


### PR DESCRIPTION
- add links to compiler explorer
- describes `vast-front` options
- fixes typos