### PR TITLE
Disable LLVM symbolizer in prerelease CI.

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -18,6 +18,9 @@ on:
 
 permissions: write-all
 
+env:
+  LLVM_DISABLE_SYMBOLIZATION: 1
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Trying to see if this provides a meaningful speedup for sv-comp benchmarks. I have also disabled compiler crash diagnostics in the SV-Comp repository (only on the CI branch at the moment).
Could potentially lead to re-enabling of `llvm` as a target for SV-Comp