### PR TITLE
Fix incorrect assumption about member expr always returning an lvalue.

### DIFF
--- a/include/vast/CodeGen/DefaultStmtVisitor.hpp
+++ b/include/vast/CodeGen/DefaultStmtVisitor.hpp
@@ -252,11 +252,11 @@ namespace vast::cg {
         // Literals
         //
 
-        // Helper for use with literal expressions that might return lvalue.
-        // It takes an expression, checks if it's lvalue expression
+        // Helper for use with expressions that might return lvalue.
+        // It takes an expression, checks if it's an lvalue expression
         // and depending on the result calls either the lvalue type visitor or
         // the standard type visitor.
-        mlir_type visit_maybe_lvalue_literal_type (const clang::Expr *expr);
+        mlir_type visit_maybe_lvalue_result_type(const clang::Expr *expr);
 
         operation VisitCharacterLiteral(const clang::CharacterLiteral *lit);
         operation VisitIntegerLiteral(const clang::IntegerLiteral *lit);

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -289,7 +289,7 @@ def RecordMemberOp
   : HighLevel_Op< "member" >
   // TODO(Heno): add type constraints
   , Arguments<(ins AnyType:$record, StrAttr:$name)>
-  , Results<(outs LValueOf<AnyType>:$element)>
+  , Results<(outs AnyType:$element)>
 {
   let summary = "VAST record element access operation";
   let description = [{ VAST record element access operation }];

--- a/lib/vast/CodeGen/DefaultStmtVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultStmtVisitor.cpp
@@ -562,7 +562,7 @@ namespace vast::cg
     //
     // Literals
     //
-    mlir_type default_stmt_visitor::visit_maybe_lvalue_literal_type (const clang::Expr *lit){
+    mlir_type default_stmt_visitor::visit_maybe_lvalue_result_type(const clang::Expr *lit){
         if (lit->isLValue())
             return self.visit_as_lvalue_type(lit->getType());
         return self.visit(lit->getType());
@@ -582,7 +582,7 @@ namespace vast::cg
 
     operation default_stmt_visitor::VisitStringLiteral(const clang::StringLiteral *lit) {
         return bld.constant(self.location(lit),
-                            visit_maybe_lvalue_literal_type(lit),
+                            visit_maybe_lvalue_result_type(lit),
                             lit->getString()).getDefiningOp();
     }
 
@@ -593,7 +593,7 @@ namespace vast::cg
     operation default_stmt_visitor::VisitCompoundLiteralExpr(const clang::CompoundLiteralExpr *lit) {
         return bld.compose< hl::CompoundLiteralOp >()
             .bind(self.location(lit))
-            .bind(visit_maybe_lvalue_literal_type(lit))
+            .bind(visit_maybe_lvalue_result_type(lit))
             .bind(mk_value_builder(lit->getInitializer()))
             .freeze();
     }

--- a/lib/vast/CodeGen/DefaultStmtVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultStmtVisitor.cpp
@@ -816,7 +816,7 @@ namespace vast::cg
     operation default_stmt_visitor::VisitMemberExpr(const clang::MemberExpr *expr) {
         return bld.compose< hl::RecordMemberOp >()
             .bind(self.location(expr))
-            .bind(self.visit_as_lvalue_type(expr->getType()))
+            .bind(visit_maybe_lvalue_result_type(expr))
             .bind_transform(self.visit(expr->getBase()), first_result)
             .bind(self.symbol(expr->getMemberDecl()))
             .freeze();

--- a/test/vast/Dialect/HighLevel/stmt-expr-d.c
+++ b/test/vast/Dialect/HighLevel/stmt-expr-d.c
@@ -1,0 +1,10 @@
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
+
+struct large { int x, y[9]; };
+
+int main() {
+    // CHECK: hl.member {{.*}} at "x" : !hl.elaborated<!hl.record<"large">> -> !hl.int
+    int fixed = ({ struct large temp3; temp3.x = 2; temp3; }).x
+	  - ({ struct large temp4; temp4.x = 1; temp4; }).x;
+}


### PR DESCRIPTION
Fix #564 