### PR TITLE
Fix types of `abi.yield`.

### DIFF
--- a/lib/vast/Conversion/ABI/EmitABI.cpp
+++ b/lib/vast/Conversion/ABI/EmitABI.cpp
@@ -369,7 +369,7 @@ namespace vast
                     }
 
                     bld.template create< abi::YieldOp >(
-                            loc, op.getFunctionType().getResults(), to_yield );
+                            loc, op.getFunctionType().getInputs(), to_yield );
                 };
 
                 auto abi_prologue = rewriter.template create< abi::PrologueOp >(
@@ -598,7 +598,7 @@ namespace vast
 
                     bld.template create< abi::YieldOp >(
                         loc,
-                        this->abified_rets(),
+                        op.getResultTypes(),
                         out);
                 };
             }

--- a/test/vast/Conversion/ABI/direct-a.c
+++ b/test/vast/Conversion/ABI/direct-a.c
@@ -8,7 +8,7 @@ struct wrapped
 // ABI:      abi.func {{.*}} (%arg0: !hl.lvalue<i32>) -> si32 {{.*}}
 // ABI-NEXT:   {{.*}} = abi.prologue {
 // ABI-NEXT:     [[V5:%[0-9]+]] = abi.direct %arg0 : !hl.lvalue<i32> -> !hl.lvalue<!hl.elaborated<!hl.record<"wrapped">>>
-// ABI-NEXT:     [[V6:%[0-9]+]] = abi.yield [[V5]] : !hl.lvalue<!hl.elaborated<!hl.record<"wrapped">>> -> si32
+// ABI-NEXT:     [[V6:%[0-9]+]] = abi.yield [[V5]] : !hl.lvalue<!hl.elaborated<!hl.record<"wrapped">>> -> !hl.lvalue<!hl.elaborated<!hl.record<"wrapped">>>
 int fn( struct wrapped w )
 {
     // ABI:      [[V4:%[0-9]+]] = abi.epilogue {

--- a/test/vast/Conversion/ABI/direct-merge-a.c
+++ b/test/vast/Conversion/ABI/direct-merge-a.c
@@ -9,7 +9,7 @@ struct vec
 // ABI:      abi.func {{.*}} (%arg0: !hl.lvalue<i64>) -> si32 {{.*}}
 // ABI-NEXT: [[P0:%[0-9]+]] = abi.prologue {
 // ABI-NEXT:   [[P9:%[0-9]+]] = abi.direct %arg0 : !hl.lvalue<i64> -> !hl.lvalue<!hl.elaborated<!hl.record<"vec">>>
-// ABI-NEXT:   {{.*}} = abi.yield [[P9]] : !hl.lvalue<!hl.elaborated<!hl.record<"vec">>> -> si32
+// ABI-NEXT:   {{.*}} = abi.yield [[P9]] : !hl.lvalue<!hl.elaborated<!hl.record<"vec">>> -> !hl.lvalue<!hl.elaborated<!hl.record<"vec">>>
 // ABI-NEXT: } : !hl.lvalue<!hl.elaborated<!hl.record<"vec">>>
 
 // ABI:      [[E8:%[0-9]+]] = abi.epilogue {

--- a/test/vast/Conversion/ABI/direct-nested-a.c
+++ b/test/vast/Conversion/ABI/direct-nested-a.c
@@ -16,7 +16,7 @@ struct data
 // ABI:      abi.func {{.*}} (%arg0: !hl.lvalue<i64>) -> i64 {{.*}}
 // ABI:        {{.*}} = abi.prologue {
 // ABI-NEXT:     [[P4:%[0-9]+]] = abi.direct %arg0 : !hl.lvalue<i64> -> !hl.lvalue<!hl.elaborated<!hl.record<"data">>>
-// ABI-NEXT:     {{.*}} = abi.yield [[P4]] : !hl.lvalue<!hl.elaborated<!hl.record<"data">>> -> !hl.elaborated<!hl.record<"data">>
+// ABI-NEXT:     {{.*}} = abi.yield [[P4]] : !hl.lvalue<!hl.elaborated<!hl.record<"data">>> -> !hl.lvalue<!hl.elaborated<!hl.record<"data">>>
 // ABI-NEXT:   } : !hl.lvalue<!hl.elaborated<!hl.record<"data">>>
 
 // ABI:      [[E3:%[0-9]+]] = abi.epilogue {
@@ -38,7 +38,7 @@ struct data id( struct data v )
 // ABI-NEXT:     [[C10:%[0-9]+]] = abi.call @id([[C9]]) : (i64) -> i64
 // ABI-NEXT:     [[C11:%[0-9]+]] = abi.call_rets {
 // ABI-NEXT:       [[C13:%[0-9]+]] = abi.direct [[C10]] : i64 -> !hl.elaborated<!hl.record<"data">>
-// ABI-NEXT:       {{.*}} = abi.yield [[C13]] : !hl.elaborated<!hl.record<"data">> -> i64
+// ABI-NEXT:       {{.*}} = abi.yield [[C13]] : !hl.elaborated<!hl.record<"data">> -> !hl.elaborated<!hl.record<"data">>
 // ABI-NEXT:     } : !hl.elaborated<!hl.record<"data">>
 // ABI-NEXT:     {{.*}} = abi.yield [[C11]] : !hl.elaborated<!hl.record<"data">> -> !hl.elaborated<!hl.record<"data">>
 // ABI-NEXT:   } : (!hl.elaborated<!hl.record<"data">>) -> !hl.elaborated<!hl.record<"data">>

--- a/test/vast/Conversion/ABI/direct-overlap-a.c
+++ b/test/vast/Conversion/ABI/direct-overlap-a.c
@@ -10,7 +10,7 @@ struct data
 // ABI:      abi.func {{.*}} (%arg0: !hl.lvalue<i64>) -> si32 {{.*}}
 // ABI:        {{.*}} = abi.prologue {
 // ABI-NEXT:     [[V0:%[0-9]+]] = abi.direct %arg0 : !hl.lvalue<i64> -> !hl.lvalue<!hl.elaborated<!hl.record<"data">>>
-// ABI-NEXT:     {{.*}} = abi.yield [[V0]] : !hl.lvalue<!hl.elaborated<!hl.record<"data">>> -> si32
+// ABI-NEXT:     {{.*}} = abi.yield [[V0]] : !hl.lvalue<!hl.elaborated<!hl.record<"data">>> -> !hl.lvalue<!hl.elaborated<!hl.record<"data">>>
 // ABI-NEXT:   } : !hl.lvalue<!hl.elaborated<!hl.record<"data">>>
 
 


### PR DESCRIPTION
This is a temporary fix as it will be updated more once lowering of value categories is merged.