### PR TITLE
Replace SkipStmt with NullStmt.

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelCF.td
+++ b/include/vast/Dialect/HighLevel/HighLevelCF.td
@@ -478,10 +478,10 @@ def HighLevel_IndirectGotoStmt
   let assemblyFormat = [{ attr-dict `:` $target }];
 }
 
-def HighLevel_SkipStmt : HighLevel_Op< "skip", [] >
+def HighLevel_NullStmt : HighLevel_Op< "null", [] >
 {
-  let summary = "VAST skip statement";
-  let description = [{ VAST skip statement }];
+  let summary = "VAST null statement";
+  let description = [{ VAST null statement }];
 
   let assemblyFormat = [{ attr-dict }];
 }

--- a/lib/vast/CodeGen/DefaultStmtVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultStmtVisitor.cpp
@@ -1033,7 +1033,7 @@ namespace vast::cg
 
     operation last_effective_operation(mlir::Block *block) {
         auto last = std::prev(block->end());
-        while (last != block->begin() && mlir::isa< hl::SkipStmt >(&*last)) {
+        while (last != block->begin() && mlir::isa< hl::NullStmt >(&*last)) {
             last = std::prev(last);
         }
         return &*last;
@@ -1090,7 +1090,7 @@ namespace vast::cg
     }
 
     operation default_stmt_visitor::VisitNullStmt(const clang::NullStmt *stmt) {
-        return bld.compose< hl::SkipStmt >().bind(self.location(stmt)).freeze();
+        return bld.compose< hl::NullStmt >().bind(self.location(stmt)).freeze();
     }
 
     operation default_stmt_visitor::VisitCXXThisExpr(const clang::CXXThisExpr *expr) {

--- a/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
@@ -46,7 +46,7 @@ namespace vast::conv::irstollvm
         ignore_pattern< hl::DeclRefOp >,
         ignore_pattern< hl::PredefinedExpr >,
         ignore_pattern< hl::AddressOf >,
-        ignore_pattern< hl::SkipStmt >,
+        ignore_pattern< hl::NullStmt >,
         erase_pattern< hl::StructDeclOp >,
         erase_pattern< hl::UnionDeclOp >,
         erase_pattern< hl::TypeDeclOp >


### PR DESCRIPTION
Changes `hl.skip` to `hl.null` to mirror clang naming.