### PR TITLE
Introduce maybe parse op

### DIFF
--- a/include/vast/Dialect/Parser/Ops.td
+++ b/include/vast/Dialect/Parser/Ops.td
@@ -62,6 +62,18 @@ def Parse_NoParse
   }];
 }
 
+def Parse_MaybeParse
+  : Parser_Op< "maybeparse" >
+  , Arguments< (ins Variadic<Parser_AnyDataType>:$arguments) >
+  , Results< (outs Variadic<Parser_AnyDataType>:$result) >
+{
+  let summary = "Maybe parsing operation data.";
+
+  let assemblyFormat = [{
+    $arguments attr-dict `:` functional-type($arguments, $result)
+  }];
+}
+
 def Parse_ToMaybe
   : Parser_Op< "to_maybe" >
   , Arguments< (ins Parser_AnyDataType:$arguments) >


### PR DESCRIPTION
This operation is to denote places where we are not able to determine 
whether the operation is parsing or not just from local analysis.

This is to be refined in future passes or can be used as overapproximation of parser.