### PR TITLE
Fix array subscript operator when an enum typed variable is used

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelTypes.td
+++ b/include/vast/Dialect/HighLevel/HighLevelTypes.td
@@ -289,7 +289,8 @@ def HLIntegerType : AnyTypeOf<[
 
 def IntegerLikeType : TypeConstraint<
   Or< [HLIntegerType.predicate, AnyInteger.predicate,
-       IsMaybeWrappedTypedef< "_self" >.predicate] >,
+       IsMaybeWrappedTypedef< "_self" >.predicate,
+       ElaboratedType<EnumType>.predicate] >,
   "integer like type"
 >;
 

--- a/test/vast/Dialect/HighLevel/subscript-a.c
+++ b/test/vast/Dialect/HighLevel/subscript-a.c
@@ -1,0 +1,11 @@
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
+
+enum FOO { BAR };
+
+int main(void) {
+    int a[1]   = { 0 };
+    enum FOO b = BAR;
+    // CHECK: hl.subscript {{%[0-9]+}} at [{{%[0-9]+}} : !hl.elaborated<!hl.enum<"FOO">>]
+    return a[b];
+}


### PR DESCRIPTION
Fix #648 