### PR TITLE
Bring `vast-repl` up to date.

### DIFF
--- a/include/vast/Frontend/Action.hpp
+++ b/include/vast/Frontend/Action.hpp
@@ -86,6 +86,10 @@ namespace vast::cc {
 
         const vast_args &vargs;
         mcontext_t &mctx;
+
+        // Once we are done result is stored here. We cannot pull it from the internals,
+        // because by that point they may be dead (and this is outside our control).
+        owning_module_ref _mod;
     };
 
     //

--- a/include/vast/repl/cli.hpp
+++ b/include/vast/repl/cli.hpp
@@ -27,8 +27,15 @@ namespace vast::repl
 
         void exec(command_ptr cmd) try {
             cmd->run(state);
+            exec_sticked();
         } catch (std::exception &e) {
             llvm::errs() << "error: " << e.what() << '\n';
+        }
+
+        void exec_sticked() {
+            for (auto &cmd : state.sticked) {
+                cmd->run(state);
+            }
         }
 
       private:

--- a/include/vast/repl/cli.hpp
+++ b/include/vast/repl/cli.hpp
@@ -12,7 +12,11 @@
 namespace vast::repl
 {
     struct cli_t {
-        explicit cli_t(mcontext_t &ctx) : state(ctx) {}
+        explicit cli_t(mcontext_t &ctx)
+            : state(ctx)
+        {
+            initialize();
+        }
 
         std::string_view help() { return "cli help"; }
 
@@ -31,6 +35,8 @@ namespace vast::repl
         } catch (std::exception &e) {
             llvm::errs() << "error: " << e.what() << '\n';
         }
+
+        void initialize(std::filesystem::path config_path = "vast.ini");
 
         void exec_sticked() {
             for (auto &cmd : state.sticked) {

--- a/include/vast/repl/codegen.hpp
+++ b/include/vast/repl/codegen.hpp
@@ -19,6 +19,6 @@ namespace vast::repl::codegen {
 
     std::unique_ptr< clang::ASTUnit > ast_from_source(string_ref source);
 
-    owning_module_ref emit_module(const std::filesystem::path &source, mcontext_t *ctx);
+    owning_module_ref emit_module(const std::filesystem::path &source, mcontext_t &ctx);
 
 } // namespace vast::repl::codegen

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -46,7 +46,7 @@ namespace vast::repl
         struct string_param  { std::string value; };
         struct integer_param { std::uint64_t value; };
 
-        enum class show_kind { source, ast, module, symbols };
+        enum class show_kind { source, ast, module, symbols, pipelines };
 
         template< typename enum_type >
         enum_type from_string(string_ref token) requires(std::is_same_v< enum_type, show_kind >) {
@@ -54,6 +54,7 @@ namespace vast::repl
             if (token == "ast")     return enum_type::ast;
             if (token == "module")  return enum_type::module;
             if (token == "symbols") return enum_type::symbols;
+            if (token == "pipelines")   return enum_type::pipelines;
             throw_error("uknnown show kind: {0}", token.str());
         }
 
@@ -251,6 +252,8 @@ namespace vast::repl
 
             params_storage params;
         };
+
+        void add_sticky_command(string_ref cmd, state_t &state);
 
         using command_list = util::type_list< exit, help, load, show, meta, raise, sticky >;
 

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -60,7 +60,7 @@ namespace vast::repl
             if (token == "ast")     return enum_type::ast;
             if (token == "module")  return enum_type::module;
             if (token == "symbols") return enum_type::symbols;
-            VAST_FATAL("uknnown show kind: {0}", token.str());
+            throw_error("uknnown show kind: {0}", token.str());
         }
 
         enum class meta_action { add, get };
@@ -69,7 +69,7 @@ namespace vast::repl
         enum_type from_string(string_ref token) requires(std::is_same_v< enum_type, meta_action >) {
             if (token == "add") return enum_type::add;
             if (token == "get") return enum_type::get;
-            VAST_FATAL("uknnown action kind: {0}", token.str());
+            throw_error("uknnown action kind: {0}", token.str());
         }
 
         //
@@ -112,7 +112,7 @@ namespace vast::repl
         template< const char *name, typename params_storage >
         auto get_param(const params_storage &params) {
             if constexpr (std::tuple_size_v< params_storage > == 0) {
-                VAST_FATAL(("unknown param name " + std::string(name)).c_str());
+                throw_error(("unknown param name " + std::string(name)).c_str());
             } else {
                 using current = typename std::tuple_element< 0, params_storage >::type;
 
@@ -267,7 +267,7 @@ namespace vast::repl
         }
 
         if constexpr (params_list::empty) {
-            VAST_FATAL(("no match for param: " + tokens.front()).str().c_str());
+            throw_error(("no match for param: " + tokens.front()).str().c_str());
         } else {
             using current_param = typename params_list::head;
             using rest          = typename params_list::tail;
@@ -296,7 +296,7 @@ namespace vast::repl
 
         if constexpr (commands::empty) {
             // we did not recursivelly match any of known commands
-            VAST_FATAL(("no match for command: " + tokens.front()).str().c_str());
+            throw_error(("no match for command: " + tokens.front()).str().c_str());
         } else {
             using current_command = typename commands::head;
             using rest            = typename commands::tail;

--- a/include/vast/repl/command_base.hpp
+++ b/include/vast/repl/command_base.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Util/TypeList.hpp"
+
+
+namespace vast::repl
+{
+    struct state_t;
+
+    namespace cmd
+    {
+        struct base {
+            using command_params = util::type_list<>;
+
+            virtual void run(state_t &) const = 0;
+            virtual ~base() = default;
+        };
+    } // namespace cmd
+
+    using command_ptr = std::unique_ptr< cmd::base >;
+} // namespace vast::repl

--- a/include/vast/repl/common.hpp
+++ b/include/vast/repl/common.hpp
@@ -4,7 +4,13 @@
 
 #include "vast/Util/Common.hpp"
 
+#include <exception>
+
 namespace vast::repl {
 
+    template< typename ... Args >
+    [[noreturn]] void throw_error(Args && ... args) {
+        throw std::runtime_error(llvm::formatv(std::forward< Args >(args) ...).str());
+    }
 
 } // namespace vast::repl

--- a/include/vast/repl/config.hpp
+++ b/include/vast/repl/config.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2023, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Util/Common.hpp"
+
+#include "gap/coro/generator.hpp"
+
+#include <fstream>
+#include <optional>
+
+namespace vast::repl::ini {
+
+    struct section_name {
+        std::string name;
+
+        static std::optional< section_name > parse(std::ifstream &in);
+    };
+
+    struct section {
+        section_name name;
+        std::vector< std::string > content;
+
+        bool is_sticky_section() const;
+        bool is_pipeline_section() const;
+
+        string_ref last_name() const;
+
+        void dump() const;
+
+        static std::optional< section > parse(std::ifstream &in);
+    };
+
+    struct config {
+        std::vector< section > sections;
+
+        void dump() const;
+
+        static config parse(std::ifstream &in);
+    };
+
+
+} // namespace vast::repl::ini

--- a/include/vast/repl/pipeline.hpp
+++ b/include/vast/repl/pipeline.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#pragma once
+
+
+namespace vast::repl {
+
+    struct pipeline {
+        using pass_name = std::string;
+        using passname_ref = std::string_view;
+
+        std::vector< pass_name > passes;
+        std::vector< passname_ref > make_snapshot_after;
+    };
+
+} // namespace vast::repl

--- a/include/vast/repl/pipeline.hpp
+++ b/include/vast/repl/pipeline.hpp
@@ -12,7 +12,7 @@ namespace vast::repl {
         std::vector< pass_name > passes;
 
         bool make_snapshot_after_each = false;
-        std::vector< passname_ref > make_snapshot_after;
+        std::vector< passname_ref > make_snapshot_after = {};
     };
 
 } // namespace vast::repl

--- a/include/vast/repl/pipeline.hpp
+++ b/include/vast/repl/pipeline.hpp
@@ -10,6 +10,8 @@ namespace vast::repl {
         using passname_ref = std::string_view;
 
         std::vector< pass_name > passes;
+
+        bool make_snapshot_after_each = false;
         std::vector< passname_ref > make_snapshot_after;
     };
 

--- a/include/vast/repl/state.hpp
+++ b/include/vast/repl/state.hpp
@@ -5,6 +5,7 @@
 #include "vast/Tower/Tower.hpp"
 #include "vast/repl/common.hpp"
 #include "vast/repl/command_base.hpp"
+#include "vast/repl/pipeline.hpp"
 
 #include <filesystem>
 
@@ -13,14 +14,36 @@ namespace vast::repl {
     struct state_t {
         explicit state_t(mcontext_t &ctx) : ctx(ctx) {}
 
+        //
+        // perform exit in next step
+        //
         bool exit = false;
 
+        //
+        // c/c++ source file to compile
+        //
         std::optional< std::filesystem::path > source;
 
+        //
+        // mlir module and context
+        //
         mcontext_t &ctx;
         std::optional< tw::default_tower > tower;
 
+        //
+        // sticked commands performed after each step
+        //
         std::vector< command_ptr > sticked;
+
+        //
+        // named pipelines
+        //
+        llvm::StringMap< pipeline > pipelines;
+
+        //
+        // verbosity flags
+        //
+        bool verbose_pipeline = true;
     };
 
 } // namespace vast::repl

--- a/include/vast/repl/state.hpp
+++ b/include/vast/repl/state.hpp
@@ -4,6 +4,7 @@
 
 #include "vast/Tower/Tower.hpp"
 #include "vast/repl/common.hpp"
+#include "vast/repl/command_base.hpp"
 
 #include <filesystem>
 
@@ -18,6 +19,8 @@ namespace vast::repl {
 
         mcontext_t &ctx;
         std::optional< tw::default_tower > tower;
+
+        std::vector< command_ptr > sticked;
     };
 
 } // namespace vast::repl

--- a/lib/vast/Frontend/Action.cpp
+++ b/lib/vast/Frontend/Action.cpp
@@ -130,11 +130,11 @@ namespace vast::cc {
             return;
         }
 
-        // TODO: pass the module around
+        _mod = consumer->result();
     }
 
     owning_module_ref vast_module_action::result() {
-        return consumer->result();
+        return std::move(_mod);
     }
 
     // emit assembly

--- a/test/repl/raise.c
+++ b/test/repl/raise.c
@@ -1,5 +1,4 @@
 // RUN: printf "load %s\n raise vast-hl-to-ll-cf\n show module\n exit" | %vast-repl | %file-check %s
 // CHECK: ll.return %0 : !hl.int
-// REQUIRES: repl
 
 int main(void) { return 0; }

--- a/tools/vast-repl/CMakeLists.txt
+++ b/tools/vast-repl/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_vast_executable(vast-repl
     vast-repl.cpp
+    cli.cpp
     codegen.cpp
     command.cpp
+    config.cpp
 
     LINK_LIBS
       ${CLANG_LIBS}

--- a/tools/vast-repl/cli.cpp
+++ b/tools/vast-repl/cli.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, Trail of Bits, Inc.
+
+#include "vast/repl/cli.hpp"
+#include "vast/repl/config.hpp"
+
+namespace vast::repl {
+
+    void cli_t::initialize(std::filesystem::path config_path) {
+        std::ifstream input(config_path);
+        if (!input.is_open()) {
+            llvm::errs() << "error: failed to opean config file\n";
+        }
+
+        auto cfg = ini::config::parse(input);
+
+        for (auto sec: cfg.sections) {
+            // setup initially sticky commands
+            // e.g., one cas set deafault printing of module
+            // putting `show module` in the config sticky section
+            if (sec.is_sticky_section()) {
+                for (auto cmd : sec.content) {
+                    cmd::add_sticky_command(cmd, state);
+                }
+            }
+
+            if (sec.is_pipeline_section()) {
+                auto name = sec.last_name();
+                state.pipelines[name.str()] = pipeline{
+                    .passes = sec.content
+                };
+            }
+        }
+    }
+
+} // namespace vast::repl

--- a/tools/vast-repl/codegen.cpp
+++ b/tools/vast-repl/codegen.cpp
@@ -25,7 +25,7 @@ namespace vast::cc {
 namespace vast::repl::codegen {
 
     std::unique_ptr< clang::ASTUnit > ast_from_source(string_ref source) {
-        return clang::tooling::buildASTFromCode(source);
+        return clang::tooling::buildASTFromCodeWithArgs(source, { "-xc" });
     }
 
     static void error_handler(void *user_data, const char *msg, bool get_crash_diag) {

--- a/tools/vast-repl/codegen.cpp
+++ b/tools/vast-repl/codegen.cpp
@@ -38,7 +38,7 @@ namespace vast::repl::codegen {
         llvm::sys::RunInterruptHandlers();
     }
 
-    owning_module_ref emit_module(const std::filesystem::path &source, mcontext_t */* mctx */) {
+    owning_module_ref emit_module(const std::filesystem::path &source, mcontext_t &mctx ) {
         // TODO setup args from repl state
         std::vector< const char * > ccargs = { source.c_str() };
         vast::cc::buffered_diagnostics diags(ccargs);
@@ -76,8 +76,7 @@ namespace vast::repl::codegen {
             return {};
         }
 
-        auto mctx = cc::mk_mcontext();
-        if (auto action = std::make_unique< vast::cc::emit_mlir_module >(vargs, *mctx); !action) {
+        if (auto action = std::make_unique< vast::cc::emit_mlir_module >(vargs, mctx)) {
             comp->ExecuteAction(*action);
             llvm::remove_fatal_error_handler();
             return action->result();

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -11,7 +11,7 @@ namespace vast::repl::cmd {
 
     void check_source(const state_t &state) {
         if (!state.source.has_value()) {
-            VAST_ERROR("error: missing source");
+            throw_error("error: missing source");
         }
     }
 
@@ -23,7 +23,7 @@ namespace vast::repl::cmd {
 
         // Check if the file is opened successfully
         if (auto errorCode = file_buffer.getError()) {
-            VAST_ERROR("error: missing source {}", errorCode.message());
+            throw_error("error: missing source {}", errorCode.message());
         }
 
         return file_buffer;
@@ -49,7 +49,7 @@ namespace vast::repl::cmd {
     // help command
     //
     void help::run(state_t&) const {
-        VAST_UNIMPLEMENTED;
+        throw_error("Not implemented!");
     };
 
     //
@@ -145,7 +145,7 @@ namespace vast::repl::cmd {
         auto th = state.tower->top();
         for (auto pass : passes) {
             if (mlir::failed(mlir::parsePassPipeline(pass, pm))) {
-                VAST_FATAL("failed to parse pass pipeline");
+                throw_error("failed to parse pass pipeline");
             }
             th = state.tower->apply(th, pm);
         }

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -88,17 +88,24 @@ namespace cmd {
         });
     }
 
-    void show::run(state_t &state) const {
-        if (!state.source.has_value()) {
-            return;
+    void show_pipelines(state_t &state) {
+        if (state.pipelines.empty()) {
+            llvm::outs() << "no pipelines\n";
         }
 
+        for (const auto &[name, _] : state.pipelines) {
+            llvm::outs() << name << "\n";
+        }
+    }
+
+    void show::run(state_t &state) const {
         auto what = get_param< kind_param >(params);
         switch (what) {
             case show_kind::source:  return show_source(state);
             case show_kind::ast:     return show_ast(state);
             case show_kind::module:  return show_module(state);
             case show_kind::symbols: return show_symbols(state);
+            case show_kind::pipelines: return show_pipelines(state);
         }
     };
 
@@ -161,7 +168,11 @@ namespace cmd {
     //
     void sticky::run(state_t &state) const {
         auto cmd = get_param< command_param >(params);
-        auto tokens = parse_tokens(cmd.value);
+        add_sticky_command(cmd.value, state);
+    }
+
+    void add_sticky_command(string_ref cmd, state_t &state) {
+        auto tokens = parse_tokens(cmd);
         state.sticked.push_back(parse_command(tokens));
     }
 

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -33,7 +33,7 @@ namespace cmd {
     void check_and_emit_module(state_t &state) {
         if (!state.tower) {
             check_source(state);
-            auto mod    = codegen::emit_module(state.source.value(), &state.ctx);
+            auto mod    = codegen::emit_module(state.source.value(), state.ctx);
             auto [t, _] = tw::default_tower::get(state.ctx, std::move(mod));
             state.tower = std::move(t);
         }

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -7,7 +7,8 @@
 #include "vast/repl/common.hpp"
 #include <optional>
 
-namespace vast::repl::cmd {
+namespace vast::repl {
+namespace cmd {
 
     void check_source(const state_t &state) {
         if (!state.source.has_value()) {
@@ -88,6 +89,10 @@ namespace vast::repl::cmd {
     }
 
     void show::run(state_t &state) const {
+        if (!state.source.has_value()) {
+            return;
+        }
+
         auto what = get_param< kind_param >(params);
         switch (what) {
             case show_kind::source:  return show_source(state);
@@ -151,4 +156,19 @@ namespace vast::repl::cmd {
         }
     }
 
-} // namespace vast::repl::cmd
+    //
+    // sticky command
+    //
+    void sticky::run(state_t &state) const {
+        auto cmd = get_param< command_param >(params);
+        auto tokens = parse_tokens(cmd.value);
+        state.sticked.push_back(parse_command(tokens));
+    }
+
+} // namespace cmd
+
+    command_ptr parse_command(std::span< command_token > tokens) {
+        return match< cmd::command_list >(tokens);
+    }
+
+} // namespace vast::repl

--- a/tools/vast-repl/config.cpp
+++ b/tools/vast-repl/config.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2023, Trail of Bits, Inc.
+
+#include "vast/repl/config.hpp"
+
+#include "vast/Util/Common.hpp"
+#include "vast/Util/Warnings.hpp"
+
+#include <ranges>
+
+namespace vast::repl::ini {
+
+    namespace sr = std::ranges;
+    namespace sv = std::views;
+
+    struct line_proxy
+    {
+        friend std::istream &operator>>(std::istream &is, line_proxy &proxy) {
+            std::getline(is, proxy.line);
+            return is;
+        }
+
+        operator std::string() const { return line; }
+        operator string_ref() const { return line; }
+        std::string line{};
+    };
+
+    auto lines(std::ifstream &in) {
+        return std::ranges::istream_view< line_proxy >(in);
+    }
+
+    bool section::is_sticky_section() const {
+        return string_ref(name.name).starts_with("repl:boot:sticky");
+    }
+
+    bool section::is_pipeline_section() const {
+        return string_ref(name.name).starts_with("repl:pipeline");
+    }
+
+    string_ref section::last_name() const {
+        return string_ref(name.name).rsplit(':').second;
+    }
+
+    std::optional< section_name > section_name::parse(std::ifstream &in) {
+        auto is_not_name = [] (string_ref line) {
+            return !line.starts_with("[");
+        };
+
+        auto process = [] (string_ref line) -> std::optional< section_name > {
+            if (!line.consume_front("[") || !line.consume_back("]")) {
+                return std::nullopt;
+            }
+
+            return section_name{ line.str() };
+        };
+
+        // parse section name
+        for (auto line : lines(in)) {
+            // trim commented and empty lines
+            if (is_not_name(line))
+                continue;
+            return process(line);
+        }
+
+        return std::nullopt;
+    }
+
+    void section::dump() const {
+        llvm::outs() << "[" << name.name << "]\n";
+        for (auto line : content) {
+            llvm::outs() << line << "\n";
+        }
+    }
+
+    std::optional< section > section::parse(std::ifstream &in) {
+        section sec;
+
+        if (auto name = section_name::parse(in)) {
+            sec.name = name.value();
+        } else {
+            return std::nullopt;
+        }
+
+        auto is_not_empty = [] (string_ref line) { return !line.empty(); };
+
+        for (std::string line : lines(in) | sv::take_while(is_not_empty)) {
+            if (!line.starts_with(";")) {
+                sec.content.push_back(line);
+            }
+        }
+
+        return sec;
+    }
+
+    config config::parse(std::ifstream &in) {
+        config cfg;
+        auto next = [&] { return section::parse(in); };
+        for (auto sec = next(); sec; sec = next()) {
+            cfg.sections.push_back(std::move(sec.value()));
+        }
+        return cfg;
+    }
+
+    void config::dump() const {
+        for (const auto &sec : sections) {
+            sec.dump();
+            llvm::outs() << "\n";
+        }
+    }
+
+} // namespace vast::repl::ini

--- a/tools/vast-repl/vast-repl.cpp
+++ b/tools/vast-repl/vast-repl.cpp
@@ -83,6 +83,7 @@ namespace vast::repl
 int main(int argc, char **argv) try {
     mlir::registerAllPasses();
     // Register VAST passes here
+    vast::hl::registerHighLevelPasses();
     vast::registerConversionPasses();
 
     mlir::DialectRegistry registry;


### PR DESCRIPTION
Update `vast-repl` to use newer APIs.
Backport some forgotten patches in the experimental branches - some of these features do not work yet, but there is no reason not to include them as we are already developing `tower` and we will need them in some form eventually.