### PR TITLE
Add steps to run vast-front on Linux kernel

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -413,6 +413,7 @@ jobs:
         with:
           pattern: vast_linux_kernel_times_*
           merge-multiple: true
+
       - name: Install converter dependencies
         run: pip3 install pandas scipy tabulate
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -336,10 +336,13 @@ jobs:
      - name: Export vast binaries
        run: echo "${PWD}/vast/bin/" >> $GITHUB_PATH
 
-     - name: Install benchmark dependencies
-       run: |
+    - name: Install benchmark dependencies
+      run: |
           apt-get update
-          apt-get -y install bear
+          apt-get -y install git fakeroot build-essential \
+            ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison \
+            bear \
+            apt-get -y install lld-${{ matrix.llvm-version }}
 
      - name: Clone the Linux kernel and build it to create compiliation database
        run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -355,11 +355,11 @@ jobs:
      - name: Clone vast benchmark directory
        uses: actions/checkout@v4
        with:
-         repository: trailofbits/vast-benchmarks
-         sparse-checkout: benchmarks/linux_kernel
-         ref: main
-         path: .
-         fetch-depth: 1
+          repository: trailofbits/vast-benchmarks
+          sparse-checkout: benchmarks/linux_kernel
+          ref: linux-benchmark-make-output-optional
+          path: vast-benchmarks/
+          fetch-depth: 1
 
      - name: Run benchmarks
        run: >

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -447,7 +447,7 @@ jobs:
         image-version: [22.04]
     name: "Build VAST doc"
     runs-on: ubuntu-${{ matrix.image-version }}
-    needs: [eval_llvm_ts, eval_svcomp]
+    needs: [eval_llvm_ts, eval_svcomp, convert_linux_kernel_bench]
     timeout-minutes: 60
     container:
       image:
@@ -482,6 +482,12 @@ jobs:
         with:
           name: sv-comp-results
           path: sv-comp-results
+
+      - name: Fetch Linux kernel benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: linux_kernel_times.md
+          path: linux_kernel_times
 
       - name: Build Pages
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -400,6 +400,43 @@ jobs:
           path: .
           name: vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
 
+  convert_linux_kernel_bench:
+    name: "Convert Linux Kernel benchmark results to Markdown"
+    needs: run_linux_kernel_bench
+    strategy:
+      matrix:
+        image-version: [22.04]
+    runs-on: ubuntu-${{ matrix.image-version }}
+    steps:
+      - name: Fetch result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vast_linux_kernel_times_*
+
+      - name: Install converter dependencies
+        run: pip3 install pandas scipy tabulate
+
+      - name: Clone vast benchmark directory
+        uses: actions/checkout@v4
+        with:
+          repository: trailofbits/vast-benchmarks
+          sparse-checkout: utils/
+          ref: extend_converter_to_multiple_files
+          path: vast-benchmarks/
+          fetch-depth: 1
+
+      - name: Generate the results
+        run: >
+          python3 vast-benchmarks/utils/to_markdown.py \
+          '{ "VAST with unsupported": "vast_linux_kernel_times_with_unsup.tsv", "VAST without unsupported" : "vast_linux_kernel_times_without_unsup.tsv" }'
+          --output_filepath linux_kernel_times.md
+
+      - name: Post results as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux_kernel_times.md
+          path: ./linux_kernel_times.md
+
 #
 #     Webpage build
 #

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -360,7 +360,7 @@ jobs:
          vast_linux_kernel_mlir_with_unsup/
          --num_processes=8
          --vast_option="-xc"
-         --vast_option="-vast-emit-mlir=hl"
+         --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
          > vast_linux_kernel_times_hl_with_unsup.tsv
 
 #

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -361,7 +361,16 @@ jobs:
           path: vast-benchmarks/
           fetch-depth: 1
 
+      - name: Setup result suffix
+        run: |
+          if [ "${{ matrix.disable-unsup }}" = "false" ]; then
+            echo "VAST_RESULTS_SUFFIX=with_unsup" >> $GITHUB_ENV
+          else; do
+            echo "VAST_RESULTS_SUFFIX=without_unsup" >> $GITHUB_ENV
+          fi
+
       - name: Run benchmarks
+        if: ${{ !matrix.disable-unsup }}
         run: >
           python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
           vast-front
@@ -370,7 +379,26 @@ jobs:
           --vast_option="-xc"
           --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
           --print_errors
-          > vast_linux_kernel_times_hl_with_unsup.tsv
+          > vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
+
+      - name: Run benchmarks without unsupported
+        if: ${{ matrix.disable-unsup }}
+        run: >
+          python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
+          vast-front
+          ${PWD}/linux/compile_commands.json
+          --num_processes=$(nproc)
+          --vast_option="-xc"
+          --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
+          --vast_option="-vast-disable-unsupported"
+          --print_errors
+          > vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          path: .
+          name: vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
 
 #
 #     Webpage build

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -412,7 +412,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: vast_linux_kernel_times_*
-
+          merge-multiple: true
       - name: Install converter dependencies
         run: pip3 install pandas scipy tabulate
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -361,16 +361,16 @@ jobs:
           path: vast-benchmarks/
           fetch-depth: 1
 
-      - name: Setup result suffix
+      - name: Setup result suffix and vast arguments
         run: |
           if [ "${{ matrix.disable-unsup }}" = "false" ]; then
             echo "VAST_RESULTS_SUFFIX=with_unsup" >> $GITHUB_ENV
+            echo "VAST_DISABLE_UNSUPPORTED=-vast-disable-unsupported" >> $GITHUB_ENV
           else
             echo "VAST_RESULTS_SUFFIX=without_unsup" >> $GITHUB_ENV
           fi
 
       - name: Run benchmarks
-        if: ${{ !matrix.disable-unsup }}
         run: >
           python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
           vast-front
@@ -378,19 +378,7 @@ jobs:
           --num_processes=$(nproc)
           --vast_option="-xc"
           --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
-          --print_errors
-          > vast_linux_kernel_times_${{ matrix.vast-target }}_${{ env.VAST_RESULTS_SUFFIX }}.tsv
-
-      - name: Run benchmarks without unsupported
-        if: ${{ matrix.disable-unsup }}
-        run: >
-          python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
-          vast-front
-          ${PWD}/linux/compile_commands.json
-          --num_processes=$(nproc)
-          --vast_option="-xc"
-          --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
-          --vast_option="-vast-disable-unsupported"
+          --vast_option="${{ env.VAST_DISABLE_UNSUPPORTED }}"
           --print_errors
           > vast_linux_kernel_times_${{ matrix.vast-target }}_${{ env.VAST_RESULTS_SUFFIX }}.tsv
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -343,12 +343,18 @@ jobs:
          && make defconfig
          && bear -- make LLVM=1
 
-     - name: Download the benchmark runner
-       run: wget https://raw.githubusercontent.com/PappasBrent/vast-benchmarks/add-linux-kernel-benchmark/benchmarks/linux_kernel/run_vast_benchmark.py -O run_vast_benchmark.py
+     - name: Clone vast benchmark directory
+       uses: actions/checkout@v4
+       with:
+         repository: trailofbits/vast-benchmarks
+         sparse-checkout: benchmarks/linux_kernel
+         ref: main
+         path: .
+         fetch-depth: 1
 
      - name: Run benchmarks
        run: >
-         python3 run_vast_benchmark.py
+         python3 benchmarks/linux_kernel/run_vast_benchmark.py
          vast-front # TODO: Determine if this is the correct path to vast-front
          linux/compile_commands.json
          vast_linux_kernel_mlir_with_unsup/

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -342,7 +342,7 @@ jobs:
           apt-get -y install git fakeroot build-essential \
             ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison \
             bear \
-            apt-get -y install lld-${{ matrix.llvm-version }}
+            lld-${{ matrix.llvm-version }}
 
      - name: Clone and build the Linux kernel to create a compilation database
        run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -336,12 +336,17 @@ jobs:
      - name: Export vast binaries
        run: echo "${PWD}/vast/bin/" >> $GITHUB_PATH
 
+     - name: Install benchmark dependencies
+       run: |
+          apt-get update
+          apt-get -y install bear
+
      - name: Clone the Linux kernel and build it to create compiliation database
-       run: >
+       run: |
          git clone --depth=1 https://github.com/torvalds/linux.git linux
-         && cd linux
-         && make defconfig
-         && bear -- make LLVM=1
+         cd linux
+         make defconfig
+         bear -- make LLVM=1
 
      - name: Clone vast benchmark directory
        uses: actions/checkout@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Generate the results
         run: >
           python3 vast-benchmarks/utils/to_markdown.py \
-          '{ "VAST with unsupported": "vast_linux_kernel_times_hl_with_unsup.tsv", "VAST without unsupported" : "vast_linux_kernel_times_hl_without_unsup.tsv" }'
+          '{ "HighLevel with unsupported": "vast_linux_kernel_times_hl_with_unsup.tsv", "HighLevel" : "vast_linux_kernel_times_hl_without_unsup.tsv" }'
           --output_filepath linux_kernel_times.md
 
       - name: Post results as artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -365,7 +365,7 @@ jobs:
         run: |
           if [ "${{ matrix.disable-unsup }}" = "false" ]; then
             echo "VAST_RESULTS_SUFFIX=with_unsup" >> $GITHUB_ENV
-          else; do
+          else
             echo "VAST_RESULTS_SUFFIX=without_unsup" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -363,14 +363,14 @@ jobs:
 
      - name: Run benchmarks
        run: >
-         python3 benchmarks/linux_kernel/run_vast_benchmark.py
-         vast-front # TODO: Determine if this is the correct path to vast-front
-         linux/compile_commands.json
-         vast_linux_kernel_mlir_with_unsup/
-         --num_processes=8
-         --vast_option="-xc"
-         --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
-         > vast_linux_kernel_times_hl_with_unsup.tsv
+         python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
+          vast-front
+          ${PWD}/linux/compile_commands.json
+          --num_processes=$(nproc)
+          --vast_option="-xc"
+          --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
+          --print_errors
+          > vast_linux_kernel_times_hl_with_unsup.tsv
 
 #
 #     Webpage build

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -325,45 +325,45 @@ jobs:
         ghcr.io/trailofbits/vast-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev:latest
 
     steps:
-     - name: Fetch VAST artifact
-       uses: actions/download-artifact@v4
-       with:
-         name: VAST
+      - name: Fetch VAST artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: VAST
 
-     - name: Unpack VAST
-       run: mkdir vast && tar -xf VAST-* -C vast --strip-components=1
+      - name: Unpack VAST
+        run: mkdir vast && tar -xf VAST-* -C vast --strip-components=1
 
-     - name: Export vast binaries
-       run: echo "${PWD}/vast/bin/" >> $GITHUB_PATH
+      - name: Export vast binaries
+        run: echo "${PWD}/vast/bin/" >> $GITHUB_PATH
 
-    - name: Install benchmark dependencies
-      run: |
+      - name: Install benchmark dependencies
+        run: |
           apt-get update
           apt-get -y install git fakeroot build-essential \
             ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison \
             bear \
             lld-${{ matrix.llvm-version }}
 
-     - name: Clone and build the Linux kernel to create a compilation database
-       run: |
+      - name: Clone and build the Linux kernel to create a compilation database
+        run: |
           git clone --depth=1 https://github.com/torvalds/linux.git linux
           cd linux
           bear -- make defconfig
           bear -- make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
           cd ../
 
-     - name: Clone vast benchmark directory
-       uses: actions/checkout@v4
-       with:
+      - name: Clone vast benchmark directory
+        uses: actions/checkout@v4
+        with:
           repository: trailofbits/vast-benchmarks
           sparse-checkout: benchmarks/linux_kernel
           ref: linux-benchmark-make-output-optional
           path: vast-benchmarks/
           fetch-depth: 1
 
-     - name: Run benchmarks
-       run: >
-         python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
+      - name: Run benchmarks
+        run: >
+          python3 ${PWD}/vast-benchmarks/benchmarks/linux_kernel/run_vast_benchmark.py
           vast-front
           ${PWD}/linux/compile_commands.json
           --num_processes=$(nproc)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -421,7 +421,7 @@ jobs:
         with:
           repository: trailofbits/vast-benchmarks
           sparse-checkout: utils/
-          ref: extend_converter_to_multiple_files
+          ref: main
           path: vast-benchmarks/
           fetch-depth: 1
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -379,7 +379,7 @@ jobs:
           --vast_option="-xc"
           --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
           --print_errors
-          > vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
+          > vast_linux_kernel_times_${{ matrix.vast-target }}_${{ env.VAST_RESULTS_SUFFIX }}.tsv
 
       - name: Run benchmarks without unsupported
         if: ${{ matrix.disable-unsup }}
@@ -392,13 +392,13 @@ jobs:
           --vast_option="-vast-emit-mlir=${{ matrix.vast-target }}"
           --vast_option="-vast-disable-unsupported"
           --print_errors
-          > vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
+          > vast_linux_kernel_times_${{ matrix.vast-target }}_${{ env.VAST_RESULTS_SUFFIX }}.tsv
 
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          path: .
-          name: vast_linux_kernel_times_${{ matrix.vast-target }}${{ env.VAST_RESULTS_SUFFIX }}.tsv
+          name: vast_linux_kernel_times_${{ matrix.vast-target }}_${{ env.VAST_RESULTS_SUFFIX }}.tsv
+          path: ./vast_linux_kernel_times_${{ matrix.vast-target }}_${{ env.VAST_RESULTS_SUFFIX }}.tsv
 
   convert_linux_kernel_bench:
     name: "Convert Linux Kernel benchmark results to Markdown"
@@ -428,7 +428,7 @@ jobs:
       - name: Generate the results
         run: >
           python3 vast-benchmarks/utils/to_markdown.py \
-          '{ "VAST with unsupported": "vast_linux_kernel_times_with_unsup.tsv", "VAST without unsupported" : "vast_linux_kernel_times_without_unsup.tsv" }'
+          '{ "VAST with unsupported": "vast_linux_kernel_times_hl_with_unsup.tsv", "VAST without unsupported" : "vast_linux_kernel_times_hl_without_unsup.tsv" }'
           --output_filepath linux_kernel_times.md
 
       - name: Post results as artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -304,6 +304,59 @@ jobs:
         with:
           name: sv-comp-results
           path: ./sv-comp-results.md
+
+#
+#     Linux kernel benchmark
+#
+  run_linux_kernel_bench:
+    name: "Run Linux kernel test suite"
+    needs: build
+    strategy:
+      matrix:
+        llvm-version: [18]
+        image-version: [22.04]
+        vast-target: ['hl']
+        disable-unsup: [true, false]
+
+    runs-on: ubuntu-${{ matrix.image-version }}
+    timeout-minutes: 360
+    container:
+      image:
+        ghcr.io/trailofbits/vast-ubuntu-${{ matrix.image-version }}-llvm-${{ matrix.llvm-version }}-dev:latest
+
+    steps:
+     - name: Fetch VAST artifact
+       uses: actions/download-artifact@v4
+       with:
+         name: VAST
+
+     - name: Unpack VAST
+       run: mkdir vast && tar -xf VAST-* -C vast --strip-components=1
+
+     - name: Export vast binaries
+       run: echo "${PWD}/vast/bin/" >> $GITHUB_PATH
+
+     - name: Clone the Linux kernel and build it to create compiliation database
+       run: >
+         git clone --depth=1 https://github.com/torvalds/linux.git linux
+         && cd linux
+         && make defconfig
+         && bear -- make LLVM=1
+
+     - name: Download the benchmark runner
+       run: wget https://raw.githubusercontent.com/PappasBrent/vast-benchmarks/add-linux-kernel-benchmark/benchmarks/linux_kernel/run_vast_benchmark.py -O run_vast_benchmark.py
+
+     - name: Run benchmarks
+       run: >
+         python3 run_vast_benchmark.py
+         vast-front # TODO: Determine if this is the correct path to vast-front
+         linux/compile_commands.json
+         vast_linux_kernel_mlir_with_unsup/
+         --num_processes=8
+         --vast_option="-xc"
+         --vast_option="-vast-emit-mlir=hl"
+         > vast_linux_kernel_times_hl_with_unsup.tsv
+
 #
 #     Webpage build
 #

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -344,12 +344,13 @@ jobs:
             bear \
             apt-get -y install lld-${{ matrix.llvm-version }}
 
-     - name: Clone the Linux kernel and build it to create compiliation database
+     - name: Clone and build the Linux kernel to create a compilation database
        run: |
-         git clone --depth=1 https://github.com/torvalds/linux.git linux
-         cd linux
-         make defconfig
-         bear -- make LLVM=1
+          git clone --depth=1 https://github.com/torvalds/linux.git linux
+          cd linux
+          bear -- make defconfig
+          bear -- make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
+          cd ../
 
      - name: Clone vast benchmark directory
        uses: actions/checkout@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -357,7 +357,7 @@ jobs:
         with:
           repository: trailofbits/vast-benchmarks
           sparse-checkout: benchmarks/linux_kernel
-          ref: linux-benchmark-make-output-optional
+          ref: main
           path: vast-benchmarks/
           fetch-depth: 1
 

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Benchmarks:
     - LLVM Single Source: Benchmarks/single-source-results.md
     - SV-Comp: Benchmarks/sv-comp-results.md
+    - Linux Kernel: Benchmarks/linux_kernel_times.md
   - About:
     - 'License': 'statement.md'
 

--- a/www/setup.sh
+++ b/www/setup.sh
@@ -49,6 +49,7 @@ fi
 
 cp -rv $(pwd)/llvm-test-suite-results/single-source-results.md $dst/docs/Benchmarks/
 cp -rv $(pwd)/sv-comp-results/sv-comp-results.md $dst/docs/Benchmarks/
+cp -rv $(pwd)/linux_kernel_times/linux_kernel_times.md $dst/docs/Benchmarks/
 
 # Setup site assets
 cp -rv $(pwd)/www/assets $dst


### PR DESCRIPTION
Add steps to download, configure, and build the Linux kernel; run vast-front on its compilation units; and tabulate the results.