### PR TITLE
chore(ci): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a Dependabot config, starting with just GitHub Actions. Other groups could easily be added!