### PR TITLE
Allow visitors specify attribute names

### DIFF
--- a/include/vast/CodeGen/CodeGenVisitorBase.hpp
+++ b/include/vast/CodeGen/CodeGenVisitorBase.hpp
@@ -17,7 +17,7 @@ namespace vast::cg {
         operation visit(const clang_stmt *stmt, scope_context &scope);
         mlir_type visit(const clang_type *type, scope_context &scope);
         mlir_type visit(clang_qual_type ty, scope_context &scope);
-        mlir_attr visit(const clang_attr *attr, scope_context &scope);
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope);
 
         operation visit_prototype(const clang_function *decl, scope_context &scope);
 
@@ -46,7 +46,7 @@ namespace vast::cg {
         operation visit(const clang_stmt *stmt);
         mlir_type visit(const clang_type *type);
         mlir_type visit(clang_qual_type ty);
-        mlir_attr visit(const clang_attr *attr);
+        std::optional< named_attr > visit(const clang_attr *attr);
 
         operation visit_prototype(const clang_function *decl);
 
@@ -64,7 +64,7 @@ namespace vast::cg {
         virtual operation visit(const clang_stmt *, scope_context &scope) = 0;
         virtual mlir_type visit(const clang_type *, scope_context &scope) = 0;
         virtual mlir_type visit(clang_qual_type, scope_context &scope)    = 0;
-        virtual mlir_attr visit(const clang_attr *, scope_context &scope) = 0;
+        virtual std::optional< named_attr > visit(const clang_attr *, scope_context &scope) = 0;
 
         virtual operation visit_prototype(const clang_function *decl, scope_context &scope) = 0;
 

--- a/include/vast/CodeGen/CodeGenVisitorList.hpp
+++ b/include/vast/CodeGen/CodeGenVisitorList.hpp
@@ -29,7 +29,10 @@ namespace vast::cg {
         operation visit(const clang_stmt *stmt, scope_context &scope) override { return visitor::visit(stmt, scope); }
         mlir_type visit(const clang_type *type, scope_context &scope) override { return visitor::visit(type, scope); }
         mlir_type visit(clang_qual_type type, scope_context &scope)   override { return visitor::visit(type, scope); }
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) override { return visitor::visit(attr, scope); }
+
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override {
+            return visitor::visit(attr, scope);
+        }
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override {
             return visitor::visit_prototype(decl, scope);
@@ -99,7 +102,10 @@ namespace vast::cg {
         operation visit(const clang_stmt *stmt, scope_context &scope) override { return head->visit(stmt, scope); }
         mlir_type visit(const clang_type *type, scope_context &scope) override { return head->visit(type, scope); }
         mlir_type visit(clang_qual_type type, scope_context &scope)   override { return head->visit(type, scope); }
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) override { return head->visit(attr, scope); }
+
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override {
+            return head->visit(attr, scope);
+        }
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override {
             return head->visit_prototype(decl, scope);
@@ -118,7 +124,10 @@ namespace vast::cg {
         operation visit(const clang_stmt *stmt, scope_context &scope) override { return next->visit(stmt, scope); }
         mlir_type visit(const clang_type *type, scope_context &scope) override { return next->visit(type, scope); }
         mlir_type visit(clang_qual_type type, scope_context &scope)   override { return next->visit(type, scope); }
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) override { return next->visit(attr, scope); }
+
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override {
+            return next->visit(attr, scope);
+        }
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override {
             return next->visit_prototype(decl, scope);
@@ -157,7 +166,10 @@ namespace vast::cg {
         operation visit(const clang_stmt *stmt, scope_context &scope) override { return try_visit_or_pass(stmt, scope); }
         mlir_type visit(const clang_type *type, scope_context &scope) override { return try_visit_or_pass(type, scope); }
         mlir_type visit(clang_qual_type type, scope_context &scope)   override { return try_visit_or_pass(type, scope); }
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) override { return try_visit_or_pass(attr, scope); }
+
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override {
+            return try_visit_or_pass(attr, scope);
+        }
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override {
             if (auto result = base_visitor::visit_prototype(decl, scope)) {

--- a/include/vast/CodeGen/DefaultVisitor.hpp
+++ b/include/vast/CodeGen/DefaultVisitor.hpp
@@ -37,7 +37,8 @@ namespace vast::cg
         operation visit(const clang_stmt *stmt, scope_context &scope) override;
         mlir_type visit(const clang_type *type, scope_context &scope) override;
         mlir_type visit(clang_qual_type type, scope_context &scope) override;
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) override;
+
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override;
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override;
 

--- a/include/vast/CodeGen/UnreachableVisitor.hpp
+++ b/include/vast/CodeGen/UnreachableVisitor.hpp
@@ -31,7 +31,7 @@ namespace vast::cg
             VAST_FATAL("unsupported type: {0}", type.getAsString());
         }
 
-        mlir_attr visit(const clang_attr *attr, scope_context &) override {
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &) override {
             VAST_FATAL("unsupported attr: {0}", attr->getSpelling());
         }
 

--- a/include/vast/CodeGen/UnsupportedVisitor.hpp
+++ b/include/vast/CodeGen/UnsupportedVisitor.hpp
@@ -88,9 +88,12 @@ namespace vast::cg
     {
         using util::crtp< derived, unsup_attr_visitor >::underlying;
 
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) {
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) {
             std::string spelling(attr->getSpelling());
-            return unsup::UnsupportedAttr::get(&underlying().mcontext(), spelling);
+            auto mctx = &underlying().mcontext();
+            return std::make_optional< named_attr >(
+                mlir::StringAttr::get(mctx, spelling), unsup::UnsupportedAttr::get(mctx, spelling)
+            );
         }
     };
 
@@ -124,7 +127,7 @@ namespace vast::cg
             return unsup_type_visitor::visit(type, scope);
         }
 
-        mlir_attr visit(const clang_attr *attr, scope_context &scope) override {
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override {
             return unsup_attr_visitor::visit(attr, scope);
         }
 

--- a/include/vast/Util/Common.hpp
+++ b/include/vast/Util/Common.hpp
@@ -64,6 +64,7 @@ namespace vast {
 
     using mlir_attr    = mlir::Attribute;
     using maybe_attr_t = std::optional< mlir_attr >;
+    using named_attr   = mlir::NamedAttribute;
 
     using integer_attr_t = mlir::IntegerAttr;
 

--- a/lib/vast/CodeGen/AttrVisitorProxy.cpp
+++ b/lib/vast/CodeGen/AttrVisitorProxy.cpp
@@ -23,6 +23,13 @@ namespace vast::cg
 
         for (auto attr : filtered_attrs) {
             if (auto visited = head.visit(attr, scope)) {
+                // Using `attrs.set` instead of `push_back` to ensure that if the
+                // attribute already exists, it is updated with the new value. This
+                // is crucial for handling cases of redeclaration with a different
+                // attribute value.
+                //
+                // FIXME: This is a temporary solution. We need to handle union
+                // of values for the same attribute.
                 attrs.set(visited->getName(), visited->getValue());
             }
         }

--- a/lib/vast/CodeGen/AttrVisitorProxy.cpp
+++ b/lib/vast/CodeGen/AttrVisitorProxy.cpp
@@ -22,11 +22,9 @@ namespace vast::cg
         });
 
         for (auto attr : filtered_attrs) {
-            auto visited = head.visit(attr, scope);
-            auto is_unsup = mlir::isa< unsup::UnsupportedDialect >(visited.getDialect());
-            auto key = is_unsup ? attr->getSpelling() : visited.getAbstractAttribute().getName();
-
-            attrs.set(key, visited);
+            if (auto visited = head.visit(attr, scope)) {
+                attrs.set(visited->getName(), visited->getValue());
+            }
         }
 
         op->setAttrs(attrs);

--- a/lib/vast/CodeGen/CodeGenVisitorBase.cpp
+++ b/lib/vast/CodeGen/CodeGenVisitorBase.cpp
@@ -23,7 +23,7 @@ namespace vast::cg
         return visitor.visit(ty, scope);
     }
 
-    mlir_attr visitor_view::visit(const clang_attr *attr, scope_context &scope) {
+    std::optional< named_attr > visitor_view::visit(const clang_attr *attr, scope_context &scope) {
         return visitor.visit(attr, scope);
     }
 
@@ -47,7 +47,7 @@ namespace vast::cg
         return visitor_view::visit(ty, scope);
     }
 
-    mlir_attr scoped_visitor_view::visit(const clang_attr *attr) {
+    std::optional< named_attr > scoped_visitor_view::visit(const clang_attr *attr) {
         return visitor_view::visit(attr, scope);
     }
 

--- a/lib/vast/CodeGen/DefaultVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultVisitor.cpp
@@ -30,9 +30,16 @@ namespace vast::cg
         return visitor.visit(type);
     }
 
-    mlir_attr default_visitor::visit(const clang_attr *attr, scope_context &scope) {
+    std::optional< named_attr > default_visitor::visit(const clang_attr *attr, scope_context &scope) {
         default_attr_visitor visitor(mctx, bld, self, scope);
-        return visitor.visit(attr);
+        if (auto visited = visitor.visit(attr)) {
+            auto name = visited.getAbstractAttribute().getName();
+            return std::make_optional< named_attr >(
+                mlir::StringAttr::get(&mctx, name), visited
+            );
+        }
+
+        return std::nullopt;
     }
 
     operation default_visitor::visit_prototype(const clang_function *decl, scope_context &scope) {


### PR DESCRIPTION
Changes visitor API to provide:

```
       std::optional< named_attr > visit(const clang_attr *, scope_context &scope);
```

instead of

```
        mlir_attr visit(const clang_attr *, scope_context &scope);
```

This allows visitors to take care of responsibility for attribute naming, and does not leak this abstraction to top-level visitors.