### PR TITLE
`core::SelectOp` and some `void` related fixes.

### DIFF
--- a/lib/vast/Conversion/Core/ToLLVM.cpp
+++ b/lib/vast/Conversion/Core/ToLLVM.cpp
@@ -36,9 +36,19 @@ namespace vast
             using base::base;
 
             auto lazy_into_block(
-                Operation* lazy_op, Block* target, conversion_rewriter &rewriter) const
-            {
+                Operation* lazy_op, Block* target, conversion_rewriter &rewriter
+            ) const -> std::tuple< mlir_value, mlir::Block * > {
                 auto &lazy_region = mlir::dyn_cast< core::LazyOp >(*lazy_op).getLazy();
+
+                // In case `lazy_op` already has multiple blocks (nested lazy ops)
+                // we need to return the block that does not yet have the control flow.
+                // This will be the block with the yield, but if it is in the first block,
+                // it will get merged.
+                auto end_block = [&] {
+                    if (&lazy_region.front() == &lazy_region.back())
+                        return target;
+                    return &lazy_region.back();
+                }();
 
                 // Last block should have hl.value.yield with the final value
                 auto &yield = lazy_region.back().back();
@@ -55,7 +65,55 @@ namespace vast
 
                 rewriter.eraseOp(lazy_op);
 
-                return res;
+                return { res, end_block };
+            }
+
+
+            template< std::size_t count > requires (count > 1)
+            auto split_into_blocks_at(operation op, mlir::Block *block) const {
+                auto next = block->splitBlock(op);
+                return std::tuple_cat(
+                    std::make_tuple(next), split_into_blocks_at< count - 1 >(op, next));
+            }
+
+            template< std::size_t count > requires (count == 1)
+            auto split_into_blocks_at(operation op, mlir::Block *block) const {
+                return std::make_tuple(block->splitBlock(op));
+            }
+
+            auto mk_icmp_ne(auto &rewriter, auto loc, auto value) const {
+                auto zero = iN(rewriter, loc, value.getType(), 0);
+                return rewriter.template create< LLVM::ICmpOp >(
+                    loc, LLVM::ICmpPredicate::ne, value, zero);
+            }
+
+
+            auto tie_block(
+                auto &rewriter, auto loc, auto current_block, auto target_block, auto arg
+            ) const {
+                auto g = insertion_guard(rewriter);
+                auto current_it = current_block->getIterator();
+                rewriter.setInsertionPointToEnd(&*current_it);
+                if (arg)
+                    rewriter.template create< LLVM::BrOp >(loc, arg, target_block);
+                else
+                    rewriter.template create< LLVM::BrOp >(loc, std::nullopt, target_block);
+            }
+
+            auto get_tie_block(auto &rewriter, auto loc, auto target_block) const {
+                return [=, &rewriter](auto current_block, auto arg) {
+                    return tie_block(rewriter, loc, current_block, target_block, arg);
+                };
+            }
+
+            bool is_void(mlir_type t) const { return mlir::isa< mlir::LLVM::LLVMVoidType >(t); }
+
+            auto add_argument(
+                mlir::Block *block, auto type, auto loc
+            ) const -> std::optional< mlir::BlockArgument > {
+                if (is_void(type))
+                    return std::nullopt;
+                return std::make_optional(block->addArgument(type, loc));
             }
         };
 
@@ -92,8 +150,8 @@ namespace vast
                 auto rhs_block = curr_block->splitBlock(op);
                 auto end_block = rhs_block->splitBlock(op);
 
-                auto lhs_res = lazy_into_block(ops.getLhs().getDefiningOp(), curr_block, rewriter);
-                auto rhs_res = lazy_into_block(ops.getRhs().getDefiningOp(), rhs_block, rewriter);
+                auto [ lhs_res, _1 ] = lazy_into_block(ops.getLhs().getDefiningOp(), curr_block, rewriter);
+                auto [ rhs_res, _2 ] = lazy_into_block(ops.getRhs().getDefiningOp(), rhs_block, rewriter);
 
                 rewriter.setInsertionPointToEnd(curr_block);
                 auto zero = iN(rewriter, op.getLoc(), lhs_res.getType(), 0);
@@ -127,9 +185,63 @@ namespace vast
             }
         };
 
+        struct select : lazy_base< core::SelectOp >
+        {
+            using op_t = core::SelectOp;
+            using base = lazy_base<  op_t >;
+            using base::base;
+
+            using base::lazy_into_block;
+            using base::iN;
+
+            logical_result matchAndRewrite(
+                op_t op, typename op_t::Adaptor ops, conversion_rewriter &rewriter) const override
+            {
+                auto curr_block = rewriter.getBlock();
+                auto [true_block, false_block, end_block] = split_into_blocks_at< 3 >(op, curr_block);
+
+                auto init_block = [&](auto operand, auto block) {
+                    return lazy_into_block(operand.getDefiningOp(), block, rewriter);
+                };
+
+                auto [ true_res, true_end ] = init_block(ops.getThenRegion(), true_block);
+                auto [ false_res, false_end ] = init_block(ops.getElseRegion(), false_block);
+
+                rewriter.setInsertionPointToEnd(curr_block);
+                auto cmp = mk_icmp_ne(rewriter, op.getLoc(), ops.getCond());
+
+                // Block argument that recieves the result value
+                auto end_arg = add_argument(end_block, true_res.getType(), op.getLoc());
+
+                rewriter.create< LLVM::CondBrOp >(
+                    op.getLoc(), cmp, true_block, std::nullopt, false_block, std::nullopt);
+
+
+                auto tie = get_tie_block(rewriter, op.getLoc(), end_block);
+                tie(false_end, (end_arg) ? false_res : mlir_value{});
+                tie(true_end, (end_arg) ? true_res : mlir_value{});
+
+                rewriter.setInsertionPointToStart(end_block);
+
+                auto trg_type = op.getResult(0).getType();
+                if (mlir::isa< mlir::IntegerType >(trg_type)) {
+                    VAST_ASSERT(end_arg);
+                    replace_with_trunc_or_ext(
+                        op, *end_arg, end_arg->getType(), op.getResult(0).getType(), rewriter);
+                } else if (is_void(trg_type)) {
+                    rewriter.eraseOp(op);
+                } else {
+                    VAST_ASSERT(end_arg);
+                    rewriter.replaceOp(op, *end_arg);
+                }
+                return mlir::success();
+            }
+        };
+
         using bin_lop_conversions = util::type_list<
             lazy_bin_logical< core::BinLAndOp, false >,
-            lazy_bin_logical< core::BinLOrOp, true >
+            lazy_bin_logical< core::BinLOrOp, true >,
+            select
         >;
 
     } //namespace pattern
@@ -150,6 +262,18 @@ namespace vast
 
         static void populate_conversions(config_t &config) {
             populate_conversions_base< pattern::bin_lop_conversions >(config);
+        }
+
+        void after_operation() override {
+            // Now we know that we need to get rid fo any remaining `llvm.mlir.zero` that
+            // are of void type because they cannot be codegen'ed into LLVM IR.
+            auto exec = [&](mlir::LLVM::ZeroOp op) {
+                if (!llvm::isa< mlir::LLVM::LLVMVoidType >(op.getType()))
+                    return;
+                VAST_CHECK(op->getUsers().empty(), "{0} remains live after all conversions!", op);
+                op->erase();
+            };
+            this->getOperation()->walk(exec);
         }
     };
 

--- a/lib/vast/Conversion/ToLLVM/Common.hpp
+++ b/lib/vast/Conversion/ToLLVM/Common.hpp
@@ -77,6 +77,14 @@ namespace vast::conv::irstollvm {
                 return {};
             return convert(ptr.getElementType());
         }
+
+        std::vector< mlir::Value > strip_voids(const auto &values) const {
+            std::vector< mlir::Value > out;
+            for (auto v : values)
+                if (!mlir::isa< LLVM::LLVMVoidType >(v.getType()))
+                    out.push_back(v);
+            return out;
+        }
     };
 
     template< typename src_t, typename trg_t >

--- a/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
@@ -1304,15 +1304,24 @@ namespace vast::conv::irstollvm
             LazyOp op, typename LazyOp::Adaptor ops,
             conversion_rewriter &rewriter) const override
         {
-            auto lower_res_type = [&]()
-            {
-                auto result = op.getResult();
-                result.setType(this->convert(result.getType()));
-            };
+            // It does have regions, we cannot use `clone` as it will screw the
+            // queue of ops that needs to be converted conversion to-be done.
+            if (op->getNumRegions()) {
+                auto lower_res_type = [&]()
+                {
+                    for (std::size_t i = 0; i < op->getNumResults(); ++i) {
+                        auto result = op->getResult(i);
+                        result.setType(this->convert(result.getType()));
+                    }
+                };
 
-            // TODO: Should we use clone instead?
-            rewriter.modifyOpInPlace(op, lower_res_type);
-            return logical_result::success();
+                // TODO: Should we use clone instead?
+                rewriter.modifyOpInPlace(op, lower_res_type);
+                return logical_result::success();
+            }
+
+            // It does not have regions
+            return this->update_via_clone(rewriter, op, ops.getOperands());
         }
     };
 
@@ -1351,6 +1360,7 @@ namespace vast::conv::irstollvm
         lazy_op_type< core::LazyOp >,
         lazy_op_type< core::BinLAndOp >,
         lazy_op_type< core::BinLOrOp >,
+        lazy_op_type< core::SelectOp >,
         fixup_yield_types< hl::ValueYieldOp >
     >;
 
@@ -1439,6 +1449,7 @@ namespace vast::conv::irstollvm
             legal_with_llvm_ret_type( core::LazyOp{} );
             legal_with_llvm_ret_type( core::BinLAndOp{} );
             legal_with_llvm_ret_type( core::BinLOrOp{} );
+            legal_with_llvm_ret_type( core::SelectOp{} );
 
             target.addDynamicallyLegalOp< hl::ValueYieldOp >([&](hl::ValueYieldOp op) {
                 return mlir::isa< core::LazyOp >(op->getParentOp()) &&

--- a/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
@@ -679,7 +679,7 @@ namespace vast::conv::irstollvm
                 op_t ret_op, typename op_t::Adaptor ops,
                 conversion_rewriter &rewriter) const override
         {
-            rewriter.create< LLVM::ReturnOp >(ret_op.getLoc(), ops.getOperands());
+            rewriter.create< LLVM::ReturnOp >(ret_op.getLoc(), this->strip_voids(ops.getOperands()));
             rewriter.eraseOp(ret_op);
             return logical_result::success();
         }

--- a/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
@@ -1333,10 +1333,13 @@ namespace vast::conv::irstollvm
             if (mlir::isa< mlir::LLVM::GlobalOp >(op->getParentOp()))
                 return logical_result::failure();
 
-            if (ops.getResult().getType().template isa< mlir::LLVM::LLVMVoidType >())
-            {
-                rewriter.eraseOp(op);
-                return logical_result::success();
+            // Some operations need to keep it even with void value.
+            if (!mlir::isa< core::LazyOp >(op->getParentOp())) {
+                if (ops.getResult().getType().template isa< mlir::LLVM::LLVMVoidType >())
+                {
+                    rewriter.eraseOp(op);
+                    return logical_result::success();
+                }
             }
 
             // TODO: What would it take to make this work `updateRootInPlace`?

--- a/test/vast/Compile/SingleSource/ternary-a.c
+++ b/test/vast/Compile/SingleSource/ternary-a.c
@@ -1,0 +1,14 @@
+// RUN: %vast-front -o %t %s
+// RUN: %t 1 2 | %file-check %s -check-prefix="A"
+// RUN: %t 1 2 3 | %file-check %s -check-prefix="B"
+// RUN: %t | %file-check %s -check-prefix="A"
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    char c = (argc % 2 == 0) ? '0' : '1';
+    // A: 1
+    // B: 0
+    putchar(c);
+}

--- a/test/vast/Compile/SingleSource/ternary-b.c
+++ b/test/vast/Compile/SingleSource/ternary-b.c
@@ -1,0 +1,16 @@
+// RUN: %vast-front -o %t %s
+// RUN: %t 1 2 | %file-check %s -check-prefix="FOO"
+// RUN: %t 1 2 3 | %file-check %s -check-prefix="BOO"
+// RUN: %t | %file-check %s -check-prefix="FOO"
+
+#include <stdio.h>
+
+void foo() { printf("foo\n"); }
+void boo() { printf("boo\n"); }
+
+int main(int argc, char **argv)
+{
+    // FOO: foo
+    // BOO: boo
+    (argc % 2 == 0) ? boo() : foo();
+}

--- a/test/vast/Compile/SingleSource/ternary-c.c
+++ b/test/vast/Compile/SingleSource/ternary-c.c
@@ -1,0 +1,20 @@
+// RUN: %vast-front -o %t %s
+// RUN: %t 1 2 | %file-check %s -check-prefix="FOO"
+// RUN: %t 1 2 3 | %file-check %s -check-prefix="BOO"
+// RUN: %t 1 | %file-check %s -check-prefix="GOO"
+
+#include <stdio.h>
+
+void foo() { printf("foo\n"); }
+void boo() { printf("boo\n"); }
+void goo() { printf("goo\n"); }
+
+int main(int argc, char **argv)
+{
+    // FOO: foo
+    // BOO: boo
+    // GOO: goo
+    (argc % 2 == 0) ? ( (argc == 2) ? goo()
+                                    : boo() )
+                    : foo();
+}

--- a/test/vast/Compile/SingleSource/ternary-d.c
+++ b/test/vast/Compile/SingleSource/ternary-d.c
@@ -1,0 +1,28 @@
+// RUN: %vast-front -o %t %s
+// RUN: %t 1 2 | %file-check %s -check-prefix="FOO"
+// RUN: %t 1 2 3 | %file-check %s -check-prefix="BOO"
+// RUN: %t 1 | %file-check %s -check-prefix="GOO"
+
+#include <stdio.h>
+
+int foo() { printf("foo\n"); return 0; }
+int boo() { printf("boo\n"); return 1; }
+int goo() { printf("goo\n"); return 2; }
+
+int main(int argc, char **argv)
+{
+    // FOO: foo
+    // BOO: boo
+    // GOO: goo
+    int o = (argc % 2 == 0) ? ( (argc == 2) ? goo()
+                                            : boo() )
+                            : foo();
+    if (o == 0)
+        return (argc == 3) ? 0 : 1;
+
+    if (o == 1)
+        return (argc == 4) ? 0 : 1;
+
+    if (o == 2)
+        return (argc == 2) ? 0 : 1;
+}

--- a/test/vast/Compile/SingleSource/void-return-a.c
+++ b/test/vast/Compile/SingleSource/void-return-a.c
@@ -1,0 +1,17 @@
+// RUN: %vast-front -o %t %s && %t hello | %file-check %s
+
+#include <stdio.h>
+
+void boo() {
+    printf("boo reached!");
+}
+
+void foo() {
+    return boo();
+}
+
+int main(int argc, char **argv)
+{
+    // CHECK: boo reached!
+    foo();
+}

--- a/test/vast/Conversion/select-a.c
+++ b/test/vast/Conversion/select-a.c
@@ -1,0 +1,31 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -vast-snapshot-at="vast-core-to-llvm;vast-hl-to-lazy-regions" %s
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-hl-to-lazy-regions -check-prefix=LAZY
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-core-to-llvm -check-prefix=LLVM
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char** argv)
+{
+    // LAZY: [[V4:%[0-9]+]] = core.lazy.op {
+    // LAZY:   [[V13:%[0-9]+]] = hl.call @atoi({{.*}}) : (!hl.ptr<si8>) -> si32
+    // LAZY:   hl.value.yield [[V13]] : si32
+    // LAZY: } : si32
+    // LAZY: [[V5:%[0-9]+]] = core.lazy.op {
+    // LAZY:   [[V9:%[0-9]+]] = hl.const #core.integer<769> : si32
+    // LAZY:   hl.value.yield [[V9]] : si32
+    // LAZY: } : si32
+    // LAZY: {{.*}} = core.select {{.*}}, [[V4]], [[V5]] : (si32, si32, si32) -> si32
+
+    // LLVM:    [[V11:%[0-9]+]] = llvm.icmp "ne" {{.*}} : i32
+    // LLVM:    llvm.cond_br [[V11]], ^bb1, ^bb2
+    // LLVM: ^bb1:  // pred: ^bb0
+    // LLVM:    [[V16:%[0-9]+]] = llvm.call @atoi({{.*}}) : (!llvm.ptr) -> i32
+    // LLVM:    llvm.br ^bb3([[V16]] : i32)
+    // LLVM: ^bb2:  // pred: ^bb0
+    // LLVM:    [[V17:%[0-9]+]] = llvm.mlir.constant(769 : i32) : i32
+    // LLVM:    llvm.br ^bb3([[V17]] : i32)
+    // LLVM: ^bb3([[V20:%[0-9]+]]: i32):  // 2 preds: ^bb1, ^bb2
+    // LLVM:    llvm.store [[V20]], {{.*}} : i32, !llvm.ptr
+    int i = (argc >= 3)? atoi(argv[2]) : 769;
+}

--- a/test/vast/Conversion/select-b.c
+++ b/test/vast/Conversion/select-b.c
@@ -1,0 +1,29 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -vast-snapshot-at="vast-core-to-llvm;vast-irs-to-llvm" %s
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-irs-to-llvm -check-prefix=I_LLVM
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-core-to-llvm -check-prefix=C_LLVM
+
+void foo() {}
+
+int main(int argc, char** argv)
+{
+    // I_LLVM: [[V6:%[0-9]+]] = core.lazy.op {
+    // I_LLVM:   llvm.call @foo() : () -> ()
+    // I_LLVM:   {{.*}} = llvm.mlir.zero : !llvm.void
+    // I_LLVM:   [[V11:%[0-9]+]] = llvm.mlir.zero : !llvm.void
+    // I_LLVM:   hl.value.yield [[V11]] : !llvm.void
+    // I_LLVM: } : !llvm.void
+    // I_LLVM: [[V7:%[0-9]+]] = core.lazy.op {
+    // I_LLVM:   [[V12:%[0-9]+]] = llvm.mlir.zero : !llvm.void
+    // I_LLVM:   hl.value.yield [[V12]] : !llvm.void
+    // I_LLVM: } : !llvm.void
+    // I_LLVM: {{.*}} = core.select {{.*}}, [[V6]], [[V7]] : (i32, !llvm.void, !llvm.void) -> !llvm.void
+
+    // C_LLVM:   llvm.cond_br {{.*}}, ^bb1, ^bb2
+    // C_LLVM: ^bb1:  // pred: ^bb0
+    // C_LLVM:   llvm.call @foo() : () -> ()
+    // C_LLVM:   llvm.br ^bb3
+    // C_LLVM: ^bb2:  // pred: ^bb0
+    // C_LLVM:   llvm.br ^bb3
+    // C_LLVM: ^bb3:  // 2 preds: ^bb1, ^bb2
+    (argc >= 3) ? foo() : (void)0;
+}

--- a/test/vast/Conversion/select-c.c
+++ b/test/vast/Conversion/select-c.c
@@ -1,0 +1,47 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -vast-snapshot-at="vast-core-to-llvm;vast-irs-to-llvm" %s
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-irs-to-llvm -check-prefix=I_LLVM
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-core-to-llvm -check-prefix=C_LLVM
+
+int main(int argc, char** argv)
+{
+    // I_LLVM: [[V6:%[0-9]+]] = core.lazy.op {
+    // I_LLVM:   [[V13:%[0-9]+]] = core.lazy.op {
+    // I_LLVM:     [[V16:%[0-9]+]] = llvm.mlir.constant(0 : i32) : i32
+    // I_LLVM:     hl.value.yield [[V16]] : i32
+    // I_LLVM:   } : i32
+    // I_LLVM:   [[V14:%[0-9]+]] = core.lazy.op {
+    // I_LLVM:     [[V26:%[0-9]+]] = llvm.mlir.constant(1 : i32) : i32
+    // I_LLVM:     hl.value.yield [[V26]] : i32
+    // I_LLVM:   } : i32
+    // I_LLVM:   [[V15:%[0-9]+]] = core.select {{.*}}, [[V13]], [[V14]] : (i32, i32, i32) -> i32
+    // I_LLVM:   hl.value.yield [[V15]] : i32
+    // I_LLVM: } : i32
+    // I_LLVM: [[V7:%[0-9]+]] = core.lazy.op {
+    // I_LLVM:   [[V9:%[0-9]+]] = llvm.mlir.constant(2 : i32) : i32
+    // I_LLVM:   hl.value.yield [[V9]] : i32
+    // I_LLVM: } : i32
+    // I_LLVM: [[V8:%[0-9]+]] = core.select {{.*}}, [[V6]], [[V7]] : (i32, i32, i32) -> i32
+    // I_LLVM: llvm.return [[V8]] : i32
+
+    // C_LLVM:  llvm.cond_br {{.*}}, ^bb1, ^bb5
+    // C_LLVM: ^bb1:  // pred: ^bb0
+    // C_LLVM:  {{.*}} = llvm.mlir.constant(3 : i32) : i32
+    // C_LLVM:  llvm.cond_br %13, ^bb2, ^bb3
+    // C_LLVM: ^bb2:  // pred: ^bb1
+    // C_LLVM:  [[V14:%[0-9]+]] = llvm.mlir.constant(0 : i32) : i32
+    // C_LLVM:  llvm.br ^bb4([[V14]] : i32)
+    // C_LLVM: ^bb3:  // pred: ^bb1
+    // C_LLVM:  [[V15:%[0-9]+]] = llvm.mlir.constant(1 : i32) : i32
+    // C_LLVM:  llvm.br ^bb4([[V15]] : i32)
+    // C_LLVM: ^bb4([[V16:%[0-9]+]]: i32):  // 2 preds: ^bb2, ^bb3
+    // C_LLVM:  llvm.br ^bb6([[V16]] : i32)
+    // C_LLVM: ^bb5:  // pred: ^bb0
+    // C_LLVM:  [[V17:%[0-9]+]] = llvm.mlir.constant(2 : i32) : i32
+    // C_LLVM:  llvm.br ^bb6([[V17]] : i32)
+    // C_LLVM: ^bb6([[V18:%[0-9]+]]: i32):  // 2 preds: ^bb4, ^bb5
+    // C_LLVM:  llvm.return [[V18]] : i32
+
+
+    return (argc >= 3) ? ( ( argc == 3) ? 0 : 1 )
+                       : 2;
+}

--- a/test/vast/Conversion/void-return-a.c
+++ b/test/vast/Conversion/void-return-a.c
@@ -1,0 +1,8 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -vast-snapshot-at="vast-irs-to-llvm" %s
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-irs-to-llvm -check-prefix=LLVM
+
+void foo() {
+    // LLVM: llvm.call @foo() : () -> ()
+    // LLVM: llvm.return
+    return foo();
+}

--- a/test/vast/Conversion/void-return-b.c
+++ b/test/vast/Conversion/void-return-b.c
@@ -1,0 +1,8 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -vast-snapshot-at="vast-irs-to-llvm" %s
+// RUN: %file-check %s -input-file=$(basename %s .c).vast-irs-to-llvm -check-prefix=LLVM
+
+// REQUIRES: hl.stmt.expr
+
+void foo() {
+    return ( { foo(); } );
+}


### PR DESCRIPTION
Adds lowering of `core::SelectOp`. Fixes some corner cases related to `void` "values" being returned.