### PR TITLE
No longer lower `hl.array` into `memref`.

### DIFF
--- a/include/vast/Conversion/TypeConverters/HLToStd.hpp
+++ b/include/vast/Conversion/TypeConverters/HLToStd.hpp
@@ -214,18 +214,14 @@ namespace vast::conv::tc {
         }
 
         maybe_type_t convert_arr_type(hl::ArrayType arr) {
-            auto [dims, nested_ty] = arr.dim_and_type();
-            std::vector< int64_t > coerced_dim;
-            for (auto dim : dims) {
-                if (dim.has_value()) {
-                    coerced_dim.push_back(dim.value());
-                } else {
-                    coerced_dim.push_back(mlir::ShapedType::kDynamic);
-                }
-            }
+            auto make_array = [&](mlir_type element_type) {
+                return hl::ArrayType::get(arr.getContext(), arr.getSize(), element_type);
+            };
 
-            return Maybe(convert_type_to_type(nested_ty))
-                .and_then([&](auto t) { return mlir::MemRefType::get({ coerced_dim }, *t); })
+            return Maybe(arr.getElementType())
+                .and_then(convert_type_to_type())
+                .unwrap()
+                .and_then(make_array)
                 .take_wrapped< maybe_type_t >();
         }
     };

--- a/include/vast/Conversion/TypeConverters/LLVMTypeConverter.hpp
+++ b/include/vast/Conversion/TypeConverters/LLVMTypeConverter.hpp
@@ -51,6 +51,7 @@ namespace vast::conv::tc {
             addConversion([&](hl::LabelType t) { return t; });
             addConversion([&](hl::LValueType t) { return this->convert_lvalue_type(t); });
             addConversion([&](hl::PointerType t) { return this->convert_pointer_type(t); });
+            addConversion([&](hl::ArrayType t) { return this->convert_array_type(t); });
             addConversion([&](mlir::MemRefType t) { return this->convert_memref_type(t); });
             addConversion([&](mlir::UnrankedMemRefType t) {
                 return this->convert_memref_type(t);

--- a/test/vast/Compile/ObjectFiles/call-array-a.c
+++ b/test/vast/Compile/ObjectFiles/call-array-a.c
@@ -1,0 +1,6 @@
+// RUN: %vast-front -c -vast-pipeline=with-abi -o %t.vast.o %s && %cc -c -xc %s.driver -o %t.clang.o  && %cc %t.vast.o %t.clang.o -o %t && (%t; test $? -eq 0)
+
+int sum(int array[2])
+{
+    return array[0] + array[1];
+}

--- a/test/vast/Compile/ObjectFiles/call-array-a.c.driver
+++ b/test/vast/Compile/ObjectFiles/call-array-a.c.driver
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int sum(int array[2]);
+
+int main()
+{
+    int a[2] = { 0, 0 };
+    assert(sum(a) == 0);
+    a[1] = 5;
+    assert(sum(a) == 5);
+    a[0] = 10;
+    assert(sum(a) == 15);
+    a[1] = -10;
+    assert(sum(a) == 0);
+}

--- a/test/vast/Compile/SingleSource/union-e.c
+++ b/test/vast/Compile/SingleSource/union-e.c
@@ -1,0 +1,38 @@
+// RUN: %vast-front -o %t %s && %t | %file-check %s
+
+#include <stdio.h>
+
+union U
+{
+    int arr[2];
+};
+
+int main(int argc, char **argv)
+{
+    union U u;
+    u.arr[0] = 0;
+    u.arr[1] = 0;
+
+    // CHECK: 0 0
+    printf("%i %i\n", u.arr[0], u.arr[1]);
+
+    u.arr[0] = 10;
+    u.arr[1] = 100;
+
+    // CHECK: 10 100
+    printf("%i %i\n", u.arr[0], u.arr[1]);
+
+    u.arr[1] = -100;
+
+    // CHECK: 10 -100
+    printf("%i %i\n", u.arr[0], u.arr[1]);
+
+    union U u1;
+    u1.arr[0] = 42;
+    u1.arr[1] = 43;
+
+    u = u1;
+
+    // CHECK: 42 43
+    printf("%i %i\n", u.arr[0], u.arr[1]);
+}

--- a/test/vast/Conversion/subscript-a.c
+++ b/test/vast/Conversion/subscript-a.c
@@ -1,16 +1,32 @@
-// RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %vast-opt-lower-value-categories | %file-check %s
+// RUN: %check-hl-lower-types %s | %file-check %s -check-prefix=STD_TYPES
+// RUN: %check-lower-value-categories %s | %file-check %s -check-prefix=VAL_CAT
+// RUN: %check-core-to-llvm %s | %file-check %s -check-prefix=C_LLVM
+
+// STD_TYPES:  [[V2:%[0-9]+]] = hl.ref {{.*}} : (!hl.lvalue<!hl.array<3, si32>>) -> !hl.lvalue<!hl.array<3, si32>>
+// STD_TYPES:  [[V3:%[0-9]+]] = hl.implicit_cast [[V2]] ArrayToPointerDecay : !hl.lvalue<!hl.array<3, si32>> -> !hl.ptr<si32>
+// STD_TYPES:  [[V4:%[0-9]+]] = hl.const #core.integer<0> : si32
+// STD_TYPES:  [[V5:%[0-9]+]] = hl.subscript [[V3]] at [[[V4]] : si32] : !hl.ptr<si32> -> !hl.lvalue<si3
+
+// VAL_CAT: [[V0:%[0-9]+]] = ll.alloca : !hl.ptr<!hl.array<3, si32>>
+// VAL_CAT: [[V4:%[0-9]+]] = hl.initlist {{.*}} : (si32, si32, si32) -> !hl.array<3, si32>
+// VAL_CAT: ll.store [[V0]], [[V4]] : !hl.ptr<!hl.array<3, si32>>, !hl.array<3, si32>
+
+// VAL_CAT: [[V5:%[0-9]+]] = hl.implicit_cast [[V0]] ArrayToPointerDecay : !hl.ptr<!hl.array<3, si32>> -> !hl.ptr<si32>
+// VAL_CAT: [[V6:%[0-9]+]] = hl.const #core.integer<0> : si32
+// VAL_CAT: [[V7:%[0-9]+]] = ll.subscript [[V5]] at [[[V6]] : si32] : !hl.ptr<si32> -> !hl.ptr<si32>
+// VAL_CAT: [[V8:%[0-9]+]] = ll.load [[V7]] : (!hl.ptr<si32>) -> si32
+
+// C_LLVM: [[V1:%[0-9]+]] = llvm.alloca {{.*}} x !llvm.array<3 x i32> : (i64) -> !llvm.ptr
+
+// C_LLVM: [[V9:%[0-9]+]] = llvm.getelementptr [[V1]][0] : (!llvm.ptr) -> !llvm.ptr, i32
+// C_LLVM: [[V10:%[0-9]+]] = llvm.mlir.constant(0 : i32) : i32
+// C_LLVM: [[V11:%[0-9]+]] = llvm.getelementptr [[V9]][[[V10]]] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+// C_LLVM: [[V12:%[0-9]+]] = llvm.load [[V11]] : !llvm.ptr -> i32
+
 
 void fn()
 {
-    // CHECK: [[V0:%[0-9]+]] = ll.alloca : !hl.ptr<memref<3xsi32>>
-    // CHECK: [[V4:%[0-9]+]] = hl.initlist {{.*}} : (si32, si32, si32) -> memref<3xsi32>
-    // CHECK: ll.store [[V0]], [[V4]] : !hl.ptr<memref<3xsi32>>, memref<3xsi32>
     int arr1[] = { 0, 2, 4 };
 
-
-    // CHECK: [[V5:%[0-9]+]] = hl.implicit_cast [[V0]] ArrayToPointerDecay : !hl.ptr<memref<3xsi32>> -> !hl.ptr<si32>
-    // CHECK: [[V6:%[0-9]+]] = hl.const #core.integer<0> : si32
-    // CHECK: [[V7:%[0-9]+]] = ll.subscript [[V5]] at [[[V6]] : si32] : !hl.ptr<si32> -> !hl.ptr<si32>
-    // CHECK: [[V8:%[0-9]+]] = ll.load [[V7]] : (!hl.ptr<si32>) -> si32
     (void)arr1[0];
 }

--- a/test/vast/Conversion/subscript-b.c
+++ b/test/vast/Conversion/subscript-b.c
@@ -1,16 +1,39 @@
-// RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %vast-opt-lower-value-categories | %file-check %s
+// RUN: %check-hl-lower-types %s | %file-check %s -check-prefix=STD_TYPES
+// RUN: %check-lower-value-categories %s | %file-check %s -check-prefix=VAL_CAT
+// RUN: %check-core-to-llvm %s | %file-check %s -check-prefix=C_LLVM
 
-// CHECK:  [[G:%[0-9]+]] = hl.var "arr1" : !hl.ptr<memref<3xsi32>> = {
-// CHECK:    [[GV4:%[0-9]+]] = hl.initlist {{.*}} : (si32, si32, si32) -> memref<3xsi32>
-// CHECK:    hl.value.yield [[GV4]] : memref<3xsi32>
+// STD_TYPES: {{.*}} = hl.var "arr1" : !hl.lvalue<!hl.array<3, si32>> = {
+
+
+// VAL_CAT: {{.*}} = hl.var "arr1" : !hl.ptr<!hl.array<3, si32>> = {
+// VAL_CAT:    hl.value.yield {{.*}} : !hl.array<3, si32>
+
+
+// C_LLVM:  llvm.mlir.global internal constant @arr1() {addr_space = 0 : i32} : !llvm.array<3 x i32> {
+
 int arr1[] = { 0, 2, 4 };
+
+// STD_TYPES:  [[V2:%[0-9]+]] = hl.globref "arr1" : !hl.lvalue<!hl.array<3, si32>>
+// STD_TYPES:  [[V3:%[0-9]+]] = hl.implicit_cast [[V2]] ArrayToPointerDecay : !hl.lvalue<!hl.array<3, si32>> -> !hl.ptr<si32>
+// STD_TYPES:  [[V4:%[0-9]+]] = hl.const #core.integer<0> : si32
+// STD_TYPES:  [[V5:%[0-9]+]] = hl.subscript [[V3]] at [[[V4]] : si32] : !hl.ptr<si32> -> !hl.lvalue<si32>
+// STD_TYPES:  [[V6:%[0-9]+]] = hl.implicit_cast [[V5]] LValueToRValue : !hl.lvalue<si32> -> si32
+
+
+// VAL_CAT: [[V1:%[0-9]+]] = hl.globref "arr1" : !hl.ptr<!hl.array<3, si32>>
+// VAL_CAT: [[V2:%[0-9]+]] = hl.implicit_cast [[V1]] ArrayToPointerDecay : !hl.ptr<!hl.array<3, si32>> -> !hl.ptr<si32>
+// VAL_CAT: [[V3:%[0-9]+]] = hl.const #core.integer<0> : si32
+// VAL_CAT: [[V4:%[0-9]+]] = ll.subscript [[V2]] at [[[V3]] : si32] : !hl.ptr<si32> -> !hl.ptr<si32>
+// VAL_CAT: [[V5:%[0-9]+]] = ll.load [[V4]] : (!hl.ptr<si32>) -> si32
+
+
+// C_LLVM: [[V0:%[0-9]+]] = llvm.mlir.addressof @arr1 : !llvm.ptr
+// C_LLVM: [[V1:%[0-9]+]] = llvm.getelementptr [[V0]][0] : (!llvm.ptr) -> !llvm.ptr, i32
+// C_LLVM: [[V2:%[0-9]+]] = llvm.mlir.constant(0 : i32) : i32
+// C_LLVM: [[V3:%[0-9]+]] = llvm.getelementptr [[V1]][[[V2]]] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+// C_LLVM: [[V4:%[0-9]+]] = llvm.load [[V3]] : !llvm.ptr -> i32
 
 void fn()
 {
-    // CHECK: [[V1:%[0-9]+]] = hl.globref "arr1" : !hl.ptr<memref<3xsi32>>
-    // CHECK: [[V2:%[0-9]+]] = hl.implicit_cast [[V1]] ArrayToPointerDecay : !hl.ptr<memref<3xsi32>> -> !hl.ptr<si32>
-    // CHECK: [[V3:%[0-9]+]] = hl.const #core.integer<0> : si32
-    // CHECK: [[V4:%[0-9]+]] = ll.subscript [[V2]] at [[[V3]] : si32] : !hl.ptr<si32> -> !hl.ptr<si32>
-    // CHECK: [[V5:%[0-9]+]] = ll.load [[V4]] : (!hl.ptr<si32>) -> si32
-    (void)arr1[0];
+      (void)arr1[0];
 }

--- a/test/vast/Transform/HL/LowerTypes/array-a.c
+++ b/test/vast/Transform/HL/LowerTypes/array-a.c
@@ -1,22 +1,22 @@
 // RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %vast-opt --vast-hl-lower-types | %file-check %s
 
-// CHECK: hl.var "ai" : !hl.lvalue<memref<10xsi32>>
+// CHECK: hl.var "ai" : !hl.lvalue<!hl.array<10, si32>>
 int ai[10];
 
-// CHECK: hl.var "aci" : !hl.lvalue<memref<5xsi32>>
+// CHECK: hl.var "aci" : !hl.lvalue<!hl.array<5, si32>>
 const int aci[5];
 
-// CHECK: hl.var "avi" : !hl.lvalue<memref<5xsi32>>
+// CHECK: hl.var "avi" : !hl.lvalue<!hl.array<5, si32>>
 volatile int avi[5];
 
-// CHECK: hl.var "acvi" : !hl.lvalue<memref<5xsi32>>
+// CHECK: hl.var "acvi" : !hl.lvalue<!hl.array<5, si32>>
 const volatile int acvi[5];
 
-// CHECK: hl.var "acvui" : !hl.lvalue<memref<5xui32>>
+// CHECK: hl.var "acvui" : !hl.lvalue<!hl.array<5, ui32>>
 const volatile unsigned int acvui[5];
 
-// CHECK: hl.var "af" : !hl.lvalue<memref<10xf32>>
+// CHECK: hl.var "af" : !hl.lvalue<!hl.array<10, f32>>
 float af[10];
 
-// CHECK: hl.var "a3d" : !hl.lvalue<memref<2x4x3xf32>>
+// CHECK: hl.var "a3d" : !hl.lvalue<!hl.array<2, !hl.array<4, !hl.array<3, f32>>>>
 float a3d[2][4][3];

--- a/test/vast/Transform/HL/LowerTypes/array-b.c
+++ b/test/vast/Transform/HL/LowerTypes/array-b.c
@@ -1,4 +1,4 @@
 // RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %vast-opt --vast-hl-lower-types | %file-check %s
 
-// CHECK: hl.var "a" sc_extern : !hl.lvalue<memref<?xsi32>>
+// CHECK: hl.var "a" sc_extern : !hl.lvalue<!hl.array<?, si32>>
 extern int a[];

--- a/test/vast/Transform/HL/LowerTypes/strlit-a.c
+++ b/test/vast/Transform/HL/LowerTypes/strlit-a.c
@@ -2,6 +2,6 @@
 
 int main()
 {
-    // CHECK: [[V2:%[0-9]+]] = hl.const "hello" : !hl.lvalue<memref<6xsi8>>
+    // CHECK: [[V2:%[0-9]+]] = hl.const "hello" : !hl.lvalue<!hl.array<6, si8>>
     const char *hello = "hello";
 }

--- a/test/vast/Transform/HL/LowerTypes/vars-b.cpp
+++ b/test/vast/Transform/HL/LowerTypes/vars-b.cpp
@@ -16,12 +16,12 @@ int main()
     char y = 'H';
 
 
-    // CHECK: hl.var "ia" : !hl.lvalue<memref<3xsi32>> =  {
+    // CHECK: hl.var "ia" : !hl.lvalue<!hl.array<3, si32>> =  {
     // CHECK:   [[V3:%[0-9]+]] = hl.const #core.integer<0> : si32
     // CHECK:   [[V4:%[0-9]+]] = hl.const #core.integer<1> : si32
     // CHECK:   [[V5:%[0-9]+]] = hl.const #core.integer<2> : si32
-    // CHECK:   [[V6:%[0-9]+]] = hl.initlist [[V3]], [[V4]], [[V5]] : (si32, si32, si32) -> memref<3xsi32>
-    // CHECK:   hl.value.yield [[V6]] : memref<3xsi32>
+    // CHECK:   [[V6:%[0-9]+]] = hl.initlist [[V3]], [[V4]], [[V5]] : (si32, si32, si32) -> !hl.array<3, si32>
+    // CHECK:   hl.value.yield [[V6]] : !hl.array<3, si32>
     // CHECK: }
     int ia[3] = { 0, 1, 2 };
 
@@ -40,15 +40,15 @@ int main()
     // CHECK: }
     long double ld = 91.02;
 
-    // CHECK: hl.var "fa" : !hl.lvalue<memref<3xf32>> =  {
+    // CHECK: hl.var "fa" : !hl.lvalue<!hl.array<3, f32>> =  {
     // CHECK:   [[V11:%[0-9]+]] = hl.const #core.float<0.000000e+00> : f64
     // CHECK:   [[V12:%[0-9]+]] = hl.implicit_cast [[V11]] FloatingCast : f64 -> f32
     // CHECK:   [[V13:%[0-9]+]] = hl.const #core.float<5.000000e-01> : f64
     // CHECK:   [[V14:%[0-9]+]] = hl.implicit_cast [[V13]] FloatingCast : f64 -> f32
     // CHECK:   [[V15:%[0-9]+]] = hl.const #core.float<1.000000e+00> : f64
     // CHECK:   [[V16:%[0-9]+]] = hl.implicit_cast [[V15]] FloatingCast : f64 -> f32
-    // CHECK:   [[V17:%[0-9]+]] = hl.initlist [[V12]], [[V14]], [[V16]] : (f32, f32, f32) -> memref<3xf32>
-    // CHECK:   hl.value.yield [[V17]] : memref<3xf32>
+    // CHECK:   [[V17:%[0-9]+]] = hl.initlist [[V12]], [[V14]], [[V16]] : (f32, f32, f32) -> !hl.array<3, f32>
+    // CHECK:   hl.value.yield [[V17]] : !hl.array<3, f32>
     // CHECK: }
     float fa[3] = { 0.0, 0.5, 1.0 };
 }


### PR DESCRIPTION
There is a bunch of problems with `memref` in the pipeline - most notably it not being easily added to data layout. Apart from that, it is also kind of weird that `struct/pointer` survive all the way down to final `ll`, whereas `array` did not - with this change it is more uniform.