### PR TITLE
Fix type verification when TypeOf type is involved

### DIFF
--- a/docs/Tools/vast-front.md
+++ b/docs/Tools/vast-front.md
@@ -47,7 +47,7 @@ Additional customization options include:
   - Prints operations in diagnostics.
   - Prints MLIR stack trace in diagnostics.
 
-- `-vast-disable-vast-verifier`
+- `-vast-disable-verifier`
   - Skips verification of the produced VAST MLIR module.
 
 - `vast-snapshot-at="pass1;...;passN`

--- a/include/vast/Dialect/HighLevel/HighLevelTypes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.td
@@ -189,9 +189,13 @@ class ContainsTypedef< list< string > tl > : PredOpTrait< "contains typedef type
     Or< !foreach(type, tl, IsMaybeWrappedTypedef< type >.predicate) >
 >;
 
+class ContainsTypeOf< list< string > tl > : PredOpTrait< "contains typeof type",
+    Or< !foreach(type, tl, IsTypeOf< type >.predicate) >
+>;
+
 class TypesMatchOrTypedef< list< string > tl > : PredOpTrait<
     "all types match or there is a typedef",
-    Or< [AllTypesMatch< tl >.predicate, ContainsTypedef< tl >.predicate ] >
+    Or< [AllTypesMatch< tl >.predicate, ContainsTypedef< tl >.predicate, ContainsTypeOf< tl >.predicate ] >
 >;
 
 class TypeWithSubType<string name, string mnem> : HighLevelType< name,

--- a/include/vast/Frontend/Options.hpp
+++ b/include/vast/Frontend/Options.hpp
@@ -96,7 +96,7 @@ namespace vast::cc
 
         constexpr option_t disable_unsupported = "disable-unsupported";
 
-        constexpr option_t disable_vast_verifier = "disable-vast-verifier";
+        constexpr option_t disable_vast_verifier = "disable-verifier";
         constexpr option_t vast_verify_diags = "verify-diags";
         constexpr option_t disable_emit_cxx_default = "disable-emit-cxx-default";
 

--- a/lib/vast/Frontend/Pipelines.cpp
+++ b/lib/vast/Frontend/Pipelines.cpp
@@ -191,6 +191,8 @@ namespace vast::cc {
             passes->enableCrashReproducerGeneration(reproducer_path.value(), true /* local reproducer */);
         }
 
+        passes->enableVerifier(!vargs.has_option(cc::opt::disable_vast_verifier));
+
         return passes;
     }
 

--- a/test/vast/Dialect/HighLevel/typeof-d.c
+++ b/test/vast/Dialect/HighLevel/typeof-d.c
@@ -1,0 +1,11 @@
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
+
+int main(void) {
+    int a;
+    __typeof__(int) y = 0;
+    // CHECK: hl.add {{.*}} (!hl.typeof.type<!hl.int>, !hl.int)
+    __typeof__(0) x = y + 0;
+    // CHECK: hl.add {{.*}} (!hl.int, !hl.typeof.expr<"(0)">)
+    return 1 + x;
+}


### PR DESCRIPTION
Fix #645 
I have also fixed the `-vast-disable-verifier` option (renamed form `vast-disable-vast-verifier`), so that it also applies to passes - since even emitting `hl` requires us to run a pass, it was virtually useless