### PR TITLE
Fixup function pointer lvalues

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -161,7 +161,7 @@ def HighLevel_CondOp : ControlFlowOp< "cond" >
     bool typesMatch(mlir::Type lhs, mlir::Type rhs);
   }];
 
-  let assemblyFormat = [{ $condRegion `?` $thenRegion `:` $elseRegion attr-dict `:` type(results) }];
+  let assemblyFormat = [{ attr-dict `:` type(results) $condRegion `?` $thenRegion `:` $elseRegion }];
 }
 
 def HighLevel_WhileOp : ControlFlowOp< "while", [NoTerminator] >

--- a/include/vast/Dialect/HighLevel/HighLevelOps.td
+++ b/include/vast/Dialect/HighLevel/HighLevelOps.td
@@ -1166,7 +1166,7 @@ def LNotOp  : LogicalUnOp< "lnot", [] >;
 def AddressOf
   : HighLevel_Op< "addressof", [] >
   // TODO(Heno): parameter constraints
-  , Arguments<(ins LValueOf<AnyType>:$value)>
+  , Arguments<(ins AnyType:$value)>
   , Results<(outs AnyType:$result)>
 {
     let summary = "VAST addressof operation";

--- a/lib/vast/CodeGen/DefaultStmtVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultStmtVisitor.cpp
@@ -664,7 +664,7 @@ namespace vast::cg
     operation default_stmt_visitor::visit_function_decl_ref(const clang::DeclRefExpr *expr) {
         return bld.compose< hl::FuncRefOp >()
             .bind(self.location(expr))
-            .bind(visit_as_lvalue_type(self, mctx, expr->getType()))
+            .bind(visit_maybe_lvalue_result_type(expr))
             .bind(self.symbol(expr))
             .freeze();
     }

--- a/test/vast/Dialect/HighLevel/fun-ptr-a.c
+++ b/test/vast/Dialect/HighLevel/fun-ptr-a.c
@@ -9,7 +9,7 @@ void h(void) {}
 
 int main (void) {
     // CHECK: FunctionToPointerDecay
-    // CHECK: hl.call {{.*}} : (!hl.lvalue<!hl.ptr<!core.fn<() -> (!hl.void)>>>) -> !hl.void
+    // CHECK: hl.call {{.*}} : (!hl.ptr<!core.fn<() -> (!hl.void)>>) -> !hl.void
     f(h);
     return 0;
 }

--- a/test/vast/Dialect/HighLevel/fun-ptr-b.c
+++ b/test/vast/Dialect/HighLevel/fun-ptr-b.c
@@ -1,0 +1,11 @@
+// RUN: %vast-front -vast-emit-mlir=hl %s -o - | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl %s -o %t && %vast-opt %t | diff -B %t -
+
+int hash_proof_destroy_noop(int x) {return x;}
+
+int main() {
+    int x = 0;
+    // CHECK: hl.cond : !hl.ptr<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.int)>>
+    void *fn = x ? ((void *)0) : hash_proof_destroy_noop;
+}
+

--- a/test/vast/Dialect/HighLevel/pointers-d.c
+++ b/test/vast/Dialect/HighLevel/pointers-d.c
@@ -3,10 +3,10 @@
 
 void f(int);
 // CHECK: hl.var "pf1" : !hl.lvalue<!hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>>>
-// CHECK:   [[R:%[0-9]+]] = hl.funcref @f : !hl.lvalue<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>
-// CHECK:   hl.addressof [[R]] : !hl.lvalue<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>> -> !hl.ptr<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>
+// CHECK:   [[R:%[0-9]+]] = hl.funcref @f : !core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>
+// CHECK:   hl.addressof [[R]] : !core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)> -> !hl.ptr<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>
 void (*pf1)(int) = &f;
 // CHECK: hl.var "pf2" : !hl.lvalue<!hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>>>
-// CHECK:   [[R:%[0-9]+]] = hl.funcref @f : !hl.lvalue<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>
-// CHECK:   hl.implicit_cast [[R]] FunctionToPointerDecay : !hl.lvalue<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>> -> !hl.lvalue<!hl.ptr<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>>
+// CHECK:   [[R:%[0-9]+]] = hl.funcref @f : !core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>
+// CHECK:   hl.implicit_cast [[R]] FunctionToPointerDecay : !core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)> -> !hl.ptr<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.void)>>
 void (*pf2)(int) = f; // same as &f

--- a/test/vast/Dialect/HighLevel/pointers-e.c
+++ b/test/vast/Dialect/HighLevel/pointers-e.c
@@ -5,8 +5,8 @@ int f();
 
 int main() {
     // CHECK: [[FP:%[0-9]+]] = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.paren<!core.fn<() -> (!hl.int)>>>>
-    // CHECK:   hl.funcref @f : !hl.lvalue<!core.fn<() -> (!hl.int)>>
-    // CHECK:   FunctionToPointerDecay : !hl.lvalue<!core.fn<() -> (!hl.int)>> -> !hl.lvalue<!hl.ptr<!core.fn<() -> (!hl.int)>>>
+    // CHECK:   hl.funcref @f : !core.fn<() -> (!hl.int)>
+    // CHECK:   FunctionToPointerDecay : !core.fn<() -> (!hl.int)> -> !hl.ptr<!core.fn<() -> (!hl.int)>>
     int (*p)() = f;    // pointer p is pointing to f
 
     // CHECK: [[E:%[0-9]+]] = hl.expr : !hl.paren<!core.fn<() -> (!hl.int)>>

--- a/test/vast/Dialect/HighLevel/pointers-f.c
+++ b/test/vast/Dialect/HighLevel/pointers-f.c
@@ -5,10 +5,10 @@ int f(int), fc(const int);
 
 int main() {
     // CHECK: hl.var "pc" : !hl.lvalue<!hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int< const >>) -> (!hl.int)>>>>
-    // CHECK:   hl.funcref @f : !hl.lvalue<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.int)>>
+    // CHECK:   hl.funcref @f : !core.fn<(!hl.lvalue<!hl.int>) -> (!hl.int)>
     int (*pc)(const int) = f;
     // CHECK: hl.var "p" : !hl.lvalue<!hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.int)>>>>
-    // CHECK:   hl.funcref @fc : !hl.lvalue<!core.fn<(!hl.lvalue<!hl.int< const >>) -> (!hl.int)>>
+    // CHECK: hl.funcref @fc : !core.fn<(!hl.lvalue<!hl.int< const >>) -> (!hl.int)>
     int (*p)(int) = fc;
     // CHECK: hl.assign [[P:%[0-9]+]] to [[PC:%[0-9]+]] : !hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int>) -> (!hl.int)>>>, !hl.lvalue<!hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int< const >>) -> (!hl.int)>>>> -> !hl.ptr<!hl.paren<!core.fn<(!hl.lvalue<!hl.int< const >>) -> (!hl.int)>>>
     pc = p;

--- a/test/vast/Dialect/HighLevel/quirks-j.c
+++ b/test/vast/Dialect/HighLevel/quirks-j.c
@@ -30,7 +30,7 @@ void foo() {
     // CHECK: hl.member [[R]] at "x" : !hl.lvalue<!hl.elaborated<!hl.record<"bitfield">>> -> !hl.lvalue<!hl.int< unsigned >>
     bf.x;
 
-    // CHECK: [[F:%[0-9]+]] = hl.funcref @foo : !hl.lvalue<!core.fn<() -> (!hl.void)>>
+    // CHECK: [[F:%[0-9]+]] = hl.funcref @foo : !core.fn<() -> (!hl.void)>
     foo;
 
     // CHECK: hl.implicit_cast [[F]] FunctionToPointerDecay

--- a/test/vast/Dialect/HighLevel/ternary-a.c
+++ b/test/vast/Dialect/HighLevel/ternary-a.c
@@ -4,37 +4,37 @@ typedef int INT;
 typedef INT INT2;
 
 int fun1(int arg1, double arg2) {
-    // CHECK: hl.cond {
+    // CHECK: hl.cond : !hl.double {
     // CHECK: hl.cond.yield [[X:%[0-9]+]] : !hl.int
     // CHECK: } ? {
     // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.double
     // CHECK: } : {
     // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.double
-    // CHECK: } : !hl.double
+    // CHECK: }
     int res = arg1 ? arg2 : arg1;
     return res;
 }
 
 INT2 fun2(INT2 arg1, INT arg2) {
-    // CHECK: hl.cond {
+    // CHECK: hl.cond : !hl.elaborated<!hl.typedef<"INT">> {
     // CHECK: hl.cond.yield [[X:%[0-9]+]] : !hl.elaborated<!hl.typedef<"INT2">>
     // CHECK: } ? {
     // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.elaborated<!hl.typedef<"INT">>
     // CHECK: } : {
     // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.elaborated<!hl.typedef<"INT2">>
-    // CHECK: } : !hl.elaborated<!hl.typedef<"INT">>
+    // CHECK: }
     INT res = arg1 ? arg2 : arg1;
     return res;
 }
 
 void* fun3(INT2 arg1, INT arg2) {
-    // CHECK: hl.cond {
+    // CHECK: hl.cond : !hl.ptr<!hl.elaborated<!hl.typedef<"INT">>> {
     // CHECK: hl.cond.yield [[X:%[0-9]+]] : !hl.elaborated<!hl.typedef<"INT2">>
     // CHECK: } ? {
     // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.ptr<!hl.elaborated<!hl.typedef<"INT">>>
     // CHECK: } : {
     // CHECK: hl.value.yield [[X:%[0-9]+]] : !hl.ptr<!hl.elaborated<!hl.typedef<"INT2">>>
-    // CHECK: } : !hl.ptr<!hl.elaborated<!hl.typedef<"INT">>>
+    // CHECK: }
     void* res = arg1 ? &arg2 : &arg1;
     return res;
 }


### PR DESCRIPTION
I have also made a small change to `condop` type for the sake of readability and testability.