### PR TITLE
Reconcile unrealized parser casts to pr.cast

### DIFF
--- a/include/vast/Conversion/Parser/Passes.hpp
+++ b/include/vast/Conversion/Parser/Passes.hpp
@@ -12,6 +12,7 @@ VAST_UNRELAX_WARNINGS
 namespace vast {
 
     std::unique_ptr< mlir::Pass > createHLToParserPass();
+    std::unique_ptr< mlir::Pass > createParserReconcileCastsPass();
     std::unique_ptr< mlir::Pass > createParserSourceToSarifPass();
 
     // Generate the code for registering passes.

--- a/include/vast/Conversion/Parser/Passes.td
+++ b/include/vast/Conversion/Parser/Passes.td
@@ -19,4 +19,14 @@ def HLToParser : Pass<"vast-hl-to-parser", "core::ModuleOp"> {
     ];
 }
 
+def ParserReconcileCasts : Pass<"vast-parser-reconcile-casts", "core::ModuleOp"> {
+    let summary = "Reconcile casts in parser dialect.";
+    let description = [{ WIP }];
+
+    let constructor = "vast::createParserReconcileCastsPass()";
+    let dependentDialects = [
+        "vast::pr::ParserDialect"
+    ];
+}
+
 #endif // VAST_CONVERSION_PARSER_PASSES_TD

--- a/include/vast/Dialect/Parser/Ops.td
+++ b/include/vast/Dialect/Parser/Ops.td
@@ -19,6 +19,8 @@ def Parser_Source
 {
   let summary = "Source of parsed data.";
 
+  let hasFolder = 1;
+
   let assemblyFormat = [{
     $arguments attr-dict `:` functional-type($arguments, $result)
   }];
@@ -31,6 +33,8 @@ def Paser_Sink
 {
   let summary = "Sink of parsed data.";
 
+  let hasFolder = 1;
+
   let assemblyFormat = [{
     $arguments attr-dict `:` functional-type($arguments, $result)
   }];
@@ -42,6 +46,8 @@ def Parser_Parse
   , Results< (outs Variadic<Parser_AnyDataType>:$result) >
 {
   let summary = "Parsing operation data.";
+
+  let hasFolder = 1;
 
   let assemblyFormat = [{
     $arguments attr-dict `:` functional-type($arguments, $result)
@@ -69,6 +75,8 @@ def Parse_MaybeParse
 {
   let summary = "Maybe parsing operation data.";
 
+  let hasFolder = 1;
+
   let assemblyFormat = [{
     $arguments attr-dict `:` functional-type($arguments, $result)
   }];
@@ -76,13 +84,15 @@ def Parse_MaybeParse
 
 def Parse_Cast
   : Parser_Op< "cast" >
-  , Arguments< (ins Parser_AnyDataType:$arguments) >
+  , Arguments< (ins Parser_AnyDataType:$operand) >
   , Results< (outs Parser_AnyDataType:$result) >
 {
   let summary = "Casting operation.";
 
+  let hasFolder = 1;
+
   let assemblyFormat = [{
-    $arguments attr-dict `:` functional-type($arguments, $result)
+    $operand attr-dict `:` functional-type($operand, $result)
   }];
 }
 

--- a/lib/vast/Conversion/Parser/CMakeLists.txt
+++ b/lib/vast/Conversion/Parser/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 add_vast_conversion_library(ParserConversionPasses
     ToParser.cpp
+    ReconcileCasts.cpp
 )

--- a/lib/vast/Conversion/Parser/ReconcileCasts.cpp
+++ b/lib/vast/Conversion/Parser/ReconcileCasts.cpp
@@ -1,0 +1,47 @@
+#include "vast/Util/Warnings.hpp"
+
+#include "vast/Conversion/Parser/Passes.hpp"
+
+VAST_RELAX_WARNINGS
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Transforms/DialectConversion.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+VAST_UNRELAX_WARNINGS
+
+#include "PassesDetails.hpp"
+
+#include "vast/Conversion/Common/Mixins.hpp"
+#include "vast/Conversion/Common/Patterns.hpp"
+
+#include "vast/Dialect/Parser/Ops.hpp"
+#include "vast/Dialect/Parser/Types.hpp"
+
+namespace vast::conv {
+
+    namespace pattern {
+
+        using cast_conversions = util::type_list<
+            // Casts
+        >;
+
+    } // namespace pattern
+
+    struct ParserReconcileCastsPass
+        : ConversionPassMixin< ParserReconcileCastsPass, ParserReconcileCastsBase >
+    {
+        using base = ConversionPassMixin< ParserReconcileCastsPass, ParserReconcileCastsBase >;
+
+        static conversion_target create_conversion_target(mcontext_t &mctx) {
+            return conversion_target(mctx);
+        }
+
+        static void populate_conversions(auto &cfg) {
+            base::populate_conversions< pattern::cast_conversions >(cfg);
+        }
+    };
+
+} // namespace vast::conv
+
+std::unique_ptr< mlir::Pass > vast::createParserReconcileCastsPass() {
+    return std::make_unique< vast::conv::ParserReconcileCastsPass >();
+}

--- a/lib/vast/Conversion/Parser/ToParser.cpp
+++ b/lib/vast/Conversion/Parser/ToParser.cpp
@@ -552,6 +552,24 @@ namespace vast::conv {
             }
         };
 
+        struct AssignConversion
+            : one_to_one_conversion_pattern< hl::AssignOp, pr::Assign >
+        {
+            using op_t = hl::AssignOp;
+            using base = one_to_one_conversion_pattern< op_t, pr::Assign >;
+            using base::base;
+
+            using adaptor_t = typename op_t::Adaptor;
+
+            logical_result matchAndRewrite(
+                op_t op, adaptor_t adaptor, conversion_rewriter &rewriter
+            ) const override {
+                auto args = realized_operand_values(adaptor.getOperands(), rewriter);
+                rewriter.replaceOpWithNewOp< pr::Assign >(op, std::vector< mlir_type >(), args);
+                return mlir::success();
+            }
+        };
+
         struct ExprConversion
             : parser_conversion_pattern_base< hl::ExprOp >
         {
@@ -643,6 +661,7 @@ namespace vast::conv {
             ToNoParse< hl::MulFOp >, ToNoParse< hl::DivFOp >,
             ToNoParse< hl::RemFOp >,
             // Other operations
+            AssignConversion,
             ExprConversion,
             FuncConversion,
             ParamConversion,

--- a/lib/vast/Conversion/Parser/Utils.hpp
+++ b/lib/vast/Conversion/Parser/Utils.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "vast/Util/Common.hpp"
+
+#include "vast/Dialect/Parser/Types.hpp"
+
+namespace vast::pr {
+
+    enum class data_type { data, nodata, maybedata };
+
+    static inline mlir_type to_mlir_type(data_type type, mcontext_t *mctx) {
+        switch (type) {
+            case data_type::data: return pr::DataType::get(mctx);
+            case data_type::nodata: return pr::NoDataType::get(mctx);
+            case data_type::maybedata: return pr::MaybeDataType::get(mctx);
+        }
+    }
+
+    template< typename... Ts >
+    auto is_one_of(mlir_type ty) { return (mlir::isa< Ts >(ty) || ...); }
+
+    static inline bool is_parser_type(mlir_type ty) {
+        return is_one_of< pr::DataType, pr::NoDataType, pr::MaybeDataType >(ty);
+    }
+
+} // namespace vast::pr


### PR DESCRIPTION
- adds `-vast-parser-reconcile-casts` pass to eliminate intermediate unrealized casts to pr.cast
- adds simple folds for parse operations