### PR TITLE
Fix function linkage verifier

### DIFF
--- a/include/vast/Dialect/Core/Func.hpp
+++ b/include/vast/Dialect/Core/Func.hpp
@@ -28,8 +28,12 @@ namespace vast::core {
 
         auto optional_linkage = op.getLinkage();
         if (!optional_linkage) {
-            return op.emitOpError() << "function without a linkage";
+            // Definiton might be in other TU, we do not have linkage
+            return op.isDeclaration() ? mlir::success()
+                                      : op.emitOpError() <<
+                                        "function definition with unknown linkage";
         }
+
         auto linkage = optional_linkage.value();
         constexpr auto common = GlobalLinkageKind::CommonLinkage;
         if (linkage == common) {
@@ -54,7 +58,6 @@ namespace vast::core {
         }
         return mlir::success();
     }
-
 
     ParseResult parseFunctionSignatureAndBody(
         Parser &parser, Attribute &funcion_type,

--- a/include/vast/Dialect/Core/Func.hpp
+++ b/include/vast/Dialect/Core/Func.hpp
@@ -72,6 +72,8 @@ namespace vast::core {
     ) {
         if (auto linkage = op.getLinkage()) {
             printer << stringifyGlobalLinkageKind(linkage.value()) << ' ';
+        } else {
+            printer << "unknown ";
         }
 
         auto fty = op.getFunctionType();

--- a/lib/vast/Dialect/Core/Func.cpp
+++ b/lib/vast/Dialect/Core/Func.cpp
@@ -40,7 +40,10 @@ namespace vast::core
         llvm::SmallVector< Type, 4 > result_types;
 
         // Default to external linkage if no keyword is provided.
-        if (!attr_dict.getNamed(getLinkageAttrNameString())) {
+        // If linkage is unknown, skip adding the attribute
+        if (!attr_dict.getNamed(getLinkageAttrNameString()) &&
+            mlir::failed(parser.parseOptionalKeyword("unknown")))
+        {
             attr_dict.append(
                 getLinkageAttrNameString(),
                 core::GlobalLinkageKindAttr::get(

--- a/test/vast/Dialect/HighLevel/linkage-a.c
+++ b/test/vast/Dialect/HighLevel/linkage-a.c
@@ -39,3 +39,6 @@ inline void waldo(void) {}
 inline void fred(void);
 inline extern void fred(void);
 inline void fred(void) {}
+
+// CHECK: hl.func @plugh unknown{{.*}}{sym_visibility = "private"}
+inline extern void plugh(void);


### PR DESCRIPTION
Cases when function declaration (without definition) has an unknown linkage are valid because of `inline` specified declarations.