### PR TITLE
cmake: handle separate prefix for LLVM/MLIR/clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ include(AddMLIR)
 include(HandleLLVMOptions)
 
 include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
 
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 

--- a/tools/vast-front/CMakeLists.txt
+++ b/tools/vast-front/CMakeLists.txt
@@ -8,7 +8,7 @@ add_vast_executable(vast-front
     ${CLANG_LIBS}
 )
 
-set(CLANG_BIN_PATH ${LLVM_BINARY_DIR}/bin/clang)
+set(CLANG_BIN_PATH ${CLANG_INSTALL_PREFIX}/bin/clang)
 
 if(NOT EXISTS ${CLANG_BIN_PATH})
     message(FATAL_ERROR "Could not find clang binary to deduce resource path!")


### PR DESCRIPTION
Some Linux distributions (i.e. NixOS) install LLVM, MLIR, and clang in different prefixes. On these distributions, variables like `LLVM_INCLUDE_DIRS` and `MLIR_INCLUDE_DIRS` have different values. These changes handle a few instances of this issue to get VAST building on NixOS and Nix on Darwin.