### PR TITLE
Allow vast-repl to run Clang static analyses.

### DIFF
--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -67,6 +67,15 @@ namespace vast::repl
             throw_error("uknnown action kind: {0}", token.str());
         }
 
+        enum class analyze_kind { RC, UV };
+
+        template< typename enum_type >
+        enum_type from_string(string_ref token) requires(std::is_same_v< enum_type, analyze_kind >) {
+            if (token == "RC") return enum_type::RC;
+            if (token == "UV") return enum_type::UV;
+            throw_error("uknnown analyze kind: {0}", token.str());
+        }
+
         //
         // named param
         //
@@ -186,6 +195,28 @@ namespace vast::repl
         };
 
         //
+        // analyze command
+        //
+        struct analyze : base {
+            static constexpr string_ref name() { return "analyze"; }
+
+            static constexpr inline char analyzes_param[] = "analyze_name";
+
+            using command_params = util::type_list<
+                named_param< analyzes_param, analyze_kind >
+            >;
+
+            using params_storage = command_params::as_tuple;
+
+            analyze(const params_storage &params) : params(params) {}
+            analyze(params_storage &&params) : params(std::move(params)) {}
+
+            void run(state_t &state) const override;
+
+            params_storage params;
+        };
+
+        //
         // meta command
         //
         struct meta : base {
@@ -255,7 +286,7 @@ namespace vast::repl
 
         void add_sticky_command(string_ref cmd, state_t &state);
 
-        using command_list = util::type_list< exit, help, load, show, meta, raise, sticky >;
+        using command_list = util::type_list< exit, help, load, show, analyze, meta, raise, sticky >;
 
     } // namespace cmd
 

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -67,13 +67,16 @@ namespace vast::repl
             throw_error("uknnown action kind: {0}", token.str());
         }
 
-        enum class analyze_kind { RC, UV };
+        void analyze_reachable_code(state_t &);
+        void analyze_uninitialized_variables(state_t &);
 
-        template< typename enum_type >
-        enum_type from_string(string_ref token) requires(std::is_same_v< enum_type, analyze_kind >) {
-            if (token == "RC") return enum_type::RC;
-            if (token == "UV") return enum_type::UV;
-            throw_error("uknnown analyze kind: {0}", token.str());
+        using analyze_func = llvm::function_ref< void(state_t &) >;
+
+        template< typename func_type >
+        func_type from_string(string_ref token) requires(std::is_same_v< analyze_func, func_type >) {
+            if (token == "reachable") return analyze_reachable_code;
+            if (token == "uninit")    return analyze_uninitialized_variables;
+            throw_error("unknown analyze kind: {0}", token.str());
         }
 
         //

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -109,7 +109,8 @@ namespace vast::repl
             }
 
             static constexpr bool is_enum_param = std::is_enum_v< base >;
-            static named_param parse(string_ref token) requires(is_enum_param) {
+            static constexpr bool is_func_param = std::is_same_v< base, analyze_func >;
+            static named_param parse(string_ref token) requires(is_enum_param || is_func_param) {
                 return { .value = from_string< base >(token) };
             }
 

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -208,8 +208,8 @@ namespace vast::repl
 
             using params_storage = command_params::as_tuple;
 
-            analyze(const params_storage &params) : params(params) {}
-            analyze(params_storage &&params) : params(std::move(params)) {}
+            explicit analyze(const params_storage &params) : params(params) {}
+            explicit analyze(params_storage &&params) : params(std::move(params)) {}
 
             void run(state_t &state) const override;
 

--- a/include/vast/repl/command.hpp
+++ b/include/vast/repl/command.hpp
@@ -50,11 +50,11 @@ namespace vast::repl
 
         template< typename enum_type >
         enum_type from_string(string_ref token) requires(std::is_same_v< enum_type, show_kind >) {
-            if (token == "source")  return enum_type::source;
-            if (token == "ast")     return enum_type::ast;
-            if (token == "module")  return enum_type::module;
-            if (token == "symbols") return enum_type::symbols;
-            if (token == "pipelines")   return enum_type::pipelines;
+            if (token == "source")    return enum_type::source;
+            if (token == "ast")       return enum_type::ast;
+            if (token == "module")    return enum_type::module;
+            if (token == "symbols")   return enum_type::symbols;
+            if (token == "pipelines") return enum_type::pipelines;
             throw_error("uknnown show kind: {0}", token.str());
         }
 
@@ -200,10 +200,10 @@ namespace vast::repl
         struct analyze : base {
             static constexpr string_ref name() { return "analyze"; }
 
-            static constexpr inline char analyzes_param[] = "analyze_name";
+            static constexpr inline char analysis_param[] = "analysis_name";
 
             using command_params = util::type_list<
-                named_param< analyzes_param, analyze_kind >
+                named_param< analysis_param, analyze_func >
             >;
 
             using params_storage = command_params::as_tuple;

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -110,6 +110,25 @@ namespace cmd {
     };
 
     //
+    // analyze command
+    //
+    void analyze_reachable_code(state_t &state) {
+        llvm::outs() << "run reachable code analysis\n";
+    }
+
+    void analyze_uninitialized_variables(state_t &state) {
+        llvm::outs() << "run uninitialized variables analysis\n";
+    }
+
+    void analyze::run(state_t &state) const {
+        auto what = get_param< analyzes_param >(params);
+        switch (what) {
+            case analyze_kind::RC: return analyze_reachable_code(state);
+            case analyze_kind::UV: return analyze_uninitialized_variables(state);
+        }
+    }
+
+    //
     // meta command
     //
     void meta::add(state_t &state) const {

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -101,10 +101,10 @@ namespace cmd {
     void show::run(state_t &state) const {
         auto what = get_param< kind_param >(params);
         switch (what) {
-            case show_kind::source:  return show_source(state);
-            case show_kind::ast:     return show_ast(state);
-            case show_kind::module:  return show_module(state);
-            case show_kind::symbols: return show_symbols(state);
+            case show_kind::source:    return show_source(state);
+            case show_kind::ast:       return show_ast(state);
+            case show_kind::module:    return show_module(state);
+            case show_kind::symbols:   return show_symbols(state);
             case show_kind::pipelines: return show_pipelines(state);
         }
     };

--- a/tools/vast-repl/command.cpp
+++ b/tools/vast-repl/command.cpp
@@ -121,10 +121,11 @@ namespace cmd {
     }
 
     void analyze::run(state_t &state) const {
-        auto what = get_param< analyzes_param >(params);
-        switch (what) {
-            case analyze_kind::RC: return analyze_reachable_code(state);
-            case analyze_kind::UV: return analyze_uninitialized_variables(state);
+        if (auto func = get_param< analysis_param >(params)) {
+            func(state);
+        }
+        else {
+            throw_error("not enough arguments");
         }
     }
 


### PR DESCRIPTION
Add a template for running clang static analysis in vast-repl.