### PR TITLE
High-level support for _Atomic type and its casts

### DIFF
--- a/include/vast/CodeGen/CodeGenBuilder.hpp
+++ b/include/vast/CodeGen/CodeGenBuilder.hpp
@@ -74,6 +74,7 @@ namespace vast::cg {
                 if (!valid(args...)) {
                     return result_type{};
                 }
+
                 return binder(args..., std::forward< decltype(rest) >(rest)...);
             };
             return compose_state_t< result_type, decltype(bound) >(std::move(bound));

--- a/include/vast/CodeGen/CodeGenBuilder.hpp
+++ b/include/vast/CodeGen/CodeGenBuilder.hpp
@@ -25,6 +25,11 @@ namespace vast::cg {
     template< typename result_type, typename bind_type >
     struct compose_state_t;
 
+    template< typename T >
+    concept is_castable_to_bool = requires(T t) {
+        static_cast< bool >(t);
+    };
+
     template< typename result_type, typename bind_type >
     struct compose_state_t {
 
@@ -32,7 +37,7 @@ namespace vast::cg {
 
         template< typename arg_t >
         static constexpr bool valid(const arg_t &arg) {
-            if constexpr (std::convertible_to< arg_t , bool >) {
+            if constexpr (is_castable_to_bool< arg_t >) {
                 return static_cast< bool >(arg);
             } else {
                 // initialized non-boolean arg is always valid

--- a/include/vast/CodeGen/DefaultDeclVisitor.hpp
+++ b/include/vast/CodeGen/DefaultDeclVisitor.hpp
@@ -80,7 +80,7 @@ namespace vast::cg {
             return bld.compose< RecordDeclOp >()
                 .bind(self.location(decl))
                 .bind(self.symbol(decl))
-                .bind(field_builder)
+                .bind_always(field_builder)
                 .freeze();
         });
     }

--- a/include/vast/CodeGen/DefaultStmtVisitor.hpp
+++ b/include/vast/CodeGen/DefaultStmtVisitor.hpp
@@ -321,7 +321,7 @@ namespace vast::cg {
         return bld.compose< hl::CmpOp >()
             .bind(self.location(op))
             .bind(self.visit(op->getType()))
-            .bind(pred)
+            .bind_always(pred)
             .bind_transform(self.visit(op->getLHS()), first_result)
             .bind_transform(self.visit(op->getRHS()), first_result)
             .freeze();
@@ -348,7 +348,7 @@ namespace vast::cg {
         return bld.compose< hl::FCmpOp >()
             .bind(self.location(op))
             .bind(self.visit(op->getType()))
-            .bind(pred)
+            .bind_always(pred)
             .bind_transform(self.visit(op->getLHS()), first_result)
             .bind_transform(self.visit(op->getRHS()), first_result)
             .freeze();
@@ -374,8 +374,8 @@ namespace vast::cg {
         return bld.compose< LOp >()
             .bind(self.location(op))
             .bind(self.visit(op->getType()))
-            .bind(mk_value_builder(op->getLHS()))
-            .bind(mk_value_builder(op->getRHS()))
+            .bind_always(mk_value_builder(op->getLHS()))
+            .bind_always(mk_value_builder(op->getRHS()))
             .freeze();
     }
 
@@ -459,7 +459,7 @@ namespace vast::cg {
                 .bind(self.location(cast))
                 .bind(cast_result_type(cast, arg->getResultTypes().front()))
                 .bind_transform(arg, first_result)
-                .bind(cast_kind(cast))
+                .bind_always(cast_kind(cast))
                 .freeze();
         }
 
@@ -480,7 +480,7 @@ namespace vast::cg {
         return bld.compose< op_t >()
             .bind(self.location(expr))
             .bind(self.visit(expr->getType()))
-            .bind(mk_value_builder(expr->getArgumentExpr()))
+            .bind_always(mk_value_builder(expr->getArgumentExpr()))
             .freeze();
     }
 

--- a/include/vast/CodeGen/DefaultTypeVisitor.hpp
+++ b/include/vast/CodeGen/DefaultTypeVisitor.hpp
@@ -94,6 +94,9 @@ namespace vast::cg {
         mlir_type VisitComplexType(const clang::ComplexType *ty);
         mlir_type VisitComplexType(const clang::ComplexType *ty, clang_qualifiers quals);
 
+        mlir_type VisitAtomicType(const clang::AtomicType *ty);
+        mlir_type VisitAtomicType(const clang::AtomicType *ty, clang_qualifiers quals);
+
       private:
         auto with_ucv_qualifiers(auto &&state, bool is_unsigned, clang_qualifiers q) {
             return std::forward< decltype(state) >(state)

--- a/include/vast/CodeGen/UnsupportedVisitor.hpp
+++ b/include/vast/CodeGen/UnsupportedVisitor.hpp
@@ -25,8 +25,8 @@ namespace vast::cg
 
         operation visit(const clang_decl *decl, scope_context &scope) {
             return underlying().builder().template compose< unsup::UnsupportedDecl >()
-                .bind(underlying().head().location(decl).value())
-                .bind(decl_name(decl))
+                .bind(underlying().head().location(decl))
+                .bind_always(decl_name(decl))
                 .freeze();
         }
     };
@@ -38,13 +38,12 @@ namespace vast::cg
         using util::crtp< derived, unsup_stmt_visitor >::underlying;
 
         operation visit(const clang_stmt *stmt, scope_context &scope) {
-            auto rty = return_type(stmt, scope);
-            return underlying().builder().template create< unsup::UnsupportedStmt >(
-                underlying().location(stmt).value(),
-                stmt->getStmtClassName(),
-                rty,
-                make_children(stmt, scope)
-            );
+            return underlying().builder().template compose< unsup::UnsupportedStmt >()
+                .bind(underlying().location(stmt))
+                .bind_always(stmt->getStmtClassName())
+                .bind(return_type(stmt, scope))
+                .bind_always(make_children(stmt, scope))
+                .freeze();
         }
 
       private:

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.td
@@ -465,4 +465,18 @@ def TypeOfType : CVRQualifiedType<
   let assemblyFormat = "`<` $unmodifiedType (`,` $quals^ )? `>`";
 }
 
+def Atomic : CVRQualifiedType<
+  "Atomic", "atomic"
+  , (ins "Type":$elementType)
+  , [MemRefElementTypeInterface]
+> {
+  let builders = [
+    TypeBuilder<(ins "Type":$elementType), [{
+      return $_get($_ctxt, elementType, CVRQualifiersAttr());
+    }]>
+  ];
+
+  let assemblyFormat = "`<` $elementType (`,` $quals^ )? `>`";
+}
+
 #endif // VAST_DIALECT_HIGHLEVEL_IR_HIGHLEVELTYPES

--- a/lib/vast/CodeGen/DefaultDeclVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultDeclVisitor.cpp
@@ -151,7 +151,7 @@ namespace vast::cg
             .bind(self.location(decl))
             .bind(self.symbol(decl))
             .bind_dyn_cast< vast_function_type >(visit_function_type(self, mctx, decl->getFunctionType(), decl->isVariadic()))
-            .bind(core::get_function_linkage(decl))
+            .bind_always(core::get_function_linkage(decl))
             .freeze_as_maybe() // construct vast_function
             .transform(set_visibility)
             .take();
@@ -293,7 +293,7 @@ namespace vast::cg
     operation default_decl_visitor::VisitTranslationUnitDecl(const clang::TranslationUnitDecl *decl) {
         return bld.compose< hl::TranslationUnitOp >()
             .bind(self.location(decl))
-            .bind(mk_decl_context_builder(decl))
+            .bind_always(mk_decl_context_builder(decl))
             .freeze();
     }
 
@@ -386,7 +386,7 @@ namespace vast::cg
                 .bind(self.location(decl))
                 .bind(self.symbol(decl))
                 .bind(self.visit(decl->getIntegerType()))
-                .bind(constants)
+                .bind_always(constants)
                 .freeze();
         });
     }
@@ -395,7 +395,7 @@ namespace vast::cg
         return maybe_declare([&] {
             auto initializer = [&] (auto & /* bld */, auto loc) {
                 bld.compose< hl::ValueYieldOp >()
-                    .bind(loc)
+                    .bind_always(loc)
                     .bind_transform(self.visit(decl->getInitExpr()), first_result)
                     .freeze();
             };
@@ -404,7 +404,7 @@ namespace vast::cg
                 .bind(self.location(decl))
                 .bind(self.symbol(decl))
                 .bind(self.visit(decl->getType()))
-                .bind(decl->getInitVal())
+                .bind_always(decl->getInitVal())
                 .bind_if(decl->getInitExpr(), std::move(initializer))
                 .freeze();
         });
@@ -459,7 +459,7 @@ namespace vast::cg
                 .bind(self.location(decl))
                 .bind(self.symbol(decl))
                 .bind(self.visit(decl->getType()))
-                .bind(visit_bitfield())
+                .bind_always(visit_bitfield())
                 .freeze();
         });
     }

--- a/lib/vast/CodeGen/DefaultStmtVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultStmtVisitor.cpp
@@ -531,8 +531,9 @@ namespace vast::cg
             // case clang::CastKind::CK_ARCReclaimReturnedObject:
             // case clang::CastKind::CK_ARCExtendBlockObject:
 
-            // case clang::CastKind::CK_AtomicToNonAtomic:
-            // case clang::CastKind::CK_NonAtomicToAtomic:
+            case clang::CastKind::CK_AtomicToNonAtomic:
+            case clang::CastKind::CK_NonAtomicToAtomic:
+                return keep_category_cast();
 
             // case clang::CastKind::CK_CopyAndAutoreleaseBlockObject:
             // case clang::CastKind::CK_BuiltinFnToFnPtr:

--- a/lib/vast/CodeGen/DefaultTypeVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultTypeVisitor.cpp
@@ -206,6 +206,10 @@ namespace vast::cg {
             return VisitComplexType(t, quals);
         }
 
+        if (auto t = llvm::dyn_cast< clang::AtomicType >(underlying)) {
+            return VisitAtomicType(t, quals);
+        }
+
         return {};
     }
 
@@ -456,6 +460,15 @@ namespace vast::cg {
     mlir_type default_type_visitor::VisitComplexType(const clang::ComplexType *ty, clang_qualifiers quals) {
         auto type = self.visit(ty->getElementType());
         return with_cvr_qualifiers(compose_type< hl::ComplexType >().bind(type), quals).freeze();
+    }
+
+    mlir_type default_type_visitor::VisitAtomicType(const clang::AtomicType *ty) {
+        return VisitAtomicType(ty, ty->desugar().getLocalQualifiers());
+    }
+
+    mlir_type default_type_visitor::VisitAtomicType(const clang::AtomicType *ty, clang_qualifiers quals) {
+        auto type = self.visit(ty->getValueType());
+        return with_cvr_qualifiers(compose_type< hl::AtomicType >().bind(type), quals).freeze();
     }
 
     mlir_type visit_function_type(

--- a/lib/vast/CodeGen/DefaultTypeVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultTypeVisitor.cpp
@@ -432,13 +432,13 @@ namespace vast::cg {
 
         auto def  = bld.compose< hl::TypeOfExprOp >()
             .bind(self.location(expr))
-            .bind(name)
+            .bind_always(name)
             .bind(self.visit(expr->getType()))
-            .bind(mk_type_yield_builder(expr))
+            .bind_always(mk_type_yield_builder(expr))
             .freeze();
 
         if (def) {
-            return with_cvr_qualifiers(compose_type< hl::TypeOfExprType >().bind(name), quals).freeze();
+            return with_cvr_qualifiers(compose_type< hl::TypeOfExprType >().bind_always(name), quals).freeze();
         } else {
             return {};
         }

--- a/test/vast/Dialect/HighLevel/atomic-a.c
+++ b/test/vast/Dialect/HighLevel/atomic-a.c
@@ -1,0 +1,23 @@
+// RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %file-check %s
+// RUN: %vast-cc1 -vast-emit-mlir=hl %s -o %t && %vast-opt %t | diff -B %t -
+
+// CHECK: !hl.lvalue<!hl.atomic<!hl.int>>
+_Atomic int ai;
+
+// CHECK: !hl.lvalue<!hl.ptr<!hl.atomic<!hl.int,  const >>>
+_Atomic const int * paci;
+
+// CHECK: !hl.lvalue<!hl.ptr<!hl.atomic<!hl.int>,  const >>
+_Atomic int * const aipc;
+
+// CHECK: !hl.lvalue<!hl.atomic<!hl.ptr<!hl.int< const >>>>
+_Atomic(const int*) acip;
+
+// CHECK: !hl.lvalue<!hl.atomic<!hl.int,  volatile >>
+volatile _Atomic int vai;
+
+// CHECK: !hl.lvalue<!hl.ptr<!hl.atomic<!hl.int>>>
+_Atomic int * aip;
+
+// CHECK: !hl.lvalue<!hl.ptr<!hl.atomic<!hl.int>,  restrict >>
+_Atomic int *restrict aipr;

--- a/test/vast/Dialect/HighLevel/atomic-b.c
+++ b/test/vast/Dialect/HighLevel/atomic-b.c
@@ -1,0 +1,20 @@
+// RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %file-check %s
+// RUN: %vast-cc1 -vast-emit-mlir=hl %s -o %t && %vast-opt %t | diff -B %t -
+
+void atomic_cast() {
+    _Atomic int ai;
+    _Atomic int bi;
+    // CHECK: AtomicToNonAtomic : !hl.atomic<!hl.int> -> !hl.int
+    // CHECK: NonAtomicToAtomic : !hl.int -> !hl.atomic<!hl.int>
+    ai = bi;
+    // CHECK: AtomicToNonAtomic : !hl.atomic<!hl.int> -> !hl.int
+    int i = ai;
+    // CHECK: NonAtomicToAtomic : !hl.int -> !hl.atomic<!hl.int>
+    ai = i;
+    // CHECK: AtomicToNonAtomic : !hl.atomic<!hl.int> -> !hl.int
+    // CHECK: IntegralCast : !hl.int -> !hl.long
+    long l = ai;
+    // CHECK: IntegralCast : !hl.long -> !hl.int
+    // CHECK: NonAtomicToAtomic : !hl.int -> !hl.atomic<!hl.int>
+    ai = l;
+}

--- a/test/vast/Dialect/HighLevel/stdatomic-a.c
+++ b/test/vast/Dialect/HighLevel/stdatomic-a.c
@@ -1,0 +1,41 @@
+// RUN: %vast-front -vast-emit-mlir=hl %s -o - | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl %s -o %t && %vast-opt %t | diff -B %t -
+
+// CHECK: hl.typedef "atomic_bool" : !hl.atomic<!hl.bool>
+// CHECK: hl.typedef "atomic_char" : !hl.atomic<!hl.char>
+// CHECK: hl.typedef "atomic_schar" : !hl.atomic<!hl.char>
+// CHECK: hl.typedef "atomic_uchar" : !hl.atomic<!hl.char< unsigned >>
+// CHECK: hl.typedef "atomic_short" : !hl.atomic<!hl.short>
+// CHECK: hl.typedef "atomic_ushort" : !hl.atomic<!hl.short< unsigned >>
+// CHECK: hl.typedef "atomic_int" : !hl.atomic<!hl.int>
+// CHECK: hl.typedef "atomic_uint" : !hl.atomic<!hl.int< unsigned >>
+// CHECK: hl.typedef "atomic_long" : !hl.atomic<!hl.long>
+// CHECK: hl.typedef "atomic_ulong" : !hl.atomic<!hl.long< unsigned >>
+// CHECK: hl.typedef "atomic_llong" : !hl.atomic<!hl.longlong>
+// CHECK: hl.typedef "atomic_ullong" : !hl.atomic<!hl.longlong< unsigned >>
+// CHECK: hl.typedef "atomic_char16_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_least16_t">>>
+// CHECK: hl.typedef "atomic_char32_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_least32_t">>>
+// CHECK: hl.typedef "atomic_wchar_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"wchar_t">>>
+// CHECK: hl.typedef "atomic_int_least8_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_least8_t">>>
+// CHECK: hl.typedef "atomic_uint_least8_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_least8_t">>>
+// CHECK: hl.typedef "atomic_int_least16_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_least16_t">>>
+// CHECK: hl.typedef "atomic_uint_least16_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_least16_t">>>
+// CHECK: hl.typedef "atomic_int_least32_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_least32_t">>>
+// CHECK: hl.typedef "atomic_uint_least32_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_least32_t">>>
+// CHECK: hl.typedef "atomic_int_least64_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_least64_t">>>
+// CHECK: hl.typedef "atomic_uint_least64_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_least64_t">>>
+// CHECK: hl.typedef "atomic_int_fast8_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_fast8_t">>>
+// CHECK: hl.typedef "atomic_uint_fast8_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_fast8_t">>>
+// CHECK: hl.typedef "atomic_int_fast16_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_fast16_t">>>
+// CHECK: hl.typedef "atomic_uint_fast16_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_fast16_t">>>
+// CHECK: hl.typedef "atomic_int_fast32_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_fast32_t">>>
+// CHECK: hl.typedef "atomic_uint_fast32_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_fast32_t">>>
+// CHECK: hl.typedef "atomic_int_fast64_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"int_fast64_t">>>
+// CHECK: hl.typedef "atomic_uint_fast64_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uint_fast64_t">>>
+// CHECK: hl.typedef "atomic_intptr_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"intptr_t">>>
+// CHECK: hl.typedef "atomic_uintptr_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uintptr_t">>>
+// CHECK: hl.typedef "atomic_size_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"size_t">>>
+// CHECK: hl.typedef "atomic_ptrdiff_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"ptrdiff_t">>>
+// CHECK: hl.typedef "atomic_intmax_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"intmax_t">>>
+// CHECK: hl.typedef "atomic_uintmax_t" : !hl.atomic<!hl.elaborated<!hl.typedef<"uintmax_t">>>
+#include <stdatomic.h>


### PR DESCRIPTION
- adds `hl.atomic< type >` type definition
- allows to create `AtomicToNonAtomic` and `NonAtomicToAtomic` casts
- fixes validity check in monadic builder