### PR TITLE
Improve global variable lowering

### DIFF
--- a/include/vast/Dialect/HighLevel/HighLevelVar.td
+++ b/include/vast/Dialect/HighLevel/HighLevelVar.td
@@ -24,6 +24,7 @@ def HighLevel_VarDeclOp
     TypeAttr:$type,
     Core_StorageClass:$storageClass,
     Core_ThreadStorage:$threadStorageClass,
+    UnitAttr:$constant,
     OptionalAttr<Core_GlobalLinkageKind>:$linkage
   );
 
@@ -38,6 +39,7 @@ def HighLevel_VarDeclOp
       "llvm::StringRef":$sym_name,
       "core::StorageClass":$storageClass,
       "core::TSClass":$threadStorageClass,
+      "bool":$constant,
       CArg< "std::optional< core::GlobalLinkageKind >", "std::nullopt">:$linkage,
       CArg< "maybe_builder_callback_ref", "std::nullopt" >:$initBuilder,
       CArg< "maybe_builder_callback_ref", "std::nullopt" >:$allocaBuilder
@@ -45,7 +47,7 @@ def HighLevel_VarDeclOp
   ];
 
   let assemblyFormat = [{
-    $sym_name attr-dict (`,`$linkage^)? custom< StorageClasses >($storageClass, $threadStorageClass)
+    $sym_name attr-dict (`,`$linkage^)? (`constant` $constant^):(``)? custom< StorageClasses >($storageClass, $threadStorageClass)
       `:` $type
       (`=` $initializer^)?
       (`allocation_size` $allocation_size^)?

--- a/lib/vast/CodeGen/DefaultDeclVisitor.cpp
+++ b/lib/vast/CodeGen/DefaultDeclVisitor.cpp
@@ -234,6 +234,7 @@ namespace vast::cg {
                 .bind(self.symbol(decl))
                 .bind_always(storage_class(decl))
                 .bind_always(thread_storage_class(decl))
+                .bind_always(decl->getType().isConstQualified())
                 .bind_choose(is_global, std::optional(linkage_builder(decl)), std::nullopt)
                 // FIXME: The initializer region is filled later as it might
                 // have references to the VarDecl we are currently

--- a/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
+++ b/lib/vast/Conversion/ToLLVM/IRsToLLVM.cpp
@@ -370,8 +370,7 @@ namespace vast::conv::irstollvm
             auto gop = rewriter.create< mlir::LLVM::GlobalOp >(
                     op.getLoc(),
                     target_type,
-                    // TODO(conv:irstollvm): Constant.
-                    false,
+                    op.getConstant(),
                     core::convert_linkage_to_llvm(linkage.value()),
                     op.getSymbolName(),
                     mlir::Attribute()

--- a/lib/vast/Conversion/ToMem/EvictStaticLocals.cpp
+++ b/lib/vast/Conversion/ToMem/EvictStaticLocals.cpp
@@ -44,6 +44,7 @@ namespace vast::conv {
                     (fn_symbol.getSymbolName() + "." + op.getSymName()).str(),
                     op.getStorageClass(),
                     op.getThreadStorageClass(),
+                    op.getConstant(),
                     std::optional(core::GlobalLinkageKind::InternalLinkage)
                 );
 

--- a/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
+++ b/lib/vast/Dialect/HighLevel/HighLevelOps.cpp
@@ -343,6 +343,7 @@ namespace vast::hl
         llvm::StringRef name,
         core::StorageClass storage_class,
         core::TSClass thread_storage_class,
+        bool constant,
         std::optional< core::GlobalLinkageKind > linkage,
         maybe_builder_callback_ref init,
         maybe_builder_callback_ref alloc
@@ -352,6 +353,9 @@ namespace vast::hl
         st.addAttribute("type", mlir::TypeAttr::get(type));
         st.addAttribute("storageClass", core::StorageClassAttr::get(ctx, storage_class));
         st.addAttribute("threadStorageClass", core::TSClassAttr::get(ctx, thread_storage_class));
+        if (constant) {
+            st.addAttribute(getConstantAttrName(st.name), bld.getUnitAttr());
+        }
         if (linkage) {
             st.addAttribute("linkage", core::GlobalLinkageKindAttr::get(ctx, linkage.value()));
         }

--- a/test/vast/Conversion/static-var-b.c
+++ b/test/vast/Conversion/static-var-b.c
@@ -1,0 +1,31 @@
+// RUN: %vast-front -vast-emit-mlir=hl -o - %s | %file-check %s -check-prefix=HL
+// RUN: %check-evict-static-locals %s | %file-check %s -check-prefix=EVICTED
+// RUN: %check-core-to-llvm %s | %file-check %s -check-prefix=LLVM
+
+// HL: hl.var @zeroinit, <internal>  sc_static
+// HL: hl.var @x  sc_static
+// HL: hl.ref @x
+
+// EVICTED-DAG: hl.var @zeroinit, <internal> sc_static
+// EVICTED-DAG: hl.var @foo.x {context = 0 : i64}, <internal>  sc_static
+// EVICTED: ll.func @foo
+// EVICTED: hl.ref @foo.x
+
+// LLVM-DAG: llvm.mlir.global internal @zeroinit()
+// LLVM-DAG: [[VAR:%[0-9]+]] = llvm.mlir.zero
+// LLVM-DAG: llvm.return [[VAR]]
+// LLVM-DAG: }
+//
+// LLVM-DAG: llvm.mlir.global internal @foo.x()
+// LLVM-DAG: [[VAR:%[0-9]+]] = llvm.mlir.zero
+// LLVM-DAG: llvm.return [[VAR]]
+// LLVM-DAG: }
+//
+// LLVM: llvm.func @foo
+// LLVM: llvm.mlir.addressof @foo.x
+
+static int zeroinit;
+int foo() {
+    static int x;
+    return x + zeroinit;
+}

--- a/test/vast/Conversion/zero-init-a.c
+++ b/test/vast/Conversion/zero-init-a.c
@@ -1,0 +1,8 @@
+// RUN: %vast-front -vast-emit-mlir=llvm -o - %s | %file-check %s
+
+struct big { int i[sizeof (int) >= 4 && sizeof (void *) >= 4 ? 0x4000 : 4]; };
+// CHECK: llvm.mlir.global external @gb()
+// CHECK: [[V1:%[0-9]+]] = llvm.mlir.zero : !llvm.struct<"big"
+// CHECK: llvm.return [[V1]]
+struct big gb;
+

--- a/test/vast/Dialect/HighLevel/array-a.c
+++ b/test/vast/Dialect/HighLevel/array-a.c
@@ -4,16 +4,16 @@
 // CHECK: hl.var @ai, <external> : !hl.lvalue<!hl.array<10, !hl.int>>
 int ai[10];
 
-// CHECK: hl.var @aci, <external> : !hl.lvalue<!hl.array<5, !hl.int< const >>>
+// CHECK: hl.var @aci, <external> constant : !hl.lvalue<!hl.array<5, !hl.int< const >>>
 const int aci[5];
 
 // CHECK: hl.var @avi, <external> : !hl.lvalue<!hl.array<5, !hl.int< volatile >>>
 volatile int avi[5];
 
-// CHECK: hl.var @acvi, <external> : !hl.lvalue<!hl.array<5, !hl.int< const, volatile >>>
+// CHECK: hl.var @acvi, <external> constant : !hl.lvalue<!hl.array<5, !hl.int< const, volatile >>>
 const volatile int acvi[5];
 
-// CHECK: hl.var @acvui, <external> : !hl.lvalue<!hl.array<5, !hl.int< unsigned, const, volatile >>>
+// CHECK: hl.var @acvui, <external> constant : !hl.lvalue<!hl.array<5, !hl.int< unsigned, const, volatile >>>
 const volatile unsigned int acvui[5];
 
 // CHECK: hl.var @af, <external> : !hl.lvalue<!hl.array<10, !hl.float>>

--- a/test/vast/Dialect/HighLevel/array-c.c
+++ b/test/vast/Dialect/HighLevel/array-c.c
@@ -1,7 +1,7 @@
 // RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %file-check %s
 // RUN: %vast-cc1 -vast-emit-mlir=hl %s -o %t && %vast-opt %t | diff -B %t -
 
-// CHECK: hl.var @cai, <external> : !hl.lvalue<!hl.array<3, !hl.int< const >>> = {
+// CHECK: hl.var @cai, <external> constant : !hl.lvalue<!hl.array<3, !hl.int< const >>> = {
 // CHECK:   [[V1:%[0-9]+]] = hl.const #core.integer<1> : !hl.int
 // CHECK:   [[V2:%[0-9]+]] = hl.const #core.integer<2> : !hl.int
 // CHECK:   [[V3:%[0-9]+]] = hl.const #core.integer<3> : !hl.int

--- a/test/vast/Dialect/HighLevel/autotype-a.c
+++ b/test/vast/Dialect/HighLevel/autotype-a.c
@@ -11,7 +11,7 @@ int main() {
     int x = 0;
     //CHECK: hl.var @_a : !hl.lvalue<!hl.auto<!hl.int>>
     int y = auto_t(x);
-    //CHECK: hl.var @_a : !hl.lvalue<!hl.auto<!hl.int,  const >>
+    //CHECK: hl.var @_a constant : !hl.lvalue<!hl.auto<!hl.int,  const >>
     int z = auto_tc(x);
     //CHECK: hl.var @u : !hl.lvalue<!hl.auto<!hl.int>>
     __auto_type u = z;

--- a/test/vast/Dialect/HighLevel/constants-a.c
+++ b/test/vast/Dialect/HighLevel/constants-a.c
@@ -25,7 +25,7 @@ double d = 0.0;
 // CHECK: hl.const "hello" : !hl.lvalue<!hl.array<6, !hl.char>>
 const char *str = "hello";
 
-// CHECK: hl.var @arr, <external> : !hl.lvalue<!hl.array<3, !hl.int< const >>>
+// CHECK: hl.var @arr, <external> constant : !hl.lvalue<!hl.array<3, !hl.int< const >>>
 // CHECK:   hl.const #core.integer<1> : !hl.int
 // CHECK:   hl.const #core.integer<2> : !hl.int
 // CHECK:   hl.const #core.integer<3> : !hl.int

--- a/test/vast/Dialect/HighLevel/literals-a.c
+++ b/test/vast/Dialect/HighLevel/literals-a.c
@@ -1,27 +1,27 @@
 // // RUN: %vast-cc1 -vast-emit-mlir=hl %s -o - | %file-check %s
 // // RUN: %vast-cc1 -vast-emit-mlir=hl %s -o %t && %vast-opt %t | diff -B %t -
 
-// CHECK: hl.var @li, <external> : !hl.lvalue<!hl.int< const >>
+// CHECK: hl.var @li, <external> constant : !hl.lvalue<!hl.int< const >>
 // CHECK: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 
-// CHECK: hl.var @lui, <external> : !hl.lvalue<!hl.int< unsigned, const >>
+// CHECK: hl.var @lui, <external> constant : !hl.lvalue<!hl.int< unsigned, const >>
 // CHECK: hl.const #core.integer<10> : !hl.int< unsigned >
 const unsigned int lui = 10u;
 
-// CHECK: hl.var @ll, <external> : !hl.lvalue<!hl.long< const >>
+// CHECK: hl.var @ll, <external> constant : !hl.lvalue<!hl.long< const >>
 // CHECK: hl.const #core.integer<10> : !hl.long
 const long  ll = 10l;
 
-// CHECK: hl.var @lf, <external> : !hl.lvalue<!hl.float< const >>
+// CHECK: hl.var @lf, <external> constant : !hl.lvalue<!hl.float< const >>
 // CHECK: hl.const #core.float<5.000000e-01> : !hl.float
 const float  lf = 0.5f;
 
-// CHECK: hl.var @ld, <external> : !hl.lvalue<!hl.double< const >>
+// CHECK: hl.var @ld, <external> constant : !hl.lvalue<!hl.double< const >>
 // CHECK: hl.const #core.float<5.000000e-01> : !hl.double
 const double ld = 0.5;
 
-// CHECK: hl.var @lc, <external> : !hl.lvalue<!hl.char< const >>
+// CHECK: hl.var @lc, <external> constant : !hl.lvalue<!hl.char< const >>
 // CHECK: hl.const #core.integer<97> : !hl.int
 // CHECK: IntegralCast : !hl.int -> !hl.char
 const char lc = 'a';
@@ -31,7 +31,7 @@ const char lc = 'a';
 // CHECK: NullToPointer : !hl.int -> !hl.ptr<!hl.void< const >>
 const void *null = 0;
 
-// CHECK: hl.var @lb, <external> : !hl.lvalue<!hl.bool< const >>
+// CHECK: hl.var @lb, <external> constant : !hl.lvalue<!hl.bool< const >>
 // CHECK: hl.const #core.integer<1> : !hl.int
 // CHECK: IntegralToBoolean : !hl.int -> !hl.bool
 const _Bool lb = 1;
@@ -39,17 +39,17 @@ const _Bool lb = 1;
 #define SCHAR_MIN	(-128)
 #define SCHAR_MAX	127
 
-// CHECK: hl.var @scmin, <external> : !hl.lvalue<!hl.char< const >>
+// CHECK: hl.var @scmin, <external> constant : !hl.lvalue<!hl.char< const >>
 // CHECK:   hl.const #core.integer<128> : !hl.int
 // CHECK:   hl.minus
 const char scmin = SCHAR_MIN;
 
-// CHECK: hl.var @scmax, <external> : !hl.lvalue<!hl.char< const >>
+// CHECK: hl.var @scmax, <external> constant : !hl.lvalue<!hl.char< const >>
 // CHECK:   hl.const #core.integer<127> : !hl.int
 const char scmax = SCHAR_MAX;
 
 #define UCHAR_MAX	255
 
-// CHECK: hl.var @ucmax, <external> : !hl.lvalue<!hl.char< unsigned, const >>
+// CHECK: hl.var @ucmax, <external> constant : !hl.lvalue<!hl.char< unsigned, const >>
 // CHECK:   hl.const #core.integer<255> : !hl.int
 const unsigned char ucmax = UCHAR_MAX;

--- a/test/vast/Dialect/HighLevel/pointers-a.c
+++ b/test/vast/Dialect/HighLevel/pointers-a.c
@@ -16,19 +16,19 @@ int const * icp = 0;
 // CHECK: hl.var @cip, <external> : !hl.lvalue<!hl.ptr<!hl.int< const >>>
 const int * cip = 0;
 
-// CHECK: hl.var @ipc, <external> : !hl.lvalue<!hl.ptr<!hl.int,  const >>
+// CHECK: hl.var @ipc, <external> constant : !hl.lvalue<!hl.ptr<!hl.int,  const >>
 int * const ipc = 0;
 
-// CHECK: hl.var @icpc, <external> : !hl.lvalue<!hl.ptr<!hl.int< const >,  const >>
+// CHECK: hl.var @icpc, <external> constant : !hl.lvalue<!hl.ptr<!hl.int< const >,  const >>
 int const * const icpc = 0;
 
-// CHECK: hl.var @cipc, <external> : !hl.lvalue<!hl.ptr<!hl.int< const >,  const >>
+// CHECK: hl.var @cipc, <external> constant : !hl.lvalue<!hl.ptr<!hl.int< const >,  const >>
 const int * const cipc = 0;
 
 // CHECK: hl.var @ipp, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int>>>
 int ** ipp = 0;
 
-// CHECK: hl.var @ippc, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int>,  const >>
+// CHECK: hl.var @ippc, <external> constant : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int>,  const >>
 int ** const ippc = 0;
 
 // CHECK: hl.var @ipcp, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int,  const >>>
@@ -37,7 +37,7 @@ int * const * ipcp = 0;
 // CHECK: hl.var @icpp, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int< const >>>>
 int const ** icpp = 0;
 
-// CHECK: hl.var @ipcpc, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int,  const >,  const >>
+// CHECK: hl.var @ipcpc, <external> constant : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int,  const >,  const >>
 int * const * const ipcpc = 0;
 
 // CHECK: hl.var @ippp, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.ptr<!hl.int>>>>

--- a/test/vast/Dialect/HighLevel/pointers-b.c
+++ b/test/vast/Dialect/HighLevel/pointers-b.c
@@ -13,7 +13,7 @@ int (*fp)(int); // fp is a pointer to function with type int(int)
 int n;
 const int * pc = &n; // pc is a non-const pointer to a const int
 
-// CHECK: hl.var @cp, <external> : !hl.lvalue<!hl.ptr<!hl.int,  const >>
+// CHECK: hl.var @cp, <external> constant : !hl.lvalue<!hl.ptr<!hl.int,  const >>
 int * const cp = &n; // cp is a const pointer to a non-const int
 
 // CHECK: hl.var @pcp, <external> : !hl.lvalue<!hl.ptr<!hl.ptr<!hl.int,  const >>>

--- a/test/vast/Dialect/HighLevel/qualifiers-a.cpp
+++ b/test/vast/Dialect/HighLevel/qualifiers-a.cpp
@@ -17,12 +17,12 @@ void scope() {
     // CHECK: hl.var @us : !hl.lvalue<!hl.short< unsigned >>
     unsigned short us;
 
-    // CHECK: hl.var @ci : !hl.lvalue<!hl.int< const >> = {
+    // CHECK: hl.var @ci constant : !hl.lvalue<!hl.int< const >> = {
     // CHECK: [[C1:%[0-9]+]] = hl.const #core.integer<0> : !hl.int
     // CHECK: hl.value.yield [[C1]]
     const int ci = 0;
 
-    // CHECK: hl.var @cui : !hl.lvalue<!hl.int< unsigned, const >> = {
+    // CHECK: hl.var @cui constant : !hl.lvalue<!hl.int< unsigned, const >> = {
     // CHECK: [[C2:%[0-9]+]] = hl.const #core.integer<0> : !hl.int< unsigned >
     // CHECK: hl.value.yield [[C2]]
     const unsigned cui = 0U;
@@ -33,12 +33,12 @@ void scope() {
     // CHECK: hl.var @vui : !hl.lvalue<!hl.int< unsigned, volatile >>
     volatile unsigned vui;
 
-    // CHECK: hl.var @cvi : !hl.lvalue<!hl.int< const, volatile >> = {
+    // CHECK: hl.var @cvi constant : !hl.lvalue<!hl.int< const, volatile >> = {
     // CHECK: [[C3:%[0-9]+]] = hl.const #core.integer<0> : !hl.int
     // CHECK: hl.value.yield [[C3]]
     const volatile int cvi = 0;
 
-    // CHECK: hl.var @cvui : !hl.lvalue<!hl.int< unsigned, const, volatile >> = {
+    // CHECK: hl.var @cvui constant : !hl.lvalue<!hl.int< unsigned, const, volatile >> = {
     // CHECK: [[C4:%[0-9]+]] = hl.const #core.integer<0> : !hl.int< unsigned >
     // CHECK: hl.value.yield [[C4]]
     const volatile unsigned int cvui = 0U;
@@ -49,12 +49,12 @@ void scope() {
     // CHECK: hl.var @vb : !hl.lvalue<!hl.bool< volatile >>
     volatile bool vb;
 
-    // CHECK: hl.var @cb : !hl.lvalue<!hl.bool< const >> = {
+    // CHECK: hl.var @cb constant : !hl.lvalue<!hl.bool< const >> = {
     // CHECK: [[C5:%[0-9]+]] = hl.const #false
     // CHECK: hl.value.yield [[C5]]
     const bool cb = false;
 
-    // CHECK: hl.var @cvb : !hl.lvalue<!hl.bool< const, volatile >> = {
+    // CHECK: hl.var @cvb constant : !hl.lvalue<!hl.bool< const, volatile >> = {
     // CHECK: [[C6:%[0-9]+]] = hl.const #true
     // CHECK: hl.value.yield [[C6]]
     const volatile bool cvb = true;

--- a/test/vast/Dialect/HighLevel/qualifiers-e.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-e.c
@@ -4,11 +4,11 @@
 // CHECK: hl.var @ia, <external> : !hl.lvalue<!hl.array<10, !hl.int>>
 int ia[10];
 
-// CHECK: hl.var @cia, <external> : !hl.lvalue<!hl.array<10, !hl.int< const >>>
+// CHECK: hl.var @cia, <external> constant : !hl.lvalue<!hl.array<10, !hl.int< const >>>
 const int cia[10];
 
 // CHECK: hl.var @via, <external> : !hl.lvalue<!hl.array<10, !hl.int< volatile >>>
 volatile int via[10];
 
-// CHECK: hl.var @cvia, <external> : !hl.lvalue<!hl.array<10, !hl.int< const, volatile >>>
+// CHECK: hl.var @cvia, <external> constant : !hl.lvalue<!hl.array<10, !hl.int< const, volatile >>>
 const volatile int cvia[10];

--- a/test/vast/Dialect/HighLevel/qualifiers-h.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-h.c
@@ -7,10 +7,10 @@ enum e { a, b, c };
 // CHECK: hl.var @v, <external> : !hl.lvalue<!hl.elaborated<!hl.enum<@e>>>
 enum e v;
 
-// CHECK: hl.var @cv, <external> : !hl.lvalue<!hl.elaborated<!hl.enum<@e>,  const >>
+// CHECK: hl.var @cv, <external> constant : !hl.lvalue<!hl.elaborated<!hl.enum<@e>,  const >>
 const enum e cv;
 
-// CHECK: hl.var @cvv, <external> : !hl.lvalue<!hl.elaborated<!hl.enum<@e>,  const, volatile >>
+// CHECK: hl.var @cvv, <external> constant : !hl.lvalue<!hl.elaborated<!hl.enum<@e>,  const, volatile >>
 const volatile enum e cvv;
 
 // CHECK: hl.typedef @def : !hl.elaborated<!hl.enum<@e>>
@@ -19,11 +19,11 @@ typedef enum e def;
 // CHECK: hl.var @d, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@def>>>
 def d;
 
-// CHECK: hl.var @cd, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@def>,  const >>
+// CHECK: hl.var @cd, <external> constant : !hl.lvalue<!hl.elaborated<!hl.typedef<@def>,  const >>
 const def cd;
 
 // CHECK: hl.var @vd, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@def>,  volatile >>
 volatile def vd;
 
-// CHECK: hl.var @cvd, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@def>,  const, volatile >>
+// CHECK: hl.var @cvd, <external> constant : !hl.lvalue<!hl.elaborated<!hl.typedef<@def>,  const, volatile >>
 const volatile def cvd;

--- a/test/vast/Dialect/HighLevel/qualifiers-i.c
+++ b/test/vast/Dialect/HighLevel/qualifiers-i.c
@@ -7,10 +7,10 @@ union u { int i; double d; };
 // CHECK: hl.var @v, <external> : !hl.lvalue<!hl.elaborated<!hl.record<@u>>>
 union u v;
 
-// CHECK: hl.var @cv, <external> : !hl.lvalue<!hl.elaborated<!hl.record<@u>,  const >>
+// CHECK: hl.var @cv, <external> constant : !hl.lvalue<!hl.elaborated<!hl.record<@u>,  const >>
 const union u cv;
 
-// CHECK: hl.var @cvv, <external> : !hl.lvalue<!hl.elaborated<!hl.record<@u>,  const, volatile >>
+// CHECK: hl.var @cvv, <external> constant : !hl.lvalue<!hl.elaborated<!hl.record<@u>,  const, volatile >>
 const volatile union u cvv;
 
 // CHECK: hl.typedef @e : !hl.elaborated<!hl.record<@u>>
@@ -19,11 +19,11 @@ typedef union u e;
 // CHECK: hl.var @v, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@e>>>
 e v;
 
-// CHECK: hl.var @cv, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@e>,  const >>
+// CHECK: hl.var @cv, <external> constant : !hl.lvalue<!hl.elaborated<!hl.typedef<@e>,  const >>
 const e cv;
 
 // CHECK: hl.var @vv, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@e>,  volatile >>
 volatile e vv;
 
-// CHECK: hl.var @cvv, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@e>,  const, volatile >>
+// CHECK: hl.var @cvv, <external> constant : !hl.lvalue<!hl.elaborated<!hl.typedef<@e>,  const, volatile >>
 const volatile e cvv;

--- a/test/vast/Dialect/HighLevel/quirks-j.c
+++ b/test/vast/Dialect/HighLevel/quirks-j.c
@@ -14,7 +14,7 @@ void foo() {
     int a[2];
     // CHECK: hl.var @i : !hl.lvalue<!hl.int>
     int i;
-    // CHECK: hl.var @j : !hl.lvalue<!hl.int< const >>
+    // CHECK: hl.var @j constant : !hl.lvalue<!hl.int< const >>
     const int j;
     // CHECK: hl.var @bf : !hl.lvalue<!hl.elaborated<!hl.record<@bitfield>>>
     struct bitfield bf;

--- a/test/vast/Dialect/HighLevel/quirks-n.c
+++ b/test/vast/Dialect/HighLevel/quirks-n.c
@@ -16,5 +16,5 @@ struct foo { int bar; } const typedef baz;
 s16 a;
 // CHECK: hl.var @b, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@u32>>>
 u32 b;
-// CHECK: hl.var @c, <external> : !hl.lvalue<!hl.elaborated<!hl.typedef<@baz>>>
+// CHECK: hl.var @c, <external> constant : !hl.lvalue<!hl.elaborated<!hl.typedef<@baz>>>
 baz c;

--- a/test/vast/Dialect/HighLevel/typeof-b.c
+++ b/test/vast/Dialect/HighLevel/typeof-b.c
@@ -2,7 +2,7 @@
 // RUN: %vast-front -vast-emit-mlir=hl -o - %s > %t && %vast-opt %t | diff -B %t -
 
 int main() {
-// CHECK: hl.var @i : !hl.lvalue<!hl.int< const >>
+// CHECK: hl.var @i constant : !hl.lvalue<!hl.int< const >>
 const int i = 0;
 
 // CHECK: hl.typeof.expr "(i)" {
@@ -10,10 +10,10 @@ const int i = 0;
 //  CHECK: }
 // CHECK:   hl.type.yield {{.*}} : !hl.lvalue<!hl.int< const >>
 // CHECK: } : !hl.int< const >
-// CHECK: hl.var @j : !hl.lvalue<!hl.typeof.expr<"(i)">>
+// CHECK: hl.var @j constant : !hl.lvalue<!hl.typeof.expr<"(i)">>
 // CHECK: hl.const #core.integer<0> : !hl.int
 typeof(i) j = 0;
-// CHECK: {{.* hl.var @k : !hl.lvalue<!hl.typeof.type<!hl.int< const >>>.*}}
+// CHECK: {{.* hl.var @k constant : !hl.lvalue<!hl.typeof.type<!hl.int< const >>>.*}}
 typeof(const int) k = 0;
 return 0;
 }

--- a/test/vast/Dialect/HighLevel/typeof-c.c
+++ b/test/vast/Dialect/HighLevel/typeof-c.c
@@ -10,10 +10,10 @@ int i = 0;
 // CHECK:   }
 // CHECK:   hl.type.yield {{.*}} : !hl.lvalue<!hl.int>
 // CHECK: } : !hl.int
-// CHECK: hl.var @j : !hl.lvalue<!hl.typeof.expr<"(i)", const >>
+// CHECK: hl.var @j constant : !hl.lvalue<!hl.typeof.expr<"(i)", const >>
 // CHECK: hl.const #core.integer<0> : !hl.int
 const typeof(i) j = 0;
-// CHECK: hl.var @k : !hl.lvalue<!hl.typeof.type<!hl.int, const >>
+// CHECK: hl.var @k constant : !hl.lvalue<!hl.typeof.type<!hl.int, const >>
 const typeof(int) k = 0;
 return 0;
 }

--- a/test/vast/Transform/HL/LowerTypes/array-a.c
+++ b/test/vast/Transform/HL/LowerTypes/array-a.c
@@ -3,16 +3,16 @@
 // CHECK: hl.var @ai, <external> : !hl.lvalue<!hl.array<10, si32>>
 int ai[10];
 
-// CHECK: hl.var @aci, <external> : !hl.lvalue<!hl.array<5, si32>>
+// CHECK: hl.var @aci, <external> constant : !hl.lvalue<!hl.array<5, si32>>
 const int aci[5];
 
 // CHECK: hl.var @avi, <external> : !hl.lvalue<!hl.array<5, si32>>
 volatile int avi[5];
 
-// CHECK: hl.var @acvi, <external> : !hl.lvalue<!hl.array<5, si32>>
+// CHECK: hl.var @acvi, <external> constant : !hl.lvalue<!hl.array<5, si32>>
 const volatile int acvi[5];
 
-// CHECK: hl.var @acvui, <external> : !hl.lvalue<!hl.array<5, ui32>>
+// CHECK: hl.var @acvui, <external> constant : !hl.lvalue<!hl.array<5, ui32>>
 const volatile unsigned int acvui[5];
 
 // CHECK: hl.var @af, <external> : !hl.lvalue<!hl.array<10, f32>>

--- a/test/vast/Transform/HL/LowerTypes/vars-c.c
+++ b/test/vast/Transform/HL/LowerTypes/vars-c.c
@@ -7,11 +7,11 @@ int main()
     // CHECK:   [[V1:%[0-9]+]] = hl.const #core.integer<0> : si32
     // CHECK:   hl.value.yield [[V1]] : si32
     int x = 0;
-    // CHECK: hl.var @cx : !hl.lvalue<si32> =  {
+    // CHECK: hl.var @cx constant : !hl.lvalue<si32> =  {
     // CHECK:   [[V2:%[0-9]+]] = hl.const #core.integer<0> : si32
     // CHECK:   hl.value.yield [[V2]] : si32
     const int cx = 0;
-    // CHECK: hl.var @cvx : !hl.lvalue<si32> =  {
+    // CHECK: hl.var @cvx constant : !hl.lvalue<si32> =  {
     // CHECK:   [[V3:%[0-9]+]] = hl.const #core.integer<0> : si32
     // CHECK:   hl.value.yield [[V3]] : si32
     const volatile int cvx = 0;


### PR DESCRIPTION
- Add const to hl vardecl and propagate it to llvm globals
- Zero init variables with static storage duration, if they do not have initializer