### PR TITLE
CMake presets refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: cmake --preset ci
 
       - name: Build ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
-        run: cmake --build --preset ci -C ${{ matrix.build-type }} -j $(nproc)
+        run: cmake --build --preset ci --config ${{ matrix.build-type }} -j $(nproc)
 
       - name: Test ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
-        run: ctest --preset ci -C ${{ matrix.build-type }}
+        run: ctest --preset ci --build-config ${{ matrix.build-type }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         llvm-version: [17]
         image-version: [22.04]
-        build-type: [rel, deb]
+        build-type: [Release, Debug]
         sanitizers: [ON, OFF]
 
     runs-on: ubuntu-${{ matrix.image-version }}
@@ -37,8 +37,9 @@ jobs:
 
     env:
         CMAKE_PREFIX_PATH: "/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/mlir/;/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/clang/"
-        TOOLCHAIN: ${{ github.workspace }}/cmake/lld.toolchain.cmake
         LLVM_EXTERNAL_LIT: "/usr/local/bin/lit"
+        ENABLE_SANITIZER_UNDEFINED_BEHAVIOR: ${{ matrix.sanitizers }}
+        ENABLE_SANITIZER_ADDRESS: ${{ matrix.sanitizers }}
 
     steps:
       - name: Clone the VAST repository
@@ -48,17 +49,10 @@ jobs:
           fetch-depth: 1
 
       - name: Configure build - sanitizers ${{ matrix.sanitizers }}
-        run: |
-            cmake --preset ninja-multi-default --toolchain ${TOOLCHAIN} \
-              -DCMAKE_VERBOSE_MAKEFILE=True \
-              -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=${{ matrix.sanitizers }}\
-              -DENABLE_SANITIZER_ADDRESS=${{ matrix.sanitizers }}\
-              -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
-              -DLLVM_EXTERNAL_LIT=${LLVM_EXTERNAL_LIT}
+        run: cmake --preset ci
 
       - name: Build ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
-        run: |
-            cmake --build --preset ninja-${{ matrix.build-type }} -j $(nproc)
+        run: cmake --build --preset ci -C ${{ matrix.build-type }} -j $(nproc)
 
       - name: Test ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
-        run: ctest --preset ninja-${{ matrix.build-type }} --output-on-failure
+        run: ctest --preset ci -C ${{ matrix.build-type }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,7 +32,6 @@ jobs:
 
     env:
         CMAKE_PREFIX_PATH: "/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/mlir/;/usr/lib/llvm-${{ matrix.llvm-version }}/lib/cmake/clang/"
-        TOOLCHAIN: ${{ github.workspace }}/cmake/lld.toolchain.cmake
 
     steps:
       - name: Remove safety checks for pygit
@@ -45,7 +44,7 @@ jobs:
           fetch-depth: 1
 
       - name: Export compile commands
-        run: cmake --preset ninja-multi-default --toolchain ${TOOLCHAIN} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+        run: cmake --preset ci
 
       - name: Install dependencies
         run: |
@@ -60,7 +59,7 @@ jobs:
         with:
           version: ${{ matrix.llvm-version }}
           style: file
-          database: ./builds/ninja-multi-default/
+          database: ./builds/ci/
           lines-changed-only: true
           thread-comments: true
           step-summary: true

--- a/.github/workflows/llvm-ts-run.yml
+++ b/.github/workflows/llvm-ts-run.yml
@@ -43,22 +43,19 @@ jobs:
           fetch-depth: 1
 
       - name: Configure build
-        run: |
-            cmake --preset ninja-multi-default --toolchain ${TOOLCHAIN} \
-              -DCMAKE_VERBOSE_MAKEFILE=True \
-              -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
-              -DLLVM_EXTERNAL_LIT=${LLVM_EXTERNAL_LIT}
+        run: cmake --preset ci
 
       - name: Build release
-        run: |
-            cmake --build --preset ninja-rel -j $(nproc)
-            cpack -G TXZ --config ./builds/ninja-multi-default/CPackConfig.cmake
+        run: cmake --build --preset ci-release -j $(nproc)
+
+      - name: Package
+        run: cpack --preset ci
 
       - name: Upload VAST build artifact
         uses: actions/upload-artifact@v4
         with:
           name: VAST
-          path: ./builds/ninja-multi-default/package/*
+          path: ./builds/ci/package/*
           retention-days: 1
 
   test:
@@ -84,12 +81,10 @@ jobs:
          name: VAST
 
      - name: Unpack VAST
-       run: |
-          mkdir vast && tar -xf VAST-* -C vast --strip-components=1
+       run: mkdir vast && tar -xf VAST-* -C vast --strip-components=1
 
      - name: Export vast binaries
-       run: |
-          echo "${PWD}/vast/bin/" >> $GITHUB_PATH
+       run: echo "${PWD}/vast/bin/" >> $GITHUB_PATH
 
      - name: Install test suite dependencies
        run: |
@@ -151,8 +146,7 @@ jobs:
           merge-multiple: true
 
       - name: Install evaluator dependencies
-        run: |
-            pip3 install pandas scipy tabulate
+        run: pip3 install pandas scipy tabulate
 
       - name: Clone test suite repository
         uses: actions/checkout@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -46,16 +46,13 @@ jobs:
           fetch-depth: 1
 
       - name: Configure build
-        run: |
-            cmake --preset ninja-multi-default --toolchain ${TOOLCHAIN} \
-              -DCMAKE_VERBOSE_MAKEFILE=True \
-              -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
-              -DLLVM_EXTERNAL_LIT=${LLVM_EXTERNAL_LIT}
+        run: cmake --preset ci
 
       - name: Build release
-        run: |
-            cmake --build --preset ninja-rel -j $(nproc)
-            cpack -G TXZ --config ./builds/ninja-multi-default/CPackConfig.cmake
+        run: cmake --build --preset ci-release -j $(nproc)
+
+      - name: Package
+        run: cpack --preset ci
 
       - name: Publish Pre-Release
         uses: softprops/action-gh-release@v1
@@ -65,10 +62,10 @@ jobs:
           generate_release_notes: true
           files: |
             ./LICENSE
-            ./builds/ninja-multi-default/package/*
+            ./builds/ci/package/*
 
       - name: Build VAST Doc
-        run: cmake --build --preset ninja-rel --target vast-doc
+        run: cmake --build --preset ci-release --target vast-doc
 
       - name: Fetch LLVM test suite results
         uses: actions/download-artifact@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,6 +87,18 @@
             "configurePreset": "ci"
         },
         {
+            "name": "ci-release",
+            "configurePreset": "ci",
+            "displayName": "CI Release",
+            "configuration": "Release"
+        },
+        {
+            "name": "ci-debug",
+            "configurePreset": "ci",
+            "displayName": "CI Debug",
+            "configuration": "Debug"
+        },
+        {
             "name": "compiler-explorer",
             "configurePreset": "compiler-explorer",
             "displayName": "Build VAST for Compiler Explorer",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,18 +16,33 @@
                 "CMAKE_CONFIGURATION_TYPES": "Release;RelWithDebInfo;Debug",
                 "VAST_ENABLE_TESTING": "ON",
                 "LLVM_EXTERNAL_LIT": "$env{LLVM_EXTERNAL_LIT}",
-                "CMAKE_PREFIX_PATH": "$env{CMAKE_PREFIX_PATH}",
-                "VAST_ENABLE_PDLL_CONVERSIONS": "ON"
+                "CMAKE_PREFIX_PATH": "$env{CMAKE_PREFIX_PATH}"
             }
         },
         {
             "name": "ci",
-            "displayName": "CI",
+            "displayName": "Configure VAST for CI",
             "inherits": "default",
             "cacheVariables": {
                 "ENABLE_SANITIZER_UNDEFINED_BEHAVIOR": "$env{ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}",
                 "ENABLE_SANITIZER_ADDRESS": "$env{ENABLE_SANITIZER_ADDRESS}",
                 "CMAKE_VERBOSE_MAKEFILE": "True"
+            }
+        },
+        {
+            "name": "compiler-explorer",
+            "displayName": "Configure VAST for Compiler Explorer",
+            "binaryDir": "${sourceDir}/builds/${presetName}",
+            "generator": "Ninja Multi-Config",
+            "toolchainFile": "${sourceDir}/cmake/lld.toolchain.cmake",
+            "cacheVariables": {
+                "CMAKE_CONFIGURATION_TYPES": "Release",
+                "VAST_ENABLE_TESTING": "OFF",
+                "CMAKE_C_COMPILER": "/usr/bin/clang-17",
+                "CMAKE_CXX_COMPILER": "/usr/bin/clang++-17",
+                "CMAKE_INSTALL_PREFIX": "$env{STAGING_DIR}",
+                "CMAKE_INSTALL_RPATH": "$env{ORIGIN}/../lib",
+                "CMAKE_PREFIX_PATH": "/usr/lib/llvm-17;/usr/lib/llvm-17/lib/cmake/mlir;/usr/lib/llvm-17/lib/cmake/clang"
             }
         },
         {
@@ -70,6 +85,12 @@
         {
             "name": "ci",
             "configurePreset": "ci"
+        },
+        {
+            "name": "compiler-explorer",
+            "configurePreset": "compiler-explorer",
+            "displayName": "Build VAST for Compiler Explorer",
+            "configuration": "Release"
         },
         {
             "name": "osx-cxx-common-rel",
@@ -167,6 +188,19 @@
                 {
                     "type": "test",
                     "name": "release"
+                }
+            ]
+        },
+        {
+            "name": "compiler-explorer",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "compiler-explorer"
+                },
+                {
+                    "type": "build",
+                    "name": "compiler-explorer"
                 }
             ]
         }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,14 +1,14 @@
 {
-    "version": 3,
+    "version": 6,
     "cmakeMinimumRequired": {
         "major": 3,
-        "minor": 21,
+        "minor": 25,
         "patch": 0
     },
     "configurePresets": [
         {
-            "name": "ninja-multi-default",
-            "displayName": "Ninja Multi-Config",
+            "name": "default",
+            "displayName": "Default",
             "binaryDir": "${sourceDir}/builds/${presetName}",
             "generator": "Ninja Multi-Config",
             "toolchainFile": "${sourceDir}/cmake/lld.toolchain.cmake",
@@ -21,43 +21,65 @@
             }
         },
         {
-            "name": "ninja-multi-osx-cxx-common",
+            "name": "ci",
+            "displayName": "CI",
+            "inherits": "default",
+            "cacheVariables": {
+                "ENABLE_SANITIZER_UNDEFINED_BEHAVIOR": "$env{ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}",
+                "ENABLE_SANITIZER_ADDRESS": "$env{ENABLE_SANITIZER_ADDRESS}",
+                "CMAKE_VERBOSE_MAKEFILE": "True"
+            }
+        },
+        {
+            "name": "osx-cxx-common",
             "displayName": "Ninja Multi-Config OSX with cxx-common",
             "description": "Configure with cxx-common toolchain for x64-osx",
-            "binaryDir": "${sourceDir}/builds/${presetName}",
-            "generator": "Ninja Multi-Config",
             "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "installDir": "${sourceDir}/install",
+            "inherits": "default",
             "cacheVariables": {
-                "CMAKE_CONFIGURATION_TYPES": "Release;RelWithDebInfo;Debug",
                 "VCPKG_TARGET_TRIPLET": "x64-osx",
-                "VCPKG_HOST_TRIPLET": "x64-osx",
-                "LLVM_EXTERNAL_LIT": "$env{LLVM_EXTERNAL_LIT}"
+                "VCPKG_HOST_TRIPLET": "x64-osx"
             }
         }
     ],
     "buildPresets": [
         {
-            "name": "ninja-rel",
-            "configurePreset": "ninja-multi-default",
-            "displayName": "Build ninja-multi-release",
+            "name": "default",
+            "hidden": true,
+            "configurePreset": "default"
+        },
+        {
+            "name": "release",
+            "configurePreset": "default",
+            "displayName": "Release",
             "configuration": "Release"
         },
         {
-            "name": "ninja-deb",
-            "configurePreset": "ninja-multi-default",
-            "displayName": "Build ninja-multi-debug",
+            "name": "debug",
+            "configurePreset": "default",
+            "displayName": "Debug",
             "configuration": "Debug"
         },
         {
-            "name": "ninja-osx-cxx-common-rel",
-            "configurePreset": "ninja-multi-osx-cxx-common",
+            "name": "relwithdebinfo",
+            "configurePreset": "default",
+            "displayName": "RelWithDebInfo",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci"
+        },
+        {
+            "name": "osx-cxx-common-rel",
+            "configurePreset": "osx-cxx-common",
             "displayName": "Build osx-release with cxx-common",
             "configuration": "Release"
         },
         {
-            "name": "ninja-osx-cxx-common-deb",
-            "configurePreset": "ninja-multi-osx-cxx-common",
+            "name": "osx-cxx-common-deb",
+            "configurePreset": "osx-cxx-common",
             "displayName": "Build osx-debug with cxx-common",
             "configuration": "Debug"
         }
@@ -66,7 +88,6 @@
         {
             "name": "test-base",
             "hidden": true,
-            "configurePreset": "ninja-multi-default",
             "output": {
               "outputOnFailure": true,
               "verbosity": "default"
@@ -78,35 +99,76 @@
         },
         {
             "name": "default",
+            "configurePreset": "default",
             "hidden": true,
-            "configurePreset": "ninja-multi-default",
             "inherits": "test-base"
         },
         {
-            "name": "ninja-rel", "inherits": "default",
-            "displayName": "Test ninja-rel",
+            "name": "release",
+            "configurePreset": "default",
+            "inherits": "default",
             "configuration": "Release"
         },
         {
-            "name": "ninja-deb", "inherits": "default",
-            "displayName": "Test ninja-deb",
+            "name": "debug",
+            "configurePreset": "default",
+            "inherits": "default",
             "configuration": "Debug"
         },
         {
-            "name": "cxx-common-osx",
-            "hidden": true,
-            "configurePreset": "ninja-multi-osx-cxx-common",
+            "name": "relwithdebinfo",
+            "configurePreset": "default",
+            "inherits": "default",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci",
             "inherits": "test-base"
+        }
+    ],
+    "packagePresets": [
+        {
+            "name": "ci",
+            "configurePreset": "ci",
+            "generators": ["TGZ"],
+            "configFile": "${sourceDir}/builds/${presetName}/CPackConfig.cmake"
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "debug",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "default"
+                },
+                {
+                    "type": "build",
+                    "name": "debug"
+                },
+                {
+                    "type": "test",
+                    "name": "debug"
+                }
+            ]
         },
         {
-            "name": "cxx-common-osx-rel", "inherits": "cxx-common-osx",
-            "displayName": "Test cxx-common-osx-rel",
-            "configuration": "Release"
-        },
-        {
-            "name": "cxx-common-osx-deb", "inherits": "cxx-common-osx",
-            "displayName": "Test cxx-common-osx-deb",
-            "configuration": "Debug"
+            "name": "release",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "default"
+                },
+                {
+                    "type": "build",
+                    "name": "release"
+                },
+                {
+                    "type": "test",
+                    "name": "release"
+                }
+            ]
         }
     ]
 }

--- a/docs/GettingStarted/build.md
+++ b/docs/GettingStarted/build.md
@@ -17,10 +17,16 @@ To configure project run `cmake` with following default options.
 In case `clang` isn't your default compiler prefix the command with `CC=clang CXX=clang++`.
 If you want to use system installed `llvm` and `mlir` (on Ubuntu) use:
 
+The simplest way is to run
+
 ```
-cmake --preset ninja-multi-default \
-    --toolchain ./cmake/lld.toolchain.cmake \
-    -DCMAKE_PREFIX_PATH=/usr/lib/llvm-17/
+cmake --workflow release
+```
+
+If this method doesn't work for you, configure the project in the usual way:
+
+```
+cmake --preset default
 ```
 
 To use a specific `llvm` provide `-DCMAKE_PREFIX_PATH=<llvm & mlir instalation paths>` option, where `CMAKE_PREFIX_PATH` points to directory containing `LLVMConfig.cmake` and `MLIRConfig.cmake`.
@@ -31,10 +37,10 @@ Note: vast requires LLVM with RTTI enabled. Use `LLVM_ENABLE_RTTI=ON` if you bui
 Finally, build the project:
 
 ```
-cmake --build --preset ninja-rel
+cmake --build --preset release
 ```
 
-Use `ninja-deb` preset for debug build.
+Use `debug` preset for debug build.
 
 ## Run
 
@@ -49,5 +55,5 @@ Supported dialects are: `hl`, `ll`, `llvm`
 ## Test
 
 ```
-ctest --preset ninja-deb
+ctest --preset debug
 ```

--- a/docs/GettingStarted/build.md
+++ b/docs/GettingStarted/build.md
@@ -47,7 +47,7 @@ Use `debug` preset for debug build.
 To run mlir codegen of highlevel dialect use.
 
 ```
-./builds/ninja-multi-default/tools/vast-front/Release/vast-front -vast-emit-mlir=<dialect> <input.c> -o <output.mlir>
+./builds/default/tools/vast-front/Release/vast-front -vast-emit-mlir=<dialect> <input.c> -o <output.mlir>
 ```
 
 Supported dialects are: `hl`, `ll`, `llvm`

--- a/scripts/setup_llvm_dependencies.sh
+++ b/scripts/setup_llvm_dependencies.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Set default LLVM version if not specified
+LLVM_VERSION=${LLVM_VERSION:-17}
+
+# Install LLVM tools and libraries
+bash -c "$(curl -s -o - https://apt.llvm.org/llvm.sh)" llvm.sh $LLVM_VERSION
+
+# Install required packages dynamically based on the LLVM version
+apt-get update && apt-get install -y -q \
+ libstdc++-12-dev \
+ llvm-${LLVM_VERSION} \
+ libmlir-${LLVM_VERSION} \
+ libmlir-${LLVM_VERSION}-dev \
+ mlir-${LLVM_VERSION}-tools \
+ libclang-${LLVM_VERSION}-dev


### PR DESCRIPTION
- adds `ci` specific preset
- adds `compiler-explorer` specific preset
- renames `ninja-multi-default` to `default` preset
- adds script to setup `compiler-explorer` docker