### PR TITLE
Add metagen to unsupported visitor

### DIFF
--- a/include/vast/CodeGen/InvalidMetaGenerator.hpp
+++ b/include/vast/CodeGen/InvalidMetaGenerator.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2022-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include "vast/Util/Common.hpp"
+
+VAST_RELAX_WARNINGS
+#include "mlir/IR/Location.h"
+VAST_UNRELAX_WARNINGS
+
+#include "vast/CodeGen/CodeGenMetaGenerator.hpp"
+#include "vast/CodeGen/Common.hpp"
+
+namespace vast::cg {
+    struct invalid_meta_gen final : meta_generator
+    {
+        invalid_meta_gen(mcontext_t *mctx) : mctx(mctx) {}
+
+        loc_t location(const clang_decl *decl) const override {
+            return mlir::UnknownLoc::get(mctx);
+        }
+
+        loc_t location(const clang_stmt *stmt) const override {
+            return mlir::UnknownLoc::get(mctx);
+        }
+
+        loc_t location(const clang_expr *expr) const override {
+            return mlir::UnknownLoc::get(mctx);
+        }
+
+      private:
+        mcontext_t *mctx;
+    };
+
+} // namespace vast::cg


### PR DESCRIPTION
- Adds a metagenerator to the unsupported visitor so that clients can choose what locations are emitted for unsupported operations.
- Adds an `invalid_meta_gen` struct to only emit unknown locations, and pass it to the unsupported visitor in vast's default visitor stack.

Closes #690 