### PR TITLE
Deduplicate release CI builds using artifact passing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,5 +55,13 @@ jobs:
       - name: Build ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
         run: cmake --build --preset ci-${{ matrix.features }} --config ${{ matrix.build-type }} -j $(nproc)
 
+      - name: Upload build artifacts
+        if: matrix.build-type == 'Release' && matrix.features == 'nosarif'
+        uses: actions/upload-artifact@v4
+        with:
+          name: vast-build-${{ matrix.build-type }}-${{ matrix.features }}
+          path: ./builds/ci-${{ matrix.features }}
+          retention-days: 1
+
       - name: Test ${{ matrix.build-type }} with sanitizers set ${{ matrix.sanitizers }}
         run: ctest --preset ci-${{ matrix.features }} --build-config ${{ matrix.build-type }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -55,11 +55,13 @@ jobs:
           WITH_V: true # Prefix v to the tag
           DEFAULT_BUMP: patch
 
-      - name: Configure build
-        run: cmake --preset ci
-
-      - name: Build release
-        run: cmake --build --preset ci-release -j $(nproc)
+      - name: Download build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          name: vast-build-Release-nosarif
+          path: ./builds/ci-nosarif
 
       - name: Package
         run: cpack --preset ci


### PR DESCRIPTION
Fixes #516 by implementing artifact passing between workflows:
Added build artifact upload in build.yml (Release/nosarif)
Modified prerelease.yml to download and use these artifacts
Eliminated duplicate VAST builds in the CI pipeline.