### PR TITLE
Generate Linux compile commands, don't intercept with bear

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -347,7 +347,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/torvalds/linux.git linux
           cd linux
-          make defconfig
+          make defconfig LLVM=-${{ matrix.llvm-version }}
           make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
           python3 ./scripts/clang-tools/gen_compile_commands.py
           cd ../

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -348,6 +348,7 @@ jobs:
           git clone --depth=1 https://github.com/torvalds/linux.git linux
           cd linux
           make defconfig LLVM=-${{ matrix.llvm-version }}
+          make prepare LLVM=-${{ matrix.llvm-version }}
           make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
           python3 ./scripts/clang-tools/gen_compile_commands.py
           cd ../

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Clone, configure, and build the Linux kernel
         run: |
-          git clone --depth=1 https://github.com/torvalds/linux.git linux
+          git clone https://github.com/torvalds/linux.git --depth=1 --branch=v6.10 linux
           cd linux
           make defconfig LLVM=-${{ matrix.llvm-version }}
           make prepare LLVM=-${{ matrix.llvm-version }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -341,15 +341,15 @@ jobs:
           apt-get update
           apt-get -y install git fakeroot build-essential \
             ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison \
-            bear \
             lld-${{ matrix.llvm-version }}
 
-      - name: Clone and build the Linux kernel to create a compilation database
+      - name: Clone, configure, and build the Linux kernel
         run: |
           git clone --depth=1 https://github.com/torvalds/linux.git linux
           cd linux
-          bear -- make defconfig
-          bear -- make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
+          make defconfig
+          make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
+          python3 ./scripts/clang-tools/gen_compile_commands.py
           cd ../
 
       - name: Clone vast benchmark directory

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -351,7 +351,6 @@ jobs:
           make prepare LLVM=-${{ matrix.llvm-version }}
           make LLVM=-${{ matrix.llvm-version }} -j $(nproc)
           python3 ./scripts/clang-tools/gen_compile_commands.py
-          cd ../
 
       - name: Clone vast benchmark directory
         uses: actions/checkout@v4


### PR DESCRIPTION
- Generate Linux compile commands with the `gen_compile_commands.py` script instead of using `bear` to do so since `bear`'s output does not handle single quotes in command-line macro definitions.
- Add `make prepare` step when building the Linux kernel.
- Checkout Linux v6.10 specifically to improve reproducibility.