### PR TITLE
Add codegen policy

### DIFF
--- a/docs/GettingStarted/integration.md
+++ b/docs/GettingStarted/integration.md
@@ -158,7 +158,7 @@ auto visitors = std::make_shared<visitor_list>()
     | as_node_with_list_ref<attr_visitor_proxy>()
     | as_node<type_caching_proxy>()
     | as_node_with_list_ref<default_visitor>(
-        mctx, actx, *bld, std::move(mg), std::move(sg), strict_return, missing_return_policy
+        mctx, actx, *bld, std::move(mg), std::move(sg), std::move(policy)
     )
     | optional(enable_unsupported, as_node_with_list_ref<unsup_visitor>(*mctx, *bld))
     | as_node<unreach_visitor>();

--- a/include/vast/CodeGen/CodeGenFunction.hpp
+++ b/include/vast/CodeGen/CodeGenFunction.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "vast/CodeGen/CodeGenPolicy.hpp"
 #include "vast/Util/Common.hpp"
 
 #include "vast/CodeGen/CodeGenBuilder.hpp"
@@ -10,12 +11,11 @@
 #include "vast/CodeGen/ScopeContext.hpp"
 
 #include "vast/Dialect/HighLevel/HighLevelOps.hpp"
+#include <memory>
 
 namespace vast::cg {
 
     struct module_context;
-
-    enum class missing_return_policy { emit_unreachable, emit_trap };
 
     mlir_visibility get_function_visibility(const clang_function *decl, linkage_kind linkage);
     vast_function set_visibility(const clang_function *decl, vast_function fn);
@@ -46,8 +46,7 @@ namespace vast::cg {
         void emit_implicit_return_zero(const clang_function *decl);
         void emit_implicit_void_return(const clang_function *decl);
 
-        bool emit_strict_function_return;
-        missing_return_policy missing_return_policy;
+        std::shared_ptr< policy_base > policy;
     };
 
     //

--- a/include/vast/CodeGen/CodeGenFunction.hpp
+++ b/include/vast/CodeGen/CodeGenFunction.hpp
@@ -46,7 +46,7 @@ namespace vast::cg {
         void emit_implicit_return_zero(const clang_function *decl);
         void emit_implicit_void_return(const clang_function *decl);
 
-        std::shared_ptr< policy_base > policy;
+        std::shared_ptr< codegen_policy > policy;
     };
 
     //

--- a/include/vast/CodeGen/CodeGenPolicy.hpp
+++ b/include/vast/CodeGen/CodeGenPolicy.hpp
@@ -19,6 +19,9 @@ namespace vast::cg {
         missing_return_policy([[maybe_unused]] const clang_function *decl) const = 0;
 
         virtual bool skip_function_body([[maybe_unused]] const clang_function *decl) const = 0;
+
+        virtual bool skip_global_initializer([[maybe_unused]] const clang_var_decl *decl
+        ) const = 0;
     };
 
 } // namespace vast::cg

--- a/include/vast/CodeGen/CodeGenPolicy.hpp
+++ b/include/vast/CodeGen/CodeGenPolicy.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/CodeGen/Common.hpp"
+
+namespace vast::cg {
+
+    enum class missing_return_policy { emit_unreachable, emit_trap };
+
+    struct policy_base
+    {
+        virtual ~policy_base() = default;
+
+        virtual bool emit_strict_function_return([[maybe_unused]] const clang_function *decl
+        ) const = 0;
+
+        virtual missing_return_policy
+        missing_return_policy([[maybe_unused]] const clang_function *decl) const = 0;
+
+        virtual bool skip_function_body([[maybe_unused]] const clang_function *decl) const = 0;
+    };
+
+} // namespace vast::cg

--- a/include/vast/CodeGen/CodeGenPolicy.hpp
+++ b/include/vast/CodeGen/CodeGenPolicy.hpp
@@ -8,20 +8,14 @@ namespace vast::cg {
 
     enum class missing_return_policy { emit_unreachable, emit_trap };
 
-    struct policy_base
+    struct codegen_policy
     {
-        virtual ~policy_base() = default;
+        virtual ~codegen_policy() = default;
 
-        virtual bool emit_strict_function_return([[maybe_unused]] const clang_function *decl
-        ) const = 0;
-
-        virtual missing_return_policy
-        missing_return_policy([[maybe_unused]] const clang_function *decl) const = 0;
-
-        virtual bool skip_function_body([[maybe_unused]] const clang_function *decl) const = 0;
-
-        virtual bool skip_global_initializer([[maybe_unused]] const clang_var_decl *decl
-        ) const = 0;
+        virtual bool emit_strict_function_return(const clang_function *decl) const = 0;
+        virtual missing_return_policy get_missing_return_policy(const clang_function *decl) const = 0;
+        virtual bool skip_function_body(const clang_function *decl) const = 0;
+        virtual bool skip_global_initializer(const clang_var_decl *decl) const = 0;
     };
 
 } // namespace vast::cg

--- a/include/vast/CodeGen/DefaultCodeGenPolicy.hpp
+++ b/include/vast/CodeGen/DefaultCodeGenPolicy.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "vast/CodeGen/CodeGenPolicy.hpp"
+#include "vast/Frontend/Options.hpp"
+
+namespace vast::cg {
+
+    struct default_policy : policy_base
+    {
+        default_policy(cc::action_options &opts)
+            : opts(opts)
+            , default_missing_return(
+                  opts.codegen.OptimizationLevel == 0 ? missing_return_policy::emit_trap
+                                                      : missing_return_policy::emit_unreachable
+              ) {}
+
+        ~default_policy() = default;
+
+        bool emit_strict_function_return([[maybe_unused]] const clang_function *decl
+        ) const override {
+            return opts.codegen.StrictReturn;
+        };
+
+        enum missing_return_policy
+        missing_return_policy([[maybe_unused]] const clang_function *decl) const override {
+            return default_missing_return;
+        }
+
+        bool skip_function_body([[maybe_unused]] const clang_function *decl) const override {
+            return opts.front.SkipFunctionBodies;
+        }
+
+      protected:
+        cc::action_options &opts;
+
+      private:
+        enum missing_return_policy default_missing_return;
+    };
+
+} // namespace vast::cg

--- a/include/vast/CodeGen/DefaultCodeGenPolicy.hpp
+++ b/include/vast/CodeGen/DefaultCodeGenPolicy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "vast/CodeGen/CodeGenPolicy.hpp"
+#include "vast/CodeGen/Common.hpp"
 #include "vast/Frontend/Options.hpp"
 
 namespace vast::cg {
@@ -29,6 +30,11 @@ namespace vast::cg {
         bool skip_function_body([[maybe_unused]] const clang_function *decl) const override {
             return opts.front.SkipFunctionBodies;
         }
+
+        bool skip_global_initializer([[maybe_unused]] const clang_var_decl *decl
+        ) const override {
+            return false;
+        };
 
       protected:
         cc::action_options &opts;

--- a/include/vast/CodeGen/DefaultCodeGenPolicy.hpp
+++ b/include/vast/CodeGen/DefaultCodeGenPolicy.hpp
@@ -6,41 +6,34 @@
 
 namespace vast::cg {
 
-    struct default_policy : policy_base
+    struct default_policy : codegen_policy
     {
         default_policy(cc::action_options &opts)
             : opts(opts)
-            , default_missing_return(
-                  opts.codegen.OptimizationLevel == 0 ? missing_return_policy::emit_trap
-                                                      : missing_return_policy::emit_unreachable
-              ) {}
+        {}
 
         ~default_policy() = default;
 
-        bool emit_strict_function_return([[maybe_unused]] const clang_function *decl
-        ) const override {
+        bool emit_strict_function_return(const clang_function * /* decl */) const override {
             return opts.codegen.StrictReturn;
         };
 
-        enum missing_return_policy
-        missing_return_policy([[maybe_unused]] const clang_function *decl) const override {
-            return default_missing_return;
+        missing_return_policy get_missing_return_policy(const clang_function * /* decl */) const override {
+            return opts.codegen.OptimizationLevel == 0
+                ? missing_return_policy::emit_trap
+                : missing_return_policy::emit_unreachable;
         }
 
-        bool skip_function_body([[maybe_unused]] const clang_function *decl) const override {
+        bool skip_function_body(const clang_function * /* decl */) const override {
             return opts.front.SkipFunctionBodies;
         }
 
-        bool skip_global_initializer([[maybe_unused]] const clang_var_decl *decl
-        ) const override {
+        bool skip_global_initializer(const clang_var_decl * /* decl */) const override {
             return false;
         };
 
       protected:
         cc::action_options &opts;
-
-      private:
-        enum missing_return_policy default_missing_return;
     };
 
 } // namespace vast::cg

--- a/include/vast/CodeGen/DefaultDeclVisitor.hpp
+++ b/include/vast/CodeGen/DefaultDeclVisitor.hpp
@@ -55,7 +55,7 @@ namespace vast::cg {
         template< typename RecordDeclOp >
         operation mk_record_decl(const clang::RecordDecl *decl);
 
-        std::shared_ptr< policy_base > policy;
+        std::shared_ptr< codegen_policy > policy;
     };
 
     template< typename RecordDeclOp >

--- a/include/vast/CodeGen/DefaultDeclVisitor.hpp
+++ b/include/vast/CodeGen/DefaultDeclVisitor.hpp
@@ -2,14 +2,15 @@
 
 #pragma once
 
+#include "vast/CodeGen/CodeGenPolicy.hpp"
 #include "vast/Util/Warnings.hpp"
+#include <memory>
 
 VAST_RELAX_WARNINGS
 #include <clang/AST/DeclVisitor.h>
 VAST_UNRELAX_WARNINGS
 
 #include "vast/CodeGen/ClangVisitorBase.hpp"
-#include "vast/CodeGen/CodeGenFunction.hpp"
 
 #include "vast/CodeGen/CodeGenMetaGenerator.hpp"
 #include "vast/CodeGen/SymbolGenerator.hpp"
@@ -54,8 +55,7 @@ namespace vast::cg {
         template< typename RecordDeclOp >
         operation mk_record_decl(const clang::RecordDecl *decl);
 
-        bool emit_strict_function_return;
-        missing_return_policy missing_return_policy;
+        std::shared_ptr< policy_base > policy;
     };
 
     template< typename RecordDeclOp >

--- a/include/vast/CodeGen/DefaultVisitor.hpp
+++ b/include/vast/CodeGen/DefaultVisitor.hpp
@@ -17,7 +17,7 @@ namespace vast::cg {
         default_visitor(
             visitor_base &head, mcontext_t &mctx, acontext_t &actx, codegen_builder &bld,
             std::shared_ptr< meta_generator > mg, std::shared_ptr< symbol_generator > sg,
-            std::shared_ptr< policy_base > policy
+            std::shared_ptr< codegen_policy > policy
         )
             : mctx(mctx)
             , actx(actx)
@@ -32,8 +32,7 @@ namespace vast::cg {
         mlir_type visit(const clang_type *type, scope_context &scope) override;
         mlir_type visit(clang_qual_type type, scope_context &scope) override;
 
-        std::optional< named_attr >
-        visit(const clang_attr *attr, scope_context &scope) override;
+        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override;
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override;
 
@@ -51,7 +50,7 @@ namespace vast::cg {
 
         std::shared_ptr< meta_generator > mg;
         std::shared_ptr< symbol_generator > sg;
-        std::shared_ptr< policy_base > policy;
+        std::shared_ptr< codegen_policy > policy;
     };
 
 } // namespace vast::cg

--- a/include/vast/CodeGen/DefaultVisitor.hpp
+++ b/include/vast/CodeGen/DefaultVisitor.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "vast/CodeGen/CodeGenPolicy.hpp"
 #include "vast/CodeGen/CodeGenVisitorBase.hpp"
 #include "vast/CodeGen/ClangVisitorBase.hpp"
 #include "vast/CodeGen/DefaultAttrVisitor.hpp"
@@ -9,7 +10,7 @@
 #include "vast/CodeGen/DefaultStmtVisitor.hpp"
 #include "vast/CodeGen/DefaultTypeVisitor.hpp"
 
-#include "vast/CodeGen/CodeGenFunction.hpp"
+#include <memory>
 
 namespace vast::cg
 {
@@ -22,8 +23,7 @@ namespace vast::cg
             , codegen_builder &bld
             , std::shared_ptr< meta_generator > mg
             , std::shared_ptr< symbol_generator > sg
-            , bool emit_strict_function_return
-            , missing_return_policy policy
+            , std::shared_ptr< policy_base > policy
         )
             : mctx(mctx)
             , actx(actx)
@@ -31,8 +31,7 @@ namespace vast::cg
             , self(head)
             , mg(std::move(mg))
             , sg(std::move(sg))
-            , emit_strict_function_return(emit_strict_function_return)
-            , missing_return_policy(policy)
+            , policy(std::move(policy))
         {}
 
         operation visit(const clang_decl *decl, scope_context &scope) override;
@@ -58,10 +57,7 @@ namespace vast::cg
 
         std::shared_ptr< meta_generator > mg;
         std::shared_ptr< symbol_generator > sg;
-
-        // FIXME: This should be store on single location
-        bool emit_strict_function_return;
-        missing_return_policy missing_return_policy;
+        std::shared_ptr< policy_base > policy;
     };
 
 

--- a/include/vast/CodeGen/DefaultVisitor.hpp
+++ b/include/vast/CodeGen/DefaultVisitor.hpp
@@ -2,28 +2,22 @@
 
 #pragma once
 
+#include "vast/CodeGen/ClangVisitorBase.hpp"
 #include "vast/CodeGen/CodeGenPolicy.hpp"
 #include "vast/CodeGen/CodeGenVisitorBase.hpp"
-#include "vast/CodeGen/ClangVisitorBase.hpp"
 #include "vast/CodeGen/DefaultAttrVisitor.hpp"
 #include "vast/CodeGen/DefaultDeclVisitor.hpp"
 #include "vast/CodeGen/DefaultStmtVisitor.hpp"
 #include "vast/CodeGen/DefaultTypeVisitor.hpp"
-
 #include <memory>
 
-namespace vast::cg
-{
+namespace vast::cg {
     struct default_visitor : visitor_base
     {
         default_visitor(
-              visitor_base &head
-            , mcontext_t &mctx
-            , acontext_t &actx
-            , codegen_builder &bld
-            , std::shared_ptr< meta_generator > mg
-            , std::shared_ptr< symbol_generator > sg
-            , std::shared_ptr< policy_base > policy
+            visitor_base &head, mcontext_t &mctx, acontext_t &actx, codegen_builder &bld,
+            std::shared_ptr< meta_generator > mg, std::shared_ptr< symbol_generator > sg,
+            std::shared_ptr< policy_base > policy
         )
             : mctx(mctx)
             , actx(actx)
@@ -31,15 +25,15 @@ namespace vast::cg
             , self(head)
             , mg(std::move(mg))
             , sg(std::move(sg))
-            , policy(std::move(policy))
-        {}
+            , policy(std::move(policy)) {}
 
         operation visit(const clang_decl *decl, scope_context &scope) override;
         operation visit(const clang_stmt *stmt, scope_context &scope) override;
         mlir_type visit(const clang_type *type, scope_context &scope) override;
         mlir_type visit(clang_qual_type type, scope_context &scope) override;
 
-        std::optional< named_attr > visit(const clang_attr *attr, scope_context &scope) override;
+        std::optional< named_attr >
+        visit(const clang_attr *attr, scope_context &scope) override;
 
         operation visit_prototype(const clang_function *decl, scope_context &scope) override;
 
@@ -59,6 +53,5 @@ namespace vast::cg
         std::shared_ptr< symbol_generator > sg;
         std::shared_ptr< policy_base > policy;
     };
-
 
 } // namespace vast::cg

--- a/lib/vast/CodeGen/CodeGenDriver.cpp
+++ b/lib/vast/CodeGen/CodeGenDriver.cpp
@@ -110,7 +110,7 @@ namespace vast::cg {
         return std::make_shared< default_symbol_generator >(actx.createMangleContext());
     }
 
-    std::shared_ptr< policy_base > mk_policy(cc::action_options &opts) {
+    std::shared_ptr< codegen_policy > mk_codegen_policy(cc::action_options &opts) {
         return std::make_shared< default_policy >(opts);
     }
 
@@ -124,7 +124,7 @@ namespace vast::cg {
 
         auto mg = mk_meta_generator(&actx, &mctx, vargs);
         auto sg = mk_symbol_generator(actx);
-        auto policy = mk_policy(opts);
+        auto policy = mk_codegen_policy(opts);
 
         auto visitors = std::make_shared< visitor_list >()
             | as_node_with_list_ref< attr_visitor_proxy >()

--- a/lib/vast/CodeGen/CodeGenFunction.cpp
+++ b/lib/vast/CodeGen/CodeGenFunction.cpp
@@ -128,6 +128,10 @@ namespace vast::cg
                                 parent.emit_body(decl, fn);
                             }
                         } else {
+                            // If we skip the function body, then we must set
+                            // the visibility to private because the verifier
+                            // will fail it it sees a public function
+                            // declaration without a body.
                             auto visibility = mlir_visibility::Private;
                             mlir::SymbolTable::setSymbolVisibility(fn, visibility);
                         }

--- a/lib/vast/CodeGen/CodeGenFunction.cpp
+++ b/lib/vast/CodeGen/CodeGenFunction.cpp
@@ -242,7 +242,7 @@ namespace vast::cg
             //   function call is used by the caller, the behavior is undefined.
 
             // TODO: skip if SawAsmBlock
-            switch (policy->missing_return_policy(decl)) {
+            switch (policy->get_missing_return_policy(decl)) {
                 case missing_return_policy::emit_trap:
                     emit_trap(decl);
                     break;

--- a/lib/vast/CodeGen/CodeGenFunction.cpp
+++ b/lib/vast/CodeGen/CodeGenFunction.cpp
@@ -120,13 +120,17 @@ namespace vast::cg
                     // If the user implements a function that is also a builtin,
                     // it might be visited multiple times
                     if (fn.getBody().empty()) {
-                        set_visibility(decl, fn);
-                        if (!decl->hasDefiningAttr()) {
-                            parent.declare_function_params(decl, fn);
-                            parent.emit_labels(decl, fn);
-                            parent.emit_body(decl, fn);
+                        if (!parent.policy->skip_function_body(decl)) {
+                            set_visibility(decl, fn);
+                            if (!decl->hasDefiningAttr()) {
+                                parent.declare_function_params(decl, fn);
+                                parent.emit_labels(decl, fn);
+                                parent.emit_body(decl, fn);
+                            }
+                        } else {
+                            auto visibility = mlir_visibility::Private;
+                            mlir::SymbolTable::setSymbolVisibility(fn, visibility);
                         }
-
                     }
                 });
             }

--- a/lib/vast/CodeGen/CodeGenFunction.cpp
+++ b/lib/vast/CodeGen/CodeGenFunction.cpp
@@ -213,7 +213,7 @@ namespace vast::cg
     bool function_generator::should_final_emit_unreachable(const clang_function *decl) const {
         auto rty  = decl->getReturnType();
         auto &actx = decl->getASTContext();
-        return emit_strict_function_return || may_drop_function_return(rty, actx);
+        return policy->emit_strict_function_return(decl) || may_drop_function_return(rty, actx);
     }
 
     void function_generator::deal_with_missing_return(const clang_function *decl, vast_function fn) {
@@ -234,7 +234,7 @@ namespace vast::cg
             //   function call is used by the caller, the behavior is undefined.
 
             // TODO: skip if SawAsmBlock
-            switch (missing_return_policy) {
+            switch (policy->missing_return_policy(decl)) {
                 case missing_return_policy::emit_trap:
                     emit_trap(decl);
                     break;

--- a/lib/vast/CodeGen/DefaultDeclVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultDeclVisitor.cpp
@@ -8,6 +8,7 @@
 #include "vast/CodeGen/CodeGenFunction.hpp"
 
 #include "vast/Util/Maybe.hpp"
+#include <utility>
 
 namespace vast::cg
 {
@@ -268,8 +269,7 @@ namespace vast::cg
 
     operation default_decl_visitor::VisitFunctionDecl(const clang::FunctionDecl *decl) {
         auto gen = mk_scoped_generator< function_generator >(self.scope, bld, self);
-        gen.emit_strict_function_return = emit_strict_function_return;
-        gen.missing_return_policy = missing_return_policy;
+        gen.policy = policy;
         return gen.emit(decl);
     }
 

--- a/lib/vast/CodeGen/DefaultVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultVisitor.cpp
@@ -6,8 +6,7 @@ namespace vast::cg
 {
     operation default_visitor::visit(const clang_decl *decl, scope_context &scope) {
         default_decl_visitor visitor(mctx, bld, self, scope);
-        visitor.emit_strict_function_return = emit_strict_function_return;
-        visitor.missing_return_policy = missing_return_policy;
+        visitor.policy = policy;
         return visitor.visit(decl);
     }
 


### PR DESCRIPTION
- Combines the driver options `emit_strict_function_return` and `missing_return_policy` into a single virtual class, `policy_base`, with methods for obtaining these values on a per-functiondecl basis.
- Replaces all uses of the policy options with the new policy class.
- Adds a new policy option, `skip_function_body`, for controlling whether to emit the body of a given function decl.
- Adds a new policy option, `skip_global_initializer`, for controlling whether to emit the body of a given var decl.
- Adds a `default_policy` class to provide default policy options. It accepts a `vast::cc::action_options &` instance in its constructor and defaults to returning the options' settings for all function decls.

Addresses the first two checkboxes of #462 