### PR TITLE
Disable unsupported dialect

### DIFF
--- a/include/vast/CodeGen/CodeGenOptions.hpp
+++ b/include/vast/CodeGen/CodeGenOptions.hpp
@@ -18,7 +18,7 @@ namespace vast::cg {
         unsigned int has_strict_return : 1;
 
         // visitor options
-        bool enable_unsupported : 1;
+        bool disable_unsupported : 1;
     };
 
 } // namespace vast::cg

--- a/include/vast/Frontend/Options.hpp
+++ b/include/vast/Frontend/Options.hpp
@@ -92,6 +92,8 @@ namespace vast::cc
         constexpr option_t show_locs = "show-locs";
         constexpr option_t locs_as_meta_ids = "locs-as-meta-ids";
 
+        constexpr option_t disable_unsupported = "disable-unsupported";
+
         constexpr option_t disable_vast_verifier = "disable-vast-verifier";
         constexpr option_t vast_verify_diags = "verify-diags";
         constexpr option_t disable_emit_cxx_default = "disable-emit-cxx-default";

--- a/lib/vast/CodeGen/CodeGenDriver.cpp
+++ b/lib/vast/CodeGen/CodeGenDriver.cpp
@@ -113,9 +113,9 @@ namespace vast::cg {
             .lang = cc::get_source_language(actx.getLangOpts()),
             .optimization_level = opts.codegen.OptimizationLevel,
             // function emition options
-            .has_strict_return = opts.codegen.StrictReturn,
+            .has_strict_return   = opts.codegen.StrictReturn,
             // visitor options
-            .enable_unsupported = true,
+            .disable_unsupported = vargs.has_option(cc::opt::disable_unsupported),
         };
 
         return std::make_unique< driver >(
@@ -137,7 +137,7 @@ namespace vast::cg {
             )
         );
 
-        if (opts.enable_unsupported) {
+        if (!opts.disable_unsupported) {
             top->visitors.push_back(
                 std::make_unique< unsup_visitor >(
                     *mctx, *bld, *mg, *sg, visitor_view(*top)


### PR DESCRIPTION
Adds `-vast-disable-unsupported` option to detect errors more quickly.